### PR TITLE
Message filters rework port in progress for review

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,90 +1,109 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
+
 project(message_filters)
 
-if(NOT WIN32)
-  set_directory_properties(PROPERTIES COMPILE_OPTIONS "-Wall;-Wextra")
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
 endif()
 
-find_package(catkin REQUIRED COMPONENTS roscpp rosconsole)
-catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES message_filters
-  CATKIN_DEPENDS roscpp rosconsole
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake_python REQUIRED)
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rcutils)
+find_package(builtin_interfaces REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+
+include_directories(include)
+add_library(${PROJECT_NAME} SHARED src/connection.cpp)
+ament_target_dependencies(${PROJECT_NAME}
+  "rclcpp"
+  "rcutils"
+  "std_msgs"
+  "builtin_interfaces"
+  "sensor_msgs")
+
+install(
+  TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
-catkin_python_setup()
 
-find_package(Boost REQUIRED COMPONENTS signals thread)
+install(
+DIRECTORY "include/"
+DESTINATION include
+)
 
-include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
-link_directories(${catkin_LIBRARY_DIRS})
+find_package(python_cmake_module REQUIRED)
+_ament_cmake_python_register_environment_hook()
+install(
+  DIRECTORY "src/${PROJECT_NAME}/"
+  DESTINATION "${PYTHON_INSTALL_DIR}/${PROJECT_NAME}"
+  PATTERN "*.pyc" EXCLUDE
+  PATTERN "__pycache__" EXCLUDE
+)
 
-add_library(${PROJECT_NAME} src/connection.cpp)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+ament_export_include_directories(include)
+ament_export_libraries(${PROJECT_NAME})
 
-install(TARGETS ${PROJECT_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-  FILES_MATCHING PATTERN "*.h")
+  find_package(ament_cmake_gtest)
 
-if(CATKIN_ENABLE_TESTING)
-  # Ugly workaround for check_test_ran macro issue
-  #add_subdirectory(test)
-  find_package(catkin COMPONENTS rostest rosunit)
-
-  include_directories(${GTEST_INCLUDE_DIRS})
-
-  # ********** Tests **********
-  catkin_add_gtest(${PROJECT_NAME}-msg_cache_unittest test/msg_cache_unittest.cpp)
-  if(TARGET ${PROJECT_NAME}-msg_cache_unittest)
-    target_link_libraries(${PROJECT_NAME}-msg_cache_unittest message_filters ${GTEST_LIBRARIES})
-  endif()
-
-  catkin_add_gtest(${PROJECT_NAME}-time_synchronizer_unittest test/time_synchronizer_unittest.cpp)
-  if(TARGET ${PROJECT_NAME}-time_synchronizer_unittest)
-    target_link_libraries(${PROJECT_NAME}-time_synchronizer_unittest message_filters ${GTEST_LIBRARIES})
-  endif()
-
-  catkin_add_gtest(${PROJECT_NAME}-test_synchronizer test/test_synchronizer.cpp)
-  if(TARGET ${PROJECT_NAME}-test_synchronizer)
-    target_link_libraries(${PROJECT_NAME}-test_synchronizer message_filters ${GTEST_LIBRARIES})
-  endif()
-
-  catkin_add_gtest(${PROJECT_NAME}-test_exact_time_policy test/test_exact_time_policy.cpp)
-  if(TARGET ${PROJECT_NAME}-test_exact_time_policy)
-    target_link_libraries(${PROJECT_NAME}-test_exact_time_policy message_filters ${GTEST_LIBRARIES})
-  endif()
-
-  catkin_add_gtest(${PROJECT_NAME}-test_approximate_time_policy test/test_approximate_time_policy.cpp)
-  if(TARGET ${PROJECT_NAME}-test_approximate_time_policy)
-    target_link_libraries(${PROJECT_NAME}-test_approximate_time_policy message_filters ${GTEST_LIBRARIES})
-  endif()
-
-  catkin_add_gtest(${PROJECT_NAME}-test_simple test/test_simple.cpp)
+  ament_add_gtest(${PROJECT_NAME}-test_simple test/test_simple.cpp)
   if(TARGET ${PROJECT_NAME}-test_simple)
-    target_link_libraries(${PROJECT_NAME}-test_simple message_filters ${GTEST_LIBRARIES})
+    target_link_libraries(${PROJECT_NAME}-test_simple ${PROJECT_NAME})
   endif()
 
-  catkin_add_gtest(${PROJECT_NAME}-test_chain test/test_chain.cpp)
+
+  ament_add_gtest(${PROJECT_NAME}-msg_cache_unittest test/msg_cache_unittest.cpp)
+  if(TARGET ${PROJECT_NAME}-msg_cache_unittest)
+    target_link_libraries(${PROJECT_NAME}-msg_cache_unittest ${PROJECT_NAME})
+  endif()
+
+  ament_add_gtest(${PROJECT_NAME}-test_chain test/test_chain.cpp)
   if(TARGET ${PROJECT_NAME}-test_chain)
-    target_link_libraries(${PROJECT_NAME}-test_chain message_filters ${GTEST_LIBRARIES})
+    target_link_libraries(${PROJECT_NAME}-test_chain ${PROJECT_NAME})
   endif()
 
-  # Needs to be a rostest because it spins up a node, which blocks until it hears from the master (unfortunately)
-  add_rostest_gtest(${PROJECT_NAME}-time_sequencer_unittest test/time_sequencer_unittest.xml test/time_sequencer_unittest.cpp)
-  if(TARGET ${PROJECT_NAME}-time_sequencer_unittest)
-    target_link_libraries(${PROJECT_NAME}-time_sequencer_unittest message_filters)
-  endif()
-
-  add_rostest_gtest(${PROJECT_NAME}-test_subscriber test/test_subscriber.xml test/test_subscriber.cpp)
+  ament_add_gtest(${PROJECT_NAME}-test_subscriber test/test_subscriber.cpp)
   if(TARGET ${PROJECT_NAME}-test_subscriber)
-    target_link_libraries(${PROJECT_NAME}-test_subscriber message_filters)
+    target_link_libraries(${PROJECT_NAME}-test_subscriber ${PROJECT_NAME})
   endif()
 
-  # Unit test of the approximate synchronizer
-  catkin_add_nosetests(test/test_approxsync.py)
-  catkin_add_nosetests(test/test_message_filters_cache.py)
+  ament_add_gtest(${PROJECT_NAME}-test_synchronizer test/test_synchronizer.cpp)
+  if(TARGET ${PROJECT_NAME}-test_synchronizer)
+    target_link_libraries(${PROJECT_NAME}-test_synchronizer ${PROJECT_NAME})
+  endif()
+
+  ament_add_gtest(${PROJECT_NAME}-time_synchronizer_unittest test/time_synchronizer_unittest.cpp)
+  if(TARGET ${PROJECT_NAME}-time_synchronizer_unittest)
+    target_link_libraries(${PROJECT_NAME}-time_synchronizer_unittest ${PROJECT_NAME})
+  endif()
+
+  ament_add_gtest(${PROJECT_NAME}-test_exact_time_policy test/test_exact_time_policy.cpp)
+  if(TARGET ${PROJECT_NAME}-test_exact_time_policy)
+    target_link_libraries(${PROJECT_NAME}-test_exact_time_policy ${PROJECT_NAME})
+  endif()
+
+  ament_add_gtest(${PROJECT_NAME}-test_approximate_time_policy test/test_approximate_time_policy.cpp)
+  if(TARGET ${PROJECT_NAME}-test_approximate_time_policy)
+    target_link_libraries(${PROJECT_NAME}-test_approximate_time_policy ${PROJECT_NAME})
+  endif()
+
+  ament_add_gtest(${PROJECT_NAME}-test_fuzz test/test_fuzz.cpp SKIP_TEST)
+  if(TARGET ${PROJECT_NAME}-test_fuzz)
+    target_link_libraries(${PROJECT_NAME}-test_fuzz ${PROJECT_NAME})
+  endif()
+
 endif()
+
+ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcutils)
 find_package(builtin_interfaces REQUIRED)
-find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
 include_directories(include)
@@ -24,7 +23,6 @@ add_library(${PROJECT_NAME} SHARED src/connection.cpp)
 ament_target_dependencies(${PROJECT_NAME}
   "rclcpp"
   "rcutils"
-  "std_msgs"
   "builtin_interfaces"
   "sensor_msgs")
 
@@ -54,6 +52,7 @@ ament_export_libraries(${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  find_package(std_msgs REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gtest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,11 @@ if(BUILD_TESTING)
     target_link_libraries(${PROJECT_NAME}-test_chain ${PROJECT_NAME})
   endif()
 
+  ament_add_gtest(${PROJECT_NAME}-test_time_sequencer test/time_sequencer_unittest.cpp)
+  if(TARGET ${PROJECT_NAME}-test_time_sequencer)
+    target_link_libraries(${PROJECT_NAME}-test_time_sequencer ${PROJECT_NAME})
+  endif()
+
   ament_add_gtest(${PROJECT_NAME}-test_subscriber test/test_subscriber.cpp)
   if(TARGET ${PROJECT_NAME}-test_subscriber)
     target_link_libraries(${PROJECT_NAME}-test_subscriber ${PROJECT_NAME})

--- a/include/message_filters/cache.h
+++ b/include/message_filters/cache.h
@@ -58,7 +58,7 @@ using namespace std::placeholders;
  *
  * \section connections CONNECTIONS
  *
- * Cache's input and output connections are both of the same signature as roscpp subscription callbacks, ie.
+ * Cache's input and output connections are both of the same signature as rclcpp subscription callbacks, ie.
 \verbatim
 void callback(const std::shared_ptr<M const>&);
 \endverbatim

--- a/include/message_filters/chain.h
+++ b/include/message_filters/chain.h
@@ -42,7 +42,6 @@
 
 namespace message_filters
 {
-using namespace std::placeholders;
 /**
  * \brief Base class for Chain, allows you to store multiple chains in the same container.  Provides filter retrieval
  * by index.
@@ -154,13 +153,13 @@ public:
   size_t addFilter(const std::shared_ptr<F>& filter)
   {
     FilterInfo info;
-    info.add_func = std::bind((void(F::*)(const EventType&))&F::add, filter.get(), _1);
+    info.add_func = std::bind((void(F::*)(const EventType&))&F::add, filter.get(), std::placeholders::_1);
     info.filter = filter;
     info.passthrough = std::make_shared<PassThrough<M> >();
 
     last_filter_connection_.disconnect();
     info.passthrough->connectInput(*filter);
-    last_filter_connection_ = info.passthrough->registerCallback(typename SimpleFilter<M>::EventCallback(std::bind(&Chain::lastFilterCB, this, _1)));
+    last_filter_connection_ = info.passthrough->registerCallback(typename SimpleFilter<M>::EventCallback(std::bind(&Chain::lastFilterCB, this, std::placeholders::_1)));
     if (!filters_.empty())
     {
       filter->connectInput(*filters_.back().passthrough);
@@ -196,7 +195,7 @@ public:
   void connectInput(F& f)
   {
     incoming_connection_.disconnect();
-    incoming_connection_ = f.registerCallback(typename SimpleFilter<M>::EventCallback(std::bind(&Chain::incomingCB, this, _1)));
+    incoming_connection_ = f.registerCallback(typename SimpleFilter<M>::EventCallback(std::bind(&Chain::incomingCB, this, std::placeholders::_1)));
   }
 
   /**

--- a/include/message_filters/connection.h
+++ b/include/message_filters/connection.h
@@ -35,8 +35,8 @@
 #ifndef MESSAGE_FILTERS_CONNECTION_H
 #define MESSAGE_FILTERS_CONNECTION_H
 
-#include <boost/function.hpp>
-#include <boost/signals2/connection.hpp>
+#include <functional>
+#include <memory>
 #include "macros.h"
 
 namespace message_filters
@@ -48,23 +48,19 @@ namespace message_filters
 class MESSAGE_FILTERS_DECL Connection
 {
 public:
-  typedef boost::function<void(void)> VoidDisconnectFunction;
-  typedef boost::function<void(const Connection&)> WithConnectionDisconnectFunction;
+  typedef std::function<void(void)> VoidDisconnectFunction;
+  typedef std::function<void(const Connection&)> WithConnectionDisconnectFunction;
   Connection() {}
   Connection(const VoidDisconnectFunction& func);
-  Connection(const WithConnectionDisconnectFunction& func, boost::signals2::connection conn);
 
   /**
    * \brief disconnects this connection
    */
   void disconnect();
 
-  boost::signals2::connection getBoostConnection() const { return connection_; }
-
 private:
   VoidDisconnectFunction void_disconnect_;
   WithConnectionDisconnectFunction connection_disconnect_;
-  boost::signals2::connection connection_;
 };
 
 }

--- a/include/message_filters/connection.h
+++ b/include/message_filters/connection.h
@@ -42,6 +42,15 @@
 namespace message_filters
 {
 
+class noncopyable
+{
+protected:
+  noncopyable() {}
+  ~noncopyable() {}
+  noncopyable( const noncopyable& ) = delete;
+  noncopyable& operator=( const noncopyable& ) = delete;
+};
+
 /**
  * \brief Encapsulates a connection from one filter to another (or to a user-specified callback)
  */

--- a/include/message_filters/macros.h
+++ b/include/message_filters/macros.h
@@ -28,15 +28,14 @@
 #ifndef MESSAGE_FILTERS_MACROS_H_
 #define MESSAGE_FILTERS_MACROS_H_
 
-#include <ros/macros.h> // for the DECL's
-
+#include <rclcpp/visibility_control.hpp>
 // Import/export for windows dll's and visibility for gcc shared libraries.
 
 #ifdef ROS_BUILD_SHARED_LIBS // ros is being built around shared libraries
   #ifdef message_filters_EXPORTS // we are building a shared lib/dll
-    #define MESSAGE_FILTERS_DECL ROS_HELPER_EXPORT
+    #define MESSAGE_FILTERS_DECL RCLCPP_EXPORT
   #else // we are using shared lib/dll
-    #define MESSAGE_FILTERS_DECL ROS_HELPER_IMPORT
+    #define MESSAGE_FILTERS_DECL RCLCPP_IMPORT
   #endif
 #else // ros is being built around static libraries
   #define MESSAGE_FILTERS_DECL

--- a/include/message_filters/message_event.h
+++ b/include/message_filters/message_event.h
@@ -1,0 +1,256 @@
+
+/*
+ * Copyright (C) 2010, Willow Garage, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the names of Stanford University or Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ROSCPP_MESSAGE_EVENT_H
+#define ROSCPP_MESSAGE_EVENT_H
+
+#include "ros/time.h"
+#include <ros/datatypes.h>
+#include <ros/message_traits.h>
+
+#include <boost/type_traits/is_void.hpp>
+#include <boost/type_traits/is_base_of.hpp>
+#include <boost/type_traits/is_const.hpp>
+#include <boost/type_traits/add_const.hpp>
+#include <boost/type_traits/remove_const.hpp>
+#include <boost/utility/enable_if.hpp>
+#include <boost/function.hpp>
+#include <boost/make_shared.hpp>
+
+namespace ros
+{
+
+template<typename M>
+struct DefaultMessageCreator
+{
+  boost::shared_ptr<M> operator()()
+  {
+    return boost::make_shared<M>();
+  }
+};
+
+template<typename M>
+ROS_DEPRECATED inline boost::shared_ptr<M> defaultMessageCreateFunction()
+{
+  return DefaultMessageCreator<M>()();
+}
+
+/**
+ * \brief Event type for subscriptions, const ros::MessageEvent<M const>& can be used in your callback instead of const boost::shared_ptr<M const>&
+ *
+ * Useful if you need to retrieve meta-data about the message, such as the full connection header, or the publisher's node name
+ */
+template<typename M>
+class MessageEvent
+{
+public:
+  typedef typename boost::add_const<M>::type ConstMessage;
+  typedef typename boost::remove_const<M>::type Message;
+  typedef boost::shared_ptr<Message> MessagePtr;
+  typedef boost::shared_ptr<ConstMessage> ConstMessagePtr;
+  typedef boost::function<MessagePtr()> CreateFunction;
+
+  MessageEvent()
+  : nonconst_need_copy_(true)
+  {}
+
+  MessageEvent(const MessageEvent<Message>& rhs)
+  {
+    *this = rhs;
+  }
+
+  MessageEvent(const MessageEvent<ConstMessage>& rhs)
+  {
+    *this = rhs;
+  }
+
+  MessageEvent(const MessageEvent<Message>& rhs, bool nonconst_need_copy)
+  {
+    *this = rhs;
+    nonconst_need_copy_ = nonconst_need_copy;
+  }
+
+  MessageEvent(const MessageEvent<ConstMessage>& rhs, bool nonconst_need_copy)
+  {
+    *this = rhs;
+    nonconst_need_copy_ = nonconst_need_copy;
+  }
+
+  MessageEvent(const MessageEvent<void const>& rhs, const CreateFunction& create)
+  {
+    init(boost::const_pointer_cast<Message>(boost::static_pointer_cast<ConstMessage>(rhs.getMessage())), rhs.getConnectionHeaderPtr(), rhs.getReceiptTime(), rhs.nonConstWillCopy(), create);
+  }
+
+  /**
+   * \todo Make this explicit in ROS 2.0.  Keep as auto-converting for now to maintain backwards compatibility in some places (message_filters)
+   */
+  MessageEvent(const ConstMessagePtr& message)
+  {
+    init(message, boost::shared_ptr<M_string>(), ros::Time::now(), true, ros::DefaultMessageCreator<Message>());
+  }
+
+  MessageEvent(const ConstMessagePtr& message, const boost::shared_ptr<M_string>& connection_header, ros::Time receipt_time)
+  {
+    init(message, connection_header, receipt_time, true, ros::DefaultMessageCreator<Message>());
+  }
+
+  MessageEvent(const ConstMessagePtr& message, ros::Time receipt_time)
+  {
+    init(message, boost::shared_ptr<M_string>(), receipt_time, true, ros::DefaultMessageCreator<Message>());
+  }
+
+  MessageEvent(const ConstMessagePtr& message, const boost::shared_ptr<M_string>& connection_header, ros::Time receipt_time, bool nonconst_need_copy, const CreateFunction& create)
+  {
+    init(message, connection_header, receipt_time, nonconst_need_copy, create);
+  }
+
+  void init(const ConstMessagePtr& message, const boost::shared_ptr<M_string>& connection_header, ros::Time receipt_time, bool nonconst_need_copy, const CreateFunction& create)
+  {
+    message_ = message;
+    connection_header_ = connection_header;
+    receipt_time_ = receipt_time;
+    nonconst_need_copy_ = nonconst_need_copy;
+    create_ = create;
+  }
+
+  void operator=(const MessageEvent<Message>& rhs)
+  {
+    init(boost::static_pointer_cast<Message>(rhs.getMessage()), rhs.getConnectionHeaderPtr(), rhs.getReceiptTime(), rhs.nonConstWillCopy(), rhs.getMessageFactory());
+    message_copy_.reset();
+  }
+
+  void operator=(const MessageEvent<ConstMessage>& rhs)
+  {
+    init(boost::const_pointer_cast<Message>(boost::static_pointer_cast<ConstMessage>(rhs.getMessage())), rhs.getConnectionHeaderPtr(), rhs.getReceiptTime(), rhs.nonConstWillCopy(), rhs.getMessageFactory());
+    message_copy_.reset();
+  }
+
+  /**
+   * \brief Retrieve the message.  If M is const, this returns a reference to it.  If M is non const
+   * and this event requires it, returns a copy.  Note that it caches this copy for later use, so it will
+   * only every make the copy once
+   */
+  boost::shared_ptr<M> getMessage() const
+  {
+    return copyMessageIfNecessary<M>();
+  }
+
+  /**
+   * \brief Retrieve a const version of the message
+   */
+  const boost::shared_ptr<ConstMessage>& getConstMessage() const { return message_; }
+  /**
+   * \brief Retrieve the connection header
+   */
+  M_string& getConnectionHeader() const { return *connection_header_; }
+  const boost::shared_ptr<M_string>& getConnectionHeaderPtr() const { return connection_header_; }
+
+  /**
+   * \brief Returns the name of the node which published this message
+   */
+  const std::string& getPublisherName() const { return connection_header_ ? (*connection_header_)["callerid"] : s_unknown_publisher_string_; }
+
+  /**
+   * \brief Returns the time at which this message was received
+   */
+  ros::Time getReceiptTime() const { return receipt_time_; }
+
+  bool nonConstWillCopy() const { return nonconst_need_copy_; }
+  bool getMessageWillCopy() const { return !boost::is_const<M>::value && nonconst_need_copy_; }
+
+  bool operator<(const MessageEvent<M>& rhs)
+  {
+    if (message_ != rhs.message_)
+    {
+      return message_ < rhs.message_;
+    }
+
+    if (receipt_time_ != rhs.receipt_time_)
+    {
+      return receipt_time_ < rhs.receipt_time_;
+    }
+
+    return nonconst_need_copy_ < rhs.nonconst_need_copy_;
+  }
+
+  bool operator==(const MessageEvent<M>& rhs)
+  {
+    return message_ == rhs.message_ && receipt_time_ == rhs.receipt_time_ && nonconst_need_copy_ == rhs.nonconst_need_copy_;
+  }
+
+  bool operator!=(const MessageEvent<M>& rhs)
+  {
+    return !(*this == rhs);
+  }
+
+  const CreateFunction& getMessageFactory() const { return create_; }
+
+private:
+  template<typename M2>
+  typename boost::disable_if<boost::is_void<M2>, boost::shared_ptr<M> >::type copyMessageIfNecessary() const
+  {
+    if (boost::is_const<M>::value || !nonconst_need_copy_)
+    {
+      return boost::const_pointer_cast<Message>(message_);
+    }
+
+    if (message_copy_)
+    {
+      return message_copy_;
+    }
+
+    assert(create_);
+    message_copy_ = create_();
+    *message_copy_ = *message_;
+
+    return message_copy_;
+  }
+
+  template<typename M2>
+  typename boost::enable_if<boost::is_void<M2>, boost::shared_ptr<M> >::type copyMessageIfNecessary() const
+  {
+    return boost::const_pointer_cast<Message>(message_);
+  }
+
+  ConstMessagePtr message_;
+  // Kind of ugly to make this mutable, but it means we can pass a const MessageEvent to a callback and not worry about other things being modified
+  mutable MessagePtr message_copy_;
+  boost::shared_ptr<M_string> connection_header_;
+  ros::Time receipt_time_;
+  bool nonconst_need_copy_;
+  CreateFunction create_;
+
+  static const std::string s_unknown_publisher_string_;
+};
+
+template<typename M> const std::string MessageEvent<M>::s_unknown_publisher_string_("unknown_publisher");
+
+
+}
+
+#endif // ROSCPP_MESSAGE_EVENT_H

--- a/include/message_filters/message_event.h
+++ b/include/message_filters/message_event.h
@@ -97,7 +97,7 @@ public:
 
   MessageEvent(const MessageEvent<void const>& rhs, const CreateFunction& create)
   {
-    init(std::const_pointer_cast<Message>(std::static_pointer_cast<ConstMessage>(rhs.getMessage())), rhs.getConnectionHeaderPtr(), rhs.getReceiptTime(), rhs.nonConstWillCopy(), create);
+    init(std::const_pointer_cast<Message>(std::static_pointer_cast<ConstMessage>(rhs.getMessage())), rhs.getReceiptTime(), rhs.nonConstWillCopy(), create);
   }
 
   /**
@@ -105,28 +105,22 @@ public:
    */
   MessageEvent(const ConstMessagePtr& message)
   {
-    init(message, std::shared_ptr<M_string>(), rclcpp::Clock().now(), true, message_filters::DefaultMessageCreator<Message>());
-  }
-
-  MessageEvent(const ConstMessagePtr& message, const std::shared_ptr<M_string>& connection_header, rclcpp::Time receipt_time)
-  {
-    init(message, connection_header, receipt_time, true, message_filters::DefaultMessageCreator<Message>());
+    init(message, rclcpp::Clock().now(), true, message_filters::DefaultMessageCreator<Message>());
   }
 
   MessageEvent(const ConstMessagePtr& message, rclcpp::Time receipt_time)
   {
-    init(message, std::shared_ptr<M_string>(), receipt_time, true, message_filters::DefaultMessageCreator<Message>());
+    init(message, receipt_time, true, message_filters::DefaultMessageCreator<Message>());
   }
 
-  MessageEvent(const ConstMessagePtr& message, const std::shared_ptr<M_string>& connection_header, rclcpp::Time receipt_time, bool nonconst_need_copy, const CreateFunction& create)
+  MessageEvent(const ConstMessagePtr& message, rclcpp::Time receipt_time, bool nonconst_need_copy, const CreateFunction& create)
   {
-    init(message, connection_header, receipt_time, nonconst_need_copy, create);
+    init(message, receipt_time, nonconst_need_copy, create);
   }
 
-  void init(const ConstMessagePtr& message, const std::shared_ptr<M_string>& connection_header, rclcpp::Time receipt_time, bool nonconst_need_copy, const CreateFunction& create)
+  void init(const ConstMessagePtr& message, rclcpp::Time receipt_time, bool nonconst_need_copy, const CreateFunction& create)
   {
     message_ = message;
-    connection_header_ = connection_header;
     receipt_time_ = receipt_time;
     nonconst_need_copy_ = nonconst_need_copy;
     create_ = create;
@@ -134,13 +128,13 @@ public:
 
   void operator=(const MessageEvent<Message>& rhs)
   {
-    init(std::static_pointer_cast<Message>(rhs.getMessage()), rhs.getConnectionHeaderPtr(), rhs.getReceiptTime(), rhs.nonConstWillCopy(), rhs.getMessageFactory());
+    init(std::static_pointer_cast<Message>(rhs.getMessage()), rhs.getReceiptTime(), rhs.nonConstWillCopy(), rhs.getMessageFactory());
     message_copy_.reset();
   }
 
   void operator=(const MessageEvent<ConstMessage>& rhs)
   {
-    init(std::const_pointer_cast<Message>(std::static_pointer_cast<ConstMessage>(rhs.getMessage())), rhs.getConnectionHeaderPtr(), rhs.getReceiptTime(), rhs.nonConstWillCopy(), rhs.getMessageFactory());
+    init(std::const_pointer_cast<Message>(std::static_pointer_cast<ConstMessage>(rhs.getMessage())), rhs.getReceiptTime(), rhs.nonConstWillCopy(), rhs.getMessageFactory());
     message_copy_.reset();
   }
 
@@ -158,16 +152,6 @@ public:
    * \brief Retrieve a const version of the message
    */
   const std::shared_ptr<ConstMessage>& getConstMessage() const { return message_; }
-  /**
-   * \brief Retrieve the connection header
-   */
-  M_string& getConnectionHeader() const { return *connection_header_; }
-  const std::shared_ptr<M_string>& getConnectionHeaderPtr() const { return connection_header_; }
-
-  /**
-   * \brief Returns the name of the node which published this message
-   */
-  const std::string& getPublisherName() const { return connection_header_ ? (*connection_header_)["callerid"] : s_unknown_publisher_string_; }
 
   /**
    * \brief Returns the time at which this message was received
@@ -234,7 +218,6 @@ private:
   ConstMessagePtr message_;
   // Kind of ugly to make this mutable, but it means we can pass a const MessageEvent to a callback and not worry about other things being modified
   mutable MessagePtr message_copy_;
-  std::shared_ptr<M_string> connection_header_;
   rclcpp::Time receipt_time_;
   bool nonconst_need_copy_;
   CreateFunction create_;

--- a/include/message_filters/message_event.h
+++ b/include/message_filters/message_event.h
@@ -55,7 +55,7 @@ ROS_DEPRECATED inline std::shared_ptr<M> defaultMessageCreateFunction()
 }
 */
 /**
- * \brief Event type for subscriptions, const ros::MessageEvent<M const>& can be used in your callback instead of const std::shared_ptr<M const>&
+ * \brief Event type for subscriptions, const message_filters::MessageEvent<M const>& can be used in your callback instead of const std::shared_ptr<M const>&
  *
  * Useful if you need to retrieve meta-data about the message, such as the full connection header, or the publisher's node name
  */

--- a/include/message_filters/message_event.h
+++ b/include/message_filters/message_event.h
@@ -33,6 +33,14 @@
 #include <type_traits>
 #include <memory>
 
+#ifndef RCUTILS_ASSERT
+// TODO(tfoote) remove this after it's implemented upstream
+// https://github.com/ros2/rcutils/pull/112
+#define RCUTILS_ASSERT assert
+#endif
+// Uncomment below intead
+//#include <rcutils/assert.h>
+
 namespace message_filters
 {
 typedef std::map< std::string, std::string > 	M_string;
@@ -202,7 +210,7 @@ private:
       return message_copy_;
     }
 
-    assert(create_);
+    RCUTILS_ASSERT(create_);
     message_copy_ = create_();
     *message_copy_ = *message_;
 

--- a/include/message_filters/message_event.h
+++ b/include/message_filters/message_event.h
@@ -26,42 +26,36 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef ROSCPP_MESSAGE_EVENT_H
-#define ROSCPP_MESSAGE_EVENT_H
+#ifndef RCLCPP_MESSAGE_EVENT_H
+#define RCLCPP_MESSAGE_EVENT_H
 
-#include "ros/time.h"
-#include <ros/datatypes.h>
-#include <ros/message_traits.h>
+#include <rclcpp/rclcpp.hpp>
+#include <type_traits>
+#include <memory>
 
-#include <boost/type_traits/is_void.hpp>
-#include <boost/type_traits/is_base_of.hpp>
-#include <boost/type_traits/is_const.hpp>
-#include <boost/type_traits/add_const.hpp>
-#include <boost/type_traits/remove_const.hpp>
-#include <boost/utility/enable_if.hpp>
-#include <boost/function.hpp>
-#include <boost/make_shared.hpp>
-
-namespace ros
+namespace message_filters
 {
+typedef std::map< std::string, std::string > 	M_string;
+typedef std::shared_ptr< M_string > 	M_stringPtr;
 
 template<typename M>
 struct DefaultMessageCreator
 {
-  boost::shared_ptr<M> operator()()
+  std::shared_ptr<M> operator()()
   {
-    return boost::make_shared<M>();
+    return std::make_shared<M>();
   }
 };
 
+/*
 template<typename M>
-ROS_DEPRECATED inline boost::shared_ptr<M> defaultMessageCreateFunction()
+ROS_DEPRECATED inline std::shared_ptr<M> defaultMessageCreateFunction()
 {
   return DefaultMessageCreator<M>()();
 }
-
+*/
 /**
- * \brief Event type for subscriptions, const ros::MessageEvent<M const>& can be used in your callback instead of const boost::shared_ptr<M const>&
+ * \brief Event type for subscriptions, const ros::MessageEvent<M const>& can be used in your callback instead of const std::shared_ptr<M const>&
  *
  * Useful if you need to retrieve meta-data about the message, such as the full connection header, or the publisher's node name
  */
@@ -69,11 +63,11 @@ template<typename M>
 class MessageEvent
 {
 public:
-  typedef typename boost::add_const<M>::type ConstMessage;
-  typedef typename boost::remove_const<M>::type Message;
-  typedef boost::shared_ptr<Message> MessagePtr;
-  typedef boost::shared_ptr<ConstMessage> ConstMessagePtr;
-  typedef boost::function<MessagePtr()> CreateFunction;
+  typedef typename std::add_const<M>::type ConstMessage;
+  typedef typename std::remove_const<M>::type Message;
+  typedef std::shared_ptr<Message> MessagePtr;
+  typedef std::shared_ptr<ConstMessage> ConstMessagePtr;
+  typedef std::function<MessagePtr()> CreateFunction;
 
   MessageEvent()
   : nonconst_need_copy_(true)
@@ -103,7 +97,7 @@ public:
 
   MessageEvent(const MessageEvent<void const>& rhs, const CreateFunction& create)
   {
-    init(boost::const_pointer_cast<Message>(boost::static_pointer_cast<ConstMessage>(rhs.getMessage())), rhs.getConnectionHeaderPtr(), rhs.getReceiptTime(), rhs.nonConstWillCopy(), create);
+    init(std::const_pointer_cast<Message>(std::static_pointer_cast<ConstMessage>(rhs.getMessage())), rhs.getConnectionHeaderPtr(), rhs.getReceiptTime(), rhs.nonConstWillCopy(), create);
   }
 
   /**
@@ -111,25 +105,25 @@ public:
    */
   MessageEvent(const ConstMessagePtr& message)
   {
-    init(message, boost::shared_ptr<M_string>(), ros::Time::now(), true, ros::DefaultMessageCreator<Message>());
+    init(message, std::shared_ptr<M_string>(), rclcpp::Clock().now(), true, message_filters::DefaultMessageCreator<Message>());
   }
 
-  MessageEvent(const ConstMessagePtr& message, const boost::shared_ptr<M_string>& connection_header, ros::Time receipt_time)
+  MessageEvent(const ConstMessagePtr& message, const std::shared_ptr<M_string>& connection_header, rclcpp::Time receipt_time)
   {
-    init(message, connection_header, receipt_time, true, ros::DefaultMessageCreator<Message>());
+    init(message, connection_header, receipt_time, true, message_filters::DefaultMessageCreator<Message>());
   }
 
-  MessageEvent(const ConstMessagePtr& message, ros::Time receipt_time)
+  MessageEvent(const ConstMessagePtr& message, rclcpp::Time receipt_time)
   {
-    init(message, boost::shared_ptr<M_string>(), receipt_time, true, ros::DefaultMessageCreator<Message>());
+    init(message, std::shared_ptr<M_string>(), receipt_time, true, message_filters::DefaultMessageCreator<Message>());
   }
 
-  MessageEvent(const ConstMessagePtr& message, const boost::shared_ptr<M_string>& connection_header, ros::Time receipt_time, bool nonconst_need_copy, const CreateFunction& create)
+  MessageEvent(const ConstMessagePtr& message, const std::shared_ptr<M_string>& connection_header, rclcpp::Time receipt_time, bool nonconst_need_copy, const CreateFunction& create)
   {
     init(message, connection_header, receipt_time, nonconst_need_copy, create);
   }
 
-  void init(const ConstMessagePtr& message, const boost::shared_ptr<M_string>& connection_header, ros::Time receipt_time, bool nonconst_need_copy, const CreateFunction& create)
+  void init(const ConstMessagePtr& message, const std::shared_ptr<M_string>& connection_header, rclcpp::Time receipt_time, bool nonconst_need_copy, const CreateFunction& create)
   {
     message_ = message;
     connection_header_ = connection_header;
@@ -140,13 +134,13 @@ public:
 
   void operator=(const MessageEvent<Message>& rhs)
   {
-    init(boost::static_pointer_cast<Message>(rhs.getMessage()), rhs.getConnectionHeaderPtr(), rhs.getReceiptTime(), rhs.nonConstWillCopy(), rhs.getMessageFactory());
+    init(std::static_pointer_cast<Message>(rhs.getMessage()), rhs.getConnectionHeaderPtr(), rhs.getReceiptTime(), rhs.nonConstWillCopy(), rhs.getMessageFactory());
     message_copy_.reset();
   }
 
   void operator=(const MessageEvent<ConstMessage>& rhs)
   {
-    init(boost::const_pointer_cast<Message>(boost::static_pointer_cast<ConstMessage>(rhs.getMessage())), rhs.getConnectionHeaderPtr(), rhs.getReceiptTime(), rhs.nonConstWillCopy(), rhs.getMessageFactory());
+    init(std::const_pointer_cast<Message>(std::static_pointer_cast<ConstMessage>(rhs.getMessage())), rhs.getConnectionHeaderPtr(), rhs.getReceiptTime(), rhs.nonConstWillCopy(), rhs.getMessageFactory());
     message_copy_.reset();
   }
 
@@ -155,7 +149,7 @@ public:
    * and this event requires it, returns a copy.  Note that it caches this copy for later use, so it will
    * only every make the copy once
    */
-  boost::shared_ptr<M> getMessage() const
+  std::shared_ptr<M> getMessage() const
   {
     return copyMessageIfNecessary<M>();
   }
@@ -163,12 +157,12 @@ public:
   /**
    * \brief Retrieve a const version of the message
    */
-  const boost::shared_ptr<ConstMessage>& getConstMessage() const { return message_; }
+  const std::shared_ptr<ConstMessage>& getConstMessage() const { return message_; }
   /**
    * \brief Retrieve the connection header
    */
   M_string& getConnectionHeader() const { return *connection_header_; }
-  const boost::shared_ptr<M_string>& getConnectionHeaderPtr() const { return connection_header_; }
+  const std::shared_ptr<M_string>& getConnectionHeaderPtr() const { return connection_header_; }
 
   /**
    * \brief Returns the name of the node which published this message
@@ -178,10 +172,10 @@ public:
   /**
    * \brief Returns the time at which this message was received
    */
-  ros::Time getReceiptTime() const { return receipt_time_; }
+  rclcpp::Time getReceiptTime() const { return receipt_time_; }
 
   bool nonConstWillCopy() const { return nonconst_need_copy_; }
-  bool getMessageWillCopy() const { return !boost::is_const<M>::value && nonconst_need_copy_; }
+  bool getMessageWillCopy() const { return !std::is_const<M>::value && nonconst_need_copy_; }
 
   bool operator<(const MessageEvent<M>& rhs)
   {
@@ -212,11 +206,11 @@ public:
 
 private:
   template<typename M2>
-  typename boost::disable_if<boost::is_void<M2>, boost::shared_ptr<M> >::type copyMessageIfNecessary() const
+  typename std::enable_if<!std::is_void<M2>::value, std::shared_ptr<M> >::type copyMessageIfNecessary() const
   {
-    if (boost::is_const<M>::value || !nonconst_need_copy_)
+    if (std::is_const<M>::value || !nonconst_need_copy_)
     {
-      return boost::const_pointer_cast<Message>(message_);
+      return std::const_pointer_cast<Message>(message_);
     }
 
     if (message_copy_)
@@ -232,16 +226,16 @@ private:
   }
 
   template<typename M2>
-  typename boost::enable_if<boost::is_void<M2>, boost::shared_ptr<M> >::type copyMessageIfNecessary() const
+  typename std::enable_if<std::is_void<M2>::value, std::shared_ptr<M> >::type copyMessageIfNecessary() const
   {
-    return boost::const_pointer_cast<Message>(message_);
+    return std::const_pointer_cast<Message>(message_);
   }
 
   ConstMessagePtr message_;
   // Kind of ugly to make this mutable, but it means we can pass a const MessageEvent to a callback and not worry about other things being modified
   mutable MessagePtr message_copy_;
-  boost::shared_ptr<M_string> connection_header_;
-  ros::Time receipt_time_;
+  std::shared_ptr<M_string> connection_header_;
+  rclcpp::Time receipt_time_;
   bool nonconst_need_copy_;
   CreateFunction create_;
 
@@ -253,4 +247,4 @@ template<typename M> const std::string MessageEvent<M>::s_unknown_publisher_stri
 
 }
 
-#endif // ROSCPP_MESSAGE_EVENT_H
+#endif // RCLCPP_MESSAGE_EVENT_H

--- a/include/message_filters/message_traits.h
+++ b/include/message_filters/message_traits.h
@@ -1,0 +1,360 @@
+/*
+ * Copyright (C) 2009, Willow Garage, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the names of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ROSLIB_MESSAGE_TRAITS_H
+#define ROSLIB_MESSAGE_TRAITS_H
+
+#include "message_forward.h"
+
+#include <ros/time.h>
+
+#include <string>
+#include <boost/utility/enable_if.hpp>
+#include <boost/type_traits/remove_const.hpp>
+#include <boost/type_traits/remove_reference.hpp>
+
+namespace std_msgs
+{
+  ROS_DECLARE_MESSAGE(Header)
+}
+
+#define ROS_IMPLEMENT_SIMPLE_TOPIC_TRAITS(msg, md5sum, datatype, definition) \
+  namespace ros \
+  { \
+  namespace message_traits \
+  { \
+  template<> struct MD5Sum<msg> \
+  { \
+    static const char* value() { return md5sum; } \
+    static const char* value(const msg&) { return value(); } \
+  }; \
+  template<> struct DataType<msg> \
+  { \
+    static const char* value() { return datatype; } \
+    static const char* value(const msg&) { return value(); } \
+  }; \
+  template<> struct Definition<msg> \
+  { \
+    static const char* value() { return definition; } \
+    static const char* value(const msg&) { return value(); } \
+  }; \
+  } \
+  }
+
+
+namespace ros
+{
+namespace message_traits
+{
+
+/**
+ * \brief Base type for compile-type true/false tests.  Compatible with Boost.MPL.  classes inheriting from this type
+ * are \b true values.
+ */
+struct TrueType
+{
+  static const bool value = true;
+  typedef TrueType type;
+};
+
+/**
+ * \brief Base type for compile-type true/false tests.  Compatible with Boost.MPL.  classes inheriting from this type
+ * are \b false values.
+ */
+struct FalseType
+{
+  static const bool value = false;
+  typedef FalseType type;
+};
+
+/**
+ * \brief A simple datatype is one that can be memcpy'd directly in array form, i.e. it's a POD, fixed-size type and
+ * sizeof(M) == sum(serializationLength(M:a...))
+ */
+template<typename M> struct IsSimple : public FalseType {};
+/**
+ * \brief A fixed-size datatype is one whose size is constant, i.e. it has no variable-length arrays or strings
+ */
+template<typename M> struct IsFixedSize : public FalseType {};
+/**
+ * \brief HasHeader informs whether or not there is a header that gets serialized as the first thing in the message
+ */
+template<typename M> struct HasHeader : public FalseType {};
+
+/**
+ * \brief Am I message or not
+ */
+template<typename M> struct IsMessage : public FalseType {};
+
+/**
+ * \brief Specialize to provide the md5sum for a message
+ */
+template<typename M>
+struct MD5Sum
+{
+  static const char* value()
+  {
+    return M::__s_getMD5Sum().c_str();
+  }
+
+  static const char* value(const M& m)
+  {
+    return m.__getMD5Sum().c_str();
+  }
+};
+
+/**
+ * \brief Specialize to provide the datatype for a message
+ */
+template<typename M>
+struct DataType
+{
+  static const char* value()
+  {
+    return M::__s_getDataType().c_str();
+  }
+
+  static const char* value(const M& m)
+  {
+    return m.__getDataType().c_str();
+  }
+};
+
+/**
+ * \brief Specialize to provide the definition for a message
+ */
+template<typename M>
+struct Definition
+{
+  static const char* value()
+  {
+    return M::__s_getMessageDefinition().c_str();
+  }
+
+  static const char* value(const M& m)
+  {
+    return m.__getMessageDefinition().c_str();
+  }
+};
+
+/**
+ * \brief Header trait.  In the default implementation pointer()
+ * returns &m.header if HasHeader<M>::value is true, otherwise returns NULL
+ */
+template<typename M, typename Enable = void>
+struct Header
+{
+  static std_msgs::Header* pointer(M& m) { (void)m; return 0; }
+  static std_msgs::Header const* pointer(const M& m) { (void)m; return 0; }
+};
+
+template<typename M>
+struct Header<M, typename boost::enable_if<HasHeader<M> >::type >
+{
+  static std_msgs::Header* pointer(M& m) { return &m.header; }
+  static std_msgs::Header const* pointer(const M& m) { return &m.header; }
+};
+
+/**
+ * \brief FrameId trait.  In the default implementation pointer()
+ * returns &m.header.frame_id if HasHeader<M>::value is true, otherwise returns NULL.  value()
+ * does not exist, and causes a compile error
+ */
+template<typename M, typename Enable = void>
+struct FrameId
+{
+  static std::string* pointer(M& m) { (void)m; return 0; }
+  static std::string const* pointer(const M& m) { (void)m; return 0; }
+};
+
+template<typename M>
+struct FrameId<M, typename boost::enable_if<HasHeader<M> >::type >
+{
+  static std::string* pointer(M& m) { return &m.header.frame_id; }
+  static std::string const* pointer(const M& m) { return &m.header.frame_id; }
+  static std::string value(const M& m) { return m.header.frame_id; }
+};
+
+/**
+ * \brief TimeStamp trait.  In the default implementation pointer()
+ * returns &m.header.stamp if HasHeader<M>::value is true, otherwise returns NULL.  value()
+ * does not exist, and causes a compile error
+ */
+template<typename M, typename Enable = void>
+struct TimeStamp
+{
+  static ros::Time* pointer(M& m) { (void)m; return 0; }
+  static ros::Time const* pointer(const M& m) { (void)m; return 0; }
+};
+
+template<typename M>
+struct TimeStamp<M, typename boost::enable_if<HasHeader<M> >::type >
+{
+  static ros::Time* pointer(typename boost::remove_const<M>::type &m) { return &m.header.stamp; }
+  static ros::Time const* pointer(const M& m) { return &m.header.stamp; }
+  static ros::Time value(const M& m) { return m.header.stamp; }
+};
+
+/**
+ * \brief returns MD5Sum<M>::value();
+ */
+template<typename M>
+inline const char* md5sum()
+{
+  return MD5Sum<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::value();
+}
+
+/**
+ * \brief returns DataType<M>::value();
+ */
+template<typename M>
+inline const char* datatype()
+{
+  return DataType<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::value();
+}
+
+/**
+ * \brief returns Definition<M>::value();
+ */
+template<typename M>
+inline const char* definition()
+{
+  return Definition<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::value();
+}
+
+/**
+ * \brief returns MD5Sum<M>::value(m);
+ */
+template<typename M>
+inline const char* md5sum(const M& m)
+{
+  return MD5Sum<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::value(m);
+}
+
+/**
+ * \brief returns DataType<M>::value(m);
+ */
+template<typename M>
+inline const char* datatype(const M& m)
+{
+  return DataType<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::value(m);
+}
+
+/**
+ * \brief returns Definition<M>::value(m);
+ */
+template<typename M>
+inline const char* definition(const M& m)
+{
+  return Definition<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::value(m);
+}
+
+/**
+ * \brief returns Header<M>::pointer(m);
+ */
+template<typename M>
+inline std_msgs::Header* header(M& m)
+{
+  return Header<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::pointer(m);
+}
+
+/**
+ * \brief returns Header<M>::pointer(m);
+ */
+template<typename M>
+inline std_msgs::Header const* header(const M& m)
+{
+  return Header<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::pointer(m);
+}
+
+/**
+ * \brief returns FrameId<M>::pointer(m);
+ */
+template<typename M>
+inline std::string* frameId(M& m)
+{
+  return FrameId<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::pointer(m);
+}
+
+/**
+ * \brief returns FrameId<M>::pointer(m);
+ */
+template<typename M>
+inline std::string const* frameId(const M& m)
+{
+  return FrameId<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::pointer(m);
+}
+
+/**
+ * \brief returns TimeStamp<M>::pointer(m);
+ */
+template<typename M>
+inline ros::Time* timeStamp(M& m)
+{
+  return TimeStamp<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::pointer(m);
+}
+
+/**
+ * \brief returns TimeStamp<M>::pointer(m);
+ */
+template<typename M>
+inline ros::Time const* timeStamp(const M& m)
+{
+  return TimeStamp<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::pointer(m);
+}
+
+/**
+ * \brief returns IsSimple<M>::value;
+ */
+template<typename M>
+inline bool isSimple()
+{
+  return IsSimple<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::value;
+}
+
+/**
+ * \brief returns IsFixedSize<M>::value;
+ */
+template<typename M>
+inline bool isFixedSize()
+{
+  return IsFixedSize<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::value;
+}
+
+/**
+ * \brief returns HasHeader<M>::value;
+ */
+template<typename M>
+inline bool hasHeader()
+{
+  return HasHeader<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::value;
+}
+
+} // namespace message_traits
+} // namespace ros
+
+#endif // ROSLIB_MESSAGE_TRAITS_H

--- a/include/message_filters/message_traits.h
+++ b/include/message_filters/message_traits.h
@@ -28,176 +28,21 @@
 #ifndef ROSLIB_MESSAGE_TRAITS_H
 #define ROSLIB_MESSAGE_TRAITS_H
 
-#include "message_forward.h"
+#include <type_traits>
+#include <rclcpp/rclcpp.hpp>
 
-#include <ros/time.h>
-
-#include <string>
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/remove_const.hpp>
-#include <boost/type_traits/remove_reference.hpp>
-
-namespace std_msgs
-{
-  ROS_DECLARE_MESSAGE(Header)
-}
-
-#define ROS_IMPLEMENT_SIMPLE_TOPIC_TRAITS(msg, md5sum, datatype, definition) \
-  namespace ros \
-  { \
-  namespace message_traits \
-  { \
-  template<> struct MD5Sum<msg> \
-  { \
-    static const char* value() { return md5sum; } \
-    static const char* value(const msg&) { return value(); } \
-  }; \
-  template<> struct DataType<msg> \
-  { \
-    static const char* value() { return datatype; } \
-    static const char* value(const msg&) { return value(); } \
-  }; \
-  template<> struct Definition<msg> \
-  { \
-    static const char* value() { return definition; } \
-    static const char* value(const msg&) { return value(); } \
-  }; \
-  } \
-  }
-
-
-namespace ros
+namespace message_filters
 {
 namespace message_traits
 {
 
 /**
- * \brief Base type for compile-type true/false tests.  Compatible with Boost.MPL.  classes inheriting from this type
- * are \b true values.
- */
-struct TrueType
-{
-  static const bool value = true;
-  typedef TrueType type;
-};
-
-/**
- * \brief Base type for compile-type true/false tests.  Compatible with Boost.MPL.  classes inheriting from this type
- * are \b false values.
- */
-struct FalseType
-{
-  static const bool value = false;
-  typedef FalseType type;
-};
-
-/**
- * \brief A simple datatype is one that can be memcpy'd directly in array form, i.e. it's a POD, fixed-size type and
- * sizeof(M) == sum(serializationLength(M:a...))
- */
-template<typename M> struct IsSimple : public FalseType {};
-/**
- * \brief A fixed-size datatype is one whose size is constant, i.e. it has no variable-length arrays or strings
- */
-template<typename M> struct IsFixedSize : public FalseType {};
-/**
  * \brief HasHeader informs whether or not there is a header that gets serialized as the first thing in the message
  */
-template<typename M> struct HasHeader : public FalseType {};
+template<typename M, typename = void> struct HasHeader : public std::false_type {};
 
-/**
- * \brief Am I message or not
- */
-template<typename M> struct IsMessage : public FalseType {};
-
-/**
- * \brief Specialize to provide the md5sum for a message
- */
-template<typename M>
-struct MD5Sum
-{
-  static const char* value()
-  {
-    return M::__s_getMD5Sum().c_str();
-  }
-
-  static const char* value(const M& m)
-  {
-    return m.__getMD5Sum().c_str();
-  }
-};
-
-/**
- * \brief Specialize to provide the datatype for a message
- */
-template<typename M>
-struct DataType
-{
-  static const char* value()
-  {
-    return M::__s_getDataType().c_str();
-  }
-
-  static const char* value(const M& m)
-  {
-    return m.__getDataType().c_str();
-  }
-};
-
-/**
- * \brief Specialize to provide the definition for a message
- */
-template<typename M>
-struct Definition
-{
-  static const char* value()
-  {
-    return M::__s_getMessageDefinition().c_str();
-  }
-
-  static const char* value(const M& m)
-  {
-    return m.__getMessageDefinition().c_str();
-  }
-};
-
-/**
- * \brief Header trait.  In the default implementation pointer()
- * returns &m.header if HasHeader<M>::value is true, otherwise returns NULL
- */
-template<typename M, typename Enable = void>
-struct Header
-{
-  static std_msgs::Header* pointer(M& m) { (void)m; return 0; }
-  static std_msgs::Header const* pointer(const M& m) { (void)m; return 0; }
-};
-
-template<typename M>
-struct Header<M, typename boost::enable_if<HasHeader<M> >::type >
-{
-  static std_msgs::Header* pointer(M& m) { return &m.header; }
-  static std_msgs::Header const* pointer(const M& m) { return &m.header; }
-};
-
-/**
- * \brief FrameId trait.  In the default implementation pointer()
- * returns &m.header.frame_id if HasHeader<M>::value is true, otherwise returns NULL.  value()
- * does not exist, and causes a compile error
- */
-template<typename M, typename Enable = void>
-struct FrameId
-{
-  static std::string* pointer(M& m) { (void)m; return 0; }
-  static std::string const* pointer(const M& m) { (void)m; return 0; }
-};
-
-template<typename M>
-struct FrameId<M, typename boost::enable_if<HasHeader<M> >::type >
-{
-  static std::string* pointer(M& m) { return &m.header.frame_id; }
-  static std::string const* pointer(const M& m) { return &m.header.frame_id; }
-  static std::string value(const M& m) { return m.header.frame_id; }
-};
+template <typename M>
+struct HasHeader<M, decltype((void) M::header)> : std::true_type {};
 
 /**
  * \brief TimeStamp trait.  In the default implementation pointer()
@@ -207,154 +52,22 @@ struct FrameId<M, typename boost::enable_if<HasHeader<M> >::type >
 template<typename M, typename Enable = void>
 struct TimeStamp
 {
-  static ros::Time* pointer(M& m) { (void)m; return 0; }
-  static ros::Time const* pointer(const M& m) { (void)m; return 0; }
+  static rclcpp::Time value(const M& m) {
+    (void)m;
+    return rclcpp::Time();
+  }
 };
 
 template<typename M>
-struct TimeStamp<M, typename boost::enable_if<HasHeader<M> >::type >
+struct TimeStamp<M, typename std::enable_if<HasHeader<M>::value>::type >
 {
-  static ros::Time* pointer(typename boost::remove_const<M>::type &m) { return &m.header.stamp; }
-  static ros::Time const* pointer(const M& m) { return &m.header.stamp; }
-  static ros::Time value(const M& m) { return m.header.stamp; }
+  static rclcpp::Time value(const M& m) {
+    auto stamp = m.header.stamp;
+    return rclcpp::Time(stamp.sec, stamp.nanosec);
+  }
 };
-
-/**
- * \brief returns MD5Sum<M>::value();
- */
-template<typename M>
-inline const char* md5sum()
-{
-  return MD5Sum<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::value();
-}
-
-/**
- * \brief returns DataType<M>::value();
- */
-template<typename M>
-inline const char* datatype()
-{
-  return DataType<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::value();
-}
-
-/**
- * \brief returns Definition<M>::value();
- */
-template<typename M>
-inline const char* definition()
-{
-  return Definition<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::value();
-}
-
-/**
- * \brief returns MD5Sum<M>::value(m);
- */
-template<typename M>
-inline const char* md5sum(const M& m)
-{
-  return MD5Sum<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::value(m);
-}
-
-/**
- * \brief returns DataType<M>::value(m);
- */
-template<typename M>
-inline const char* datatype(const M& m)
-{
-  return DataType<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::value(m);
-}
-
-/**
- * \brief returns Definition<M>::value(m);
- */
-template<typename M>
-inline const char* definition(const M& m)
-{
-  return Definition<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::value(m);
-}
-
-/**
- * \brief returns Header<M>::pointer(m);
- */
-template<typename M>
-inline std_msgs::Header* header(M& m)
-{
-  return Header<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::pointer(m);
-}
-
-/**
- * \brief returns Header<M>::pointer(m);
- */
-template<typename M>
-inline std_msgs::Header const* header(const M& m)
-{
-  return Header<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::pointer(m);
-}
-
-/**
- * \brief returns FrameId<M>::pointer(m);
- */
-template<typename M>
-inline std::string* frameId(M& m)
-{
-  return FrameId<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::pointer(m);
-}
-
-/**
- * \brief returns FrameId<M>::pointer(m);
- */
-template<typename M>
-inline std::string const* frameId(const M& m)
-{
-  return FrameId<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::pointer(m);
-}
-
-/**
- * \brief returns TimeStamp<M>::pointer(m);
- */
-template<typename M>
-inline ros::Time* timeStamp(M& m)
-{
-  return TimeStamp<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::pointer(m);
-}
-
-/**
- * \brief returns TimeStamp<M>::pointer(m);
- */
-template<typename M>
-inline ros::Time const* timeStamp(const M& m)
-{
-  return TimeStamp<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::pointer(m);
-}
-
-/**
- * \brief returns IsSimple<M>::value;
- */
-template<typename M>
-inline bool isSimple()
-{
-  return IsSimple<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::value;
-}
-
-/**
- * \brief returns IsFixedSize<M>::value;
- */
-template<typename M>
-inline bool isFixedSize()
-{
-  return IsFixedSize<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::value;
-}
-
-/**
- * \brief returns HasHeader<M>::value;
- */
-template<typename M>
-inline bool hasHeader()
-{
-  return HasHeader<typename boost::remove_reference<typename boost::remove_const<M>::type>::type>::value;
-}
 
 } // namespace message_traits
-} // namespace ros
+} // namespace message_filters
 
 #endif // ROSLIB_MESSAGE_TRAITS_H

--- a/include/message_filters/null_types.h
+++ b/include/message_filters/null_types.h
@@ -37,10 +37,9 @@
 
 #include "connection.h"
 
-#include <boost/shared_ptr.hpp>
-#include <ros/time.h>
-
-#include <ros/message_traits.h>
+#include "message_filters/message_traits.h"
+#include <rclcpp/rclcpp.hpp>
+#include <memory>
 
 namespace message_filters
 {
@@ -48,7 +47,7 @@ namespace message_filters
 struct NullType
 {
 };
-typedef boost::shared_ptr<NullType const> NullTypeConstPtr;
+typedef std::shared_ptr<NullType const> NullTypeConstPtr;
 
 template<class M>
 struct NullFilter
@@ -60,23 +59,20 @@ struct NullFilter
   }
 
   template<typename P>
-  Connection registerCallback(const boost::function<void(P)>&)
+  Connection registerCallback(const std::function<void(P)>&)
   {
     return Connection();
   }
 };
-}
 
-namespace ros
-{
 namespace message_traits
 {
 template<>
 struct TimeStamp<message_filters::NullType>
 {
-  static ros::Time value(const message_filters::NullType&)
+  static rclcpp::Time value(const message_filters::NullType&)
   {
-    return ros::Time();
+    return rclcpp::Time();
   }
 };
 }

--- a/include/message_filters/parameter_adapter.h
+++ b/include/message_filters/parameter_adapter.h
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2010, Willow Garage, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the names of Stanford University or Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ROSCPP_PARAMETER_ADAPTER_H
+#define ROSCPP_PARAMETER_ADAPTER_H
+
+#include "message_event.h"
+#include <memory>
+#include <type_traits>
+
+namespace message_filters
+{
+
+/**
+ * \brief Generally not for outside use.  Adapts a function parameter type into the message type, event type and parameter.  Allows you to
+ * retrieve a parameter type from an event type.
+ *
+ * ParameterAdapter is generally only useful for outside use when implementing things that require message callbacks
+ * (such as the message_filters package)and you would like to support all the roscpp message parameter types
+ *
+ * The ParameterAdapter is templated on the callback parameter type (\b not the bare message type), and provides 3 things:
+ *  - Message typedef, which provides the bare message type, no const or reference qualifiers
+ *  - Event typedef, which provides the ros::MessageEvent type
+ *  - Parameter typedef, which provides the actual parameter type (may be slightly different from M)
+ *  - static getParameter(event) function, which returns a parameter type given the event
+ *  - static bool is_const informs you whether or not the parameter type is a const message
+ *
+ *  ParameterAdapter is specialized to allow callbacks of any of the forms:
+\verbatim
+void callback(const std::shared_ptr<M const>&);
+void callback(const std::shared_ptr<M>&);
+void callback(std::shared_ptr<M const>);
+void callback(std::shared_ptr<M>);
+void callback(const M&);
+void callback(M);
+void callback(const MessageEvent<M const>&);
+void callback(const MessageEvent<M>&);
+\endverbatim
+ */
+template<typename M>
+struct ParameterAdapter
+{
+  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
+  typedef MessageEvent<Message const> Event;
+  typedef M Parameter;
+  static const bool is_const = true;
+
+  static Parameter getParameter(const Event& event)
+  {
+    return *event.getMessage();
+  }
+};
+//struct message_filters::ParameterAdapter<const std::shared_ptr<const Msg>&>
+template<typename M>
+struct ParameterAdapter<const std::shared_ptr<M const>& >
+{
+  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
+  typedef MessageEvent<Message const> Event;
+  typedef const std::shared_ptr<Message const> Parameter;
+  static const bool is_const = true;
+
+  static Parameter getParameter(const Event& event)
+  {
+    return event.getMessage();
+  }
+};
+
+template<typename M>
+struct ParameterAdapter<const std::shared_ptr<M>& >
+{
+  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
+  typedef MessageEvent<Message const> Event;
+  typedef std::shared_ptr<Message> Parameter;
+  static const bool is_const = false;
+
+  static Parameter getParameter(const Event& event)
+  {
+    return MessageEvent<Message>(event).getMessage();
+  }
+};
+
+template<typename M>
+struct ParameterAdapter<const M&>
+{
+  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
+  typedef MessageEvent<Message const> Event;
+  typedef const M& Parameter;
+  static const bool is_const = true;
+
+  static Parameter getParameter(const Event& event)
+  {
+    return *event.getMessage();
+  }
+};
+
+template<typename M>
+struct ParameterAdapter<std::shared_ptr<M const> >
+{
+  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
+  typedef MessageEvent<Message const> Event;
+  typedef std::shared_ptr<Message const> Parameter;
+  static const bool is_const = true;
+
+  static Parameter getParameter(const Event& event)
+  {
+    return event.getMessage();
+  }
+};
+
+template<typename M>
+struct ParameterAdapter<std::shared_ptr<M> >
+{
+  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
+  typedef MessageEvent<Message const> Event;
+  typedef std::shared_ptr<Message> Parameter;
+  static const bool is_const = false;
+
+  static Parameter getParameter(const Event& event)
+  {
+    return MessageEvent<Message>(event).getMessage();
+  }
+};
+
+template<typename M>
+struct ParameterAdapter<const MessageEvent<M const>& >
+{
+  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
+  typedef MessageEvent<Message const> Event;
+  typedef const MessageEvent<Message const>& Parameter;
+  static const bool is_const = true;
+
+  static Parameter getParameter(const Event& event)
+  {
+    return event;
+  }
+};
+
+template<typename M>
+struct ParameterAdapter<const MessageEvent<M>& >
+{
+  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
+  typedef MessageEvent<Message const> Event;
+  typedef MessageEvent<Message> Parameter;
+  static const bool is_const = false;
+
+  static Parameter getParameter(const Event& event)
+  {
+    return MessageEvent<Message>(event);
+  }
+};
+
+}
+
+#endif // ROSCPP_PARAMETER_ADAPTER_H

--- a/include/message_filters/parameter_adapter.h
+++ b/include/message_filters/parameter_adapter.h
@@ -25,8 +25,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef ROSCPP_PARAMETER_ADAPTER_H
-#define ROSCPP_PARAMETER_ADAPTER_H
+#ifndef MESSAGE_FILTERS_PARAMETER_ADAPTER_H
+#define MESSAGE_FILTERS_PARAMETER_ADAPTER_H
 
 #include "message_event.h"
 #include <memory>
@@ -40,11 +40,11 @@ namespace message_filters
  * retrieve a parameter type from an event type.
  *
  * ParameterAdapter is generally only useful for outside use when implementing things that require message callbacks
- * (such as the message_filters package)and you would like to support all the roscpp message parameter types
+ * (such as the message_filters package)and you would like to support all the rclcpp message parameter types
  *
  * The ParameterAdapter is templated on the callback parameter type (\b not the bare message type), and provides 3 things:
  *  - Message typedef, which provides the bare message type, no const or reference qualifiers
- *  - Event typedef, which provides the ros::MessageEvent type
+ *  - Event typedef, which provides the message_filters::MessageEvent type
  *  - Parameter typedef, which provides the actual parameter type (may be slightly different from M)
  *  - static getParameter(event) function, which returns a parameter type given the event
  *  - static bool is_const informs you whether or not the parameter type is a const message
@@ -175,4 +175,4 @@ struct ParameterAdapter<const MessageEvent<M>& >
 
 }
 
-#endif // ROSCPP_PARAMETER_ADAPTER_H
+#endif // MESSAGE_FILTERS_PARAMETER_ADAPTER_H

--- a/include/message_filters/parameter_adapter.h
+++ b/include/message_filters/parameter_adapter.h
@@ -28,11 +28,15 @@
 #ifndef ROSCPP_PARAMETER_ADAPTER_H
 #define ROSCPP_PARAMETER_ADAPTER_H
 
-#include "message_event.h"
-#include <memory>
-#include <type_traits>
+#include "ros/forwards.h"
+#include "ros/message_event.h"
+#include <ros/static_assert.h>
 
-namespace message_filters
+#include <boost/type_traits/add_const.hpp>
+#include <boost/type_traits/remove_const.hpp>
+#include <boost/type_traits/remove_reference.hpp>
+
+namespace ros
 {
 
 /**
@@ -51,10 +55,10 @@ namespace message_filters
  *
  *  ParameterAdapter is specialized to allow callbacks of any of the forms:
 \verbatim
-void callback(const std::shared_ptr<M const>&);
-void callback(const std::shared_ptr<M>&);
-void callback(std::shared_ptr<M const>);
-void callback(std::shared_ptr<M>);
+void callback(const boost::shared_ptr<M const>&);
+void callback(const boost::shared_ptr<M>&);
+void callback(boost::shared_ptr<M const>);
+void callback(boost::shared_ptr<M>);
 void callback(const M&);
 void callback(M);
 void callback(const MessageEvent<M const>&);
@@ -64,8 +68,8 @@ void callback(const MessageEvent<M>&);
 template<typename M>
 struct ParameterAdapter
 {
-  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
-  typedef MessageEvent<Message const> Event;
+  typedef typename boost::remove_reference<typename boost::remove_const<M>::type>::type Message;
+  typedef ros::MessageEvent<Message const> Event;
   typedef M Parameter;
   static const bool is_const = true;
 
@@ -74,13 +78,13 @@ struct ParameterAdapter
     return *event.getMessage();
   }
 };
-//struct message_filters::ParameterAdapter<const std::shared_ptr<const Msg>&>
+
 template<typename M>
-struct ParameterAdapter<const std::shared_ptr<M const>& >
+struct ParameterAdapter<const boost::shared_ptr<M const>& >
 {
-  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
-  typedef MessageEvent<Message const> Event;
-  typedef const std::shared_ptr<Message const> Parameter;
+  typedef typename boost::remove_reference<typename boost::remove_const<M>::type>::type Message;
+  typedef ros::MessageEvent<Message const> Event;
+  typedef const boost::shared_ptr<Message const> Parameter;
   static const bool is_const = true;
 
   static Parameter getParameter(const Event& event)
@@ -90,24 +94,24 @@ struct ParameterAdapter<const std::shared_ptr<M const>& >
 };
 
 template<typename M>
-struct ParameterAdapter<const std::shared_ptr<M>& >
+struct ParameterAdapter<const boost::shared_ptr<M>& >
 {
-  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
-  typedef MessageEvent<Message const> Event;
-  typedef std::shared_ptr<Message> Parameter;
+  typedef typename boost::remove_reference<typename boost::remove_const<M>::type>::type Message;
+  typedef ros::MessageEvent<Message const> Event;
+  typedef boost::shared_ptr<Message> Parameter;
   static const bool is_const = false;
 
   static Parameter getParameter(const Event& event)
   {
-    return MessageEvent<Message>(event).getMessage();
+    return ros::MessageEvent<Message>(event).getMessage();
   }
 };
 
 template<typename M>
 struct ParameterAdapter<const M&>
 {
-  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
-  typedef MessageEvent<Message const> Event;
+  typedef typename boost::remove_reference<typename boost::remove_const<M>::type>::type Message;
+  typedef ros::MessageEvent<Message const> Event;
   typedef const M& Parameter;
   static const bool is_const = true;
 
@@ -118,11 +122,11 @@ struct ParameterAdapter<const M&>
 };
 
 template<typename M>
-struct ParameterAdapter<std::shared_ptr<M const> >
+struct ParameterAdapter<boost::shared_ptr<M const> >
 {
-  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
-  typedef MessageEvent<Message const> Event;
-  typedef std::shared_ptr<Message const> Parameter;
+  typedef typename boost::remove_reference<typename boost::remove_const<M>::type>::type Message;
+  typedef ros::MessageEvent<Message const> Event;
+  typedef boost::shared_ptr<Message const> Parameter;
   static const bool is_const = true;
 
   static Parameter getParameter(const Event& event)
@@ -132,25 +136,25 @@ struct ParameterAdapter<std::shared_ptr<M const> >
 };
 
 template<typename M>
-struct ParameterAdapter<std::shared_ptr<M> >
+struct ParameterAdapter<boost::shared_ptr<M> >
 {
-  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
-  typedef MessageEvent<Message const> Event;
-  typedef std::shared_ptr<Message> Parameter;
+  typedef typename boost::remove_reference<typename boost::remove_const<M>::type>::type Message;
+  typedef ros::MessageEvent<Message const> Event;
+  typedef boost::shared_ptr<Message> Parameter;
   static const bool is_const = false;
 
   static Parameter getParameter(const Event& event)
   {
-    return MessageEvent<Message>(event).getMessage();
+    return ros::MessageEvent<Message>(event).getMessage();
   }
 };
 
 template<typename M>
-struct ParameterAdapter<const MessageEvent<M const>& >
+struct ParameterAdapter<const ros::MessageEvent<M const>& >
 {
-  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
-  typedef MessageEvent<Message const> Event;
-  typedef const MessageEvent<Message const>& Parameter;
+  typedef typename boost::remove_reference<typename boost::remove_const<M>::type>::type Message;
+  typedef ros::MessageEvent<Message const> Event;
+  typedef const ros::MessageEvent<Message const>& Parameter;
   static const bool is_const = true;
 
   static Parameter getParameter(const Event& event)
@@ -160,16 +164,16 @@ struct ParameterAdapter<const MessageEvent<M const>& >
 };
 
 template<typename M>
-struct ParameterAdapter<const MessageEvent<M>& >
+struct ParameterAdapter<const ros::MessageEvent<M>& >
 {
-  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
-  typedef MessageEvent<Message const> Event;
-  typedef MessageEvent<Message> Parameter;
+  typedef typename boost::remove_reference<typename boost::remove_const<M>::type>::type Message;
+  typedef ros::MessageEvent<Message const> Event;
+  typedef ros::MessageEvent<Message> Parameter;
   static const bool is_const = false;
 
   static Parameter getParameter(const Event& event)
   {
-    return MessageEvent<Message>(event);
+    return ros::MessageEvent<Message>(event);
   }
 };
 

--- a/include/message_filters/parameter_adapter.h
+++ b/include/message_filters/parameter_adapter.h
@@ -28,15 +28,11 @@
 #ifndef ROSCPP_PARAMETER_ADAPTER_H
 #define ROSCPP_PARAMETER_ADAPTER_H
 
-#include "ros/forwards.h"
-#include "ros/message_event.h"
-#include <ros/static_assert.h>
+#include "message_event.h"
+#include <memory>
+#include <type_traits>
 
-#include <boost/type_traits/add_const.hpp>
-#include <boost/type_traits/remove_const.hpp>
-#include <boost/type_traits/remove_reference.hpp>
-
-namespace ros
+namespace message_filters
 {
 
 /**
@@ -55,10 +51,10 @@ namespace ros
  *
  *  ParameterAdapter is specialized to allow callbacks of any of the forms:
 \verbatim
-void callback(const boost::shared_ptr<M const>&);
-void callback(const boost::shared_ptr<M>&);
-void callback(boost::shared_ptr<M const>);
-void callback(boost::shared_ptr<M>);
+void callback(const std::shared_ptr<M const>&);
+void callback(const std::shared_ptr<M>&);
+void callback(std::shared_ptr<M const>);
+void callback(std::shared_ptr<M>);
 void callback(const M&);
 void callback(M);
 void callback(const MessageEvent<M const>&);
@@ -68,8 +64,8 @@ void callback(const MessageEvent<M>&);
 template<typename M>
 struct ParameterAdapter
 {
-  typedef typename boost::remove_reference<typename boost::remove_const<M>::type>::type Message;
-  typedef ros::MessageEvent<Message const> Event;
+  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
+  typedef MessageEvent<Message const> Event;
   typedef M Parameter;
   static const bool is_const = true;
 
@@ -78,13 +74,13 @@ struct ParameterAdapter
     return *event.getMessage();
   }
 };
-
+//struct message_filters::ParameterAdapter<const std::shared_ptr<const Msg>&>
 template<typename M>
-struct ParameterAdapter<const boost::shared_ptr<M const>& >
+struct ParameterAdapter<const std::shared_ptr<M const>& >
 {
-  typedef typename boost::remove_reference<typename boost::remove_const<M>::type>::type Message;
-  typedef ros::MessageEvent<Message const> Event;
-  typedef const boost::shared_ptr<Message const> Parameter;
+  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
+  typedef MessageEvent<Message const> Event;
+  typedef const std::shared_ptr<Message const> Parameter;
   static const bool is_const = true;
 
   static Parameter getParameter(const Event& event)
@@ -94,24 +90,24 @@ struct ParameterAdapter<const boost::shared_ptr<M const>& >
 };
 
 template<typename M>
-struct ParameterAdapter<const boost::shared_ptr<M>& >
+struct ParameterAdapter<const std::shared_ptr<M>& >
 {
-  typedef typename boost::remove_reference<typename boost::remove_const<M>::type>::type Message;
-  typedef ros::MessageEvent<Message const> Event;
-  typedef boost::shared_ptr<Message> Parameter;
+  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
+  typedef MessageEvent<Message const> Event;
+  typedef std::shared_ptr<Message> Parameter;
   static const bool is_const = false;
 
   static Parameter getParameter(const Event& event)
   {
-    return ros::MessageEvent<Message>(event).getMessage();
+    return MessageEvent<Message>(event).getMessage();
   }
 };
 
 template<typename M>
 struct ParameterAdapter<const M&>
 {
-  typedef typename boost::remove_reference<typename boost::remove_const<M>::type>::type Message;
-  typedef ros::MessageEvent<Message const> Event;
+  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
+  typedef MessageEvent<Message const> Event;
   typedef const M& Parameter;
   static const bool is_const = true;
 
@@ -122,11 +118,11 @@ struct ParameterAdapter<const M&>
 };
 
 template<typename M>
-struct ParameterAdapter<boost::shared_ptr<M const> >
+struct ParameterAdapter<std::shared_ptr<M const> >
 {
-  typedef typename boost::remove_reference<typename boost::remove_const<M>::type>::type Message;
-  typedef ros::MessageEvent<Message const> Event;
-  typedef boost::shared_ptr<Message const> Parameter;
+  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
+  typedef MessageEvent<Message const> Event;
+  typedef std::shared_ptr<Message const> Parameter;
   static const bool is_const = true;
 
   static Parameter getParameter(const Event& event)
@@ -136,25 +132,25 @@ struct ParameterAdapter<boost::shared_ptr<M const> >
 };
 
 template<typename M>
-struct ParameterAdapter<boost::shared_ptr<M> >
+struct ParameterAdapter<std::shared_ptr<M> >
 {
-  typedef typename boost::remove_reference<typename boost::remove_const<M>::type>::type Message;
-  typedef ros::MessageEvent<Message const> Event;
-  typedef boost::shared_ptr<Message> Parameter;
+  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
+  typedef MessageEvent<Message const> Event;
+  typedef std::shared_ptr<Message> Parameter;
   static const bool is_const = false;
 
   static Parameter getParameter(const Event& event)
   {
-    return ros::MessageEvent<Message>(event).getMessage();
+    return MessageEvent<Message>(event).getMessage();
   }
 };
 
 template<typename M>
-struct ParameterAdapter<const ros::MessageEvent<M const>& >
+struct ParameterAdapter<const MessageEvent<M const>& >
 {
-  typedef typename boost::remove_reference<typename boost::remove_const<M>::type>::type Message;
-  typedef ros::MessageEvent<Message const> Event;
-  typedef const ros::MessageEvent<Message const>& Parameter;
+  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
+  typedef MessageEvent<Message const> Event;
+  typedef const MessageEvent<Message const>& Parameter;
   static const bool is_const = true;
 
   static Parameter getParameter(const Event& event)
@@ -164,16 +160,16 @@ struct ParameterAdapter<const ros::MessageEvent<M const>& >
 };
 
 template<typename M>
-struct ParameterAdapter<const ros::MessageEvent<M>& >
+struct ParameterAdapter<const MessageEvent<M>& >
 {
-  typedef typename boost::remove_reference<typename boost::remove_const<M>::type>::type Message;
-  typedef ros::MessageEvent<Message const> Event;
-  typedef ros::MessageEvent<Message> Parameter;
+  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
+  typedef MessageEvent<Message const> Event;
+  typedef MessageEvent<Message> Parameter;
   static const bool is_const = false;
 
   static Parameter getParameter(const Event& event)
   {
-    return ros::MessageEvent<Message>(event);
+    return MessageEvent<Message>(event);
   }
 };
 

--- a/include/message_filters/pass_through.h
+++ b/include/message_filters/pass_through.h
@@ -65,7 +65,7 @@ public:
   void connectInput(F& f)
   {
     incoming_connection_.disconnect();
-    incoming_connection_ = f.registerCallback(typename SimpleFilter<M>::EventCallback(std::bind(&PassThrough::cb, this, _1)));
+    incoming_connection_ = f.registerCallback(typename SimpleFilter<M>::EventCallback(std::bind(&PassThrough::cb, this, std::placeholders::_1)));
   }
 
   void add(const MConstPtr& msg)
@@ -90,4 +90,3 @@ private:
 } // namespace message_filters
 
 #endif // MESSAGE_FILTERS_PASSTHROUGH_H
-

--- a/include/message_filters/pass_through.h
+++ b/include/message_filters/pass_through.h
@@ -48,8 +48,8 @@ template<typename M>
 class PassThrough : public SimpleFilter<M>
 {
 public:
-  typedef boost::shared_ptr<M const> MConstPtr;
-  typedef ros::MessageEvent<M const> EventType;
+  typedef std::shared_ptr<M const> MConstPtr;
+  typedef MessageEvent<M const> EventType;
 
   PassThrough()
   {
@@ -65,7 +65,7 @@ public:
   void connectInput(F& f)
   {
     incoming_connection_.disconnect();
-    incoming_connection_ = f.registerCallback(typename SimpleFilter<M>::EventCallback(boost::bind(&PassThrough::cb, this, _1)));
+    incoming_connection_ = f.registerCallback(typename SimpleFilter<M>::EventCallback(std::bind(&PassThrough::cb, this, _1)));
   }
 
   void add(const MConstPtr& msg)

--- a/include/message_filters/signal9.h
+++ b/include/message_filters/signal9.h
@@ -36,6 +36,7 @@
 #define MESSAGE_FILTERS_SIGNAL9_H
 
 
+#include <functional>
 #include <mutex>
 #include "connection.h"
 #include "null_types.h"
@@ -44,7 +45,7 @@
 
 namespace message_filters
 {
-using namespace std::placeholders;
+
 template<typename M0, typename M1, typename M2, typename M3, typename M4, typename M5, typename M6, typename M7, typename M8>
 class CallbackHelper9
 {
@@ -163,6 +164,7 @@ public:
   typedef std::shared_ptr<M8 const> M8ConstPtr;
   typedef const std::shared_ptr<NullType const>& NullP;
 
+
   template<typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6, typename P7, typename P8>
   Connection addCallback(const std::function<void(P0, P1, P2, P3, P4, P5, P6, P7, P8)>& callback)
   {
@@ -176,96 +178,112 @@ public:
   template<typename P0, typename P1>
   Connection addCallback(void(*callback)(P0, P1))
   {
+    using namespace std::placeholders;
     return addCallback(std::function<void(P0, P1, NullP, NullP, NullP, NullP, NullP, NullP, NullP)>(std::bind(callback, _1, _2)));
   }
 
   template<typename P0, typename P1, typename P2>
   Connection addCallback(void(*callback)(P0, P1, P2))
   {
+    using namespace std::placeholders;
     return addCallback(std::function<void(P0, P1, P2, NullP, NullP, NullP, NullP, NullP, NullP)>(std::bind(callback, _1, _2, _3)));
   }
 
   template<typename P0, typename P1, typename P2, typename P3>
   Connection addCallback(void(*callback)(P0, P1, P2, P3))
   {
+    using namespace std::placeholders;
     return addCallback(std::function<void(P0, P1, P2, P3, NullP, NullP, NullP, NullP, NullP)>(std::bind(callback, _1, _2, _3, _4)));
   }
 
   template<typename P0, typename P1, typename P2, typename P3, typename P4>
   Connection addCallback(void(*callback)(P0, P1, P2, P3, P4))
   {
+    using namespace std::placeholders;
     return addCallback(std::function<void(P0, P1, P2, P3, P4, NullP, NullP, NullP, NullP)>(std::bind(callback, _1, _2, _3, _4, _5)));
   }
 
   template<typename P0, typename P1, typename P2, typename P3, typename P4, typename P5>
   Connection addCallback(void(*callback)(P0, P1, P2, P3, P4, P5))
   {
+    using namespace std::placeholders;
     return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, NullP, NullP, NullP)>(std::bind(callback, _1, _2, _3, _4, _5, _6)));
   }
 
   template<typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6>
   Connection addCallback(void(*callback)(P0, P1, P2, P3, P4, P5, P6))
   {
+    using namespace std::placeholders;
     return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, P6, NullP, NullP)>(std::bind(callback, _1, _2, _3, _4, _5, _6, _7)));
   }
 
   template<typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6, typename P7>
   Connection addCallback(void(*callback)(P0, P1, P2, P3, P4, P5, P6, P7))
   {
+    using namespace std::placeholders;
     return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, P6, P7, NullP)>(std::bind(callback, _1, _2, _3, _4, _5, _6, _7, _8)));
   }
 
   template<typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6, typename P7, typename P8>
   Connection addCallback(void(*callback)(P0, P1, P2, P3, P4, P5, P6, P7, P8))
   {
+    using namespace std::placeholders;
     return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, P6, P7, P8)>(std::bind(callback, _1, _2, _3, _4, _5, _6, _7, _8, _9)));
   }
 
   template<typename T, typename P0, typename P1>
   Connection addCallback(void(T::*callback)(P0, P1), T* t)
   {
+    using namespace std::placeholders;
     return addCallback(std::function<void(P0, P1, NullP, NullP, NullP, NullP, NullP, NullP, NullP)>(std::bind(callback, t, _1, _2)));
   }
 
   template<typename T, typename P0, typename P1, typename P2>
   Connection addCallback(void(T::*callback)(P0, P1, P2), T* t)
   {
+    using namespace std::placeholders;
     return addCallback(std::function<void(P0, P1, P2, NullP, NullP, NullP, NullP, NullP, NullP)>(std::bind(callback, t, _1, _2, _3)));
   }
 
   template<typename T, typename P0, typename P1, typename P2, typename P3>
   Connection addCallback(void(T::*callback)(P0, P1, P2, P3), T* t)
   {
+    using namespace std::placeholders;
     return addCallback(std::function<void(P0, P1, P2, P3, NullP, NullP, NullP, NullP, NullP)>(std::bind(callback, t, _1, _2, _3, _4)));
   }
 
   template<typename T, typename P0, typename P1, typename P2, typename P3, typename P4>
   Connection addCallback(void(T::*callback)(P0, P1, P2, P3, P4), T* t)
   {
+    using namespace std::placeholders;
     return addCallback(std::function<void(P0, P1, P2, P3, P4, NullP, NullP, NullP, NullP)>(std::bind(callback, t, _1, _2, _3, _4, _5)));
   }
 
   template<typename T, typename P0, typename P1, typename P2, typename P3, typename P4, typename P5>
   Connection addCallback(void(T::*callback)(P0, P1, P2, P3, P4, P5), T* t)
   {
+    using namespace std::placeholders;
     return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, NullP, NullP, NullP)>(std::bind(callback, t, _1, _2, _3, _4, _5, _6)));
   }
 
   template<typename T, typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6>
   Connection addCallback(void(T::*callback)(P0, P1, P2, P3, P4, P5, P6), T* t)
   {
+    using namespace std::placeholders;
     return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, P6, NullP, NullP)>(std::bind(callback, t, _1, _2, _3, _4, _5, _6, _7)));
   }
 
   template<typename T, typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6, typename P7>
   Connection addCallback(void(T::*callback)(P0, P1, P2, P3, P4, P5, P6, P7), T* t)
   {
+    using namespace std::placeholders;
     return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, P6, P7, NullP)>(std::bind(callback, t, _1, _2, _3, _4, _5, _6, _7, _8)));
   }
 
   template<typename C>
   Connection addCallback( C& callback)
   {
+    using namespace std::placeholders;
     return addCallback<const M0ConstPtr&,
                      const M1ConstPtr&,
                      const M2ConstPtr&,
@@ -309,5 +327,3 @@ private:
 } // message_filters
 
 #endif // MESSAGE_FILTERS_SIGNAL9_H
-
-

--- a/include/message_filters/signal9.h
+++ b/include/message_filters/signal9.h
@@ -35,40 +35,36 @@
 #ifndef MESSAGE_FILTERS_SIGNAL9_H
 #define MESSAGE_FILTERS_SIGNAL9_H
 
-#include <boost/noncopyable.hpp>
 
+#include <mutex>
 #include "connection.h"
 #include "null_types.h"
-#include <ros/message_event.h>
-#include <ros/parameter_adapter.h>
-
-#include <boost/bind.hpp>
-#include <boost/thread/mutex.hpp>
+#include "message_event.h"
+#include "parameter_adapter.h"
 
 namespace message_filters
 {
-using ros::ParameterAdapter;
-
+using namespace std::placeholders;
 template<typename M0, typename M1, typename M2, typename M3, typename M4, typename M5, typename M6, typename M7, typename M8>
 class CallbackHelper9
 {
 public:
-  typedef ros::MessageEvent<M0 const> M0Event;
-  typedef ros::MessageEvent<M1 const> M1Event;
-  typedef ros::MessageEvent<M2 const> M2Event;
-  typedef ros::MessageEvent<M3 const> M3Event;
-  typedef ros::MessageEvent<M4 const> M4Event;
-  typedef ros::MessageEvent<M5 const> M5Event;
-  typedef ros::MessageEvent<M6 const> M6Event;
-  typedef ros::MessageEvent<M7 const> M7Event;
-  typedef ros::MessageEvent<M8 const> M8Event;
+  typedef MessageEvent<M0 const> M0Event;
+  typedef MessageEvent<M1 const> M1Event;
+  typedef MessageEvent<M2 const> M2Event;
+  typedef MessageEvent<M3 const> M3Event;
+  typedef MessageEvent<M4 const> M4Event;
+  typedef MessageEvent<M5 const> M5Event;
+  typedef MessageEvent<M6 const> M6Event;
+  typedef MessageEvent<M7 const> M7Event;
+  typedef MessageEvent<M8 const> M8Event;
 
   virtual ~CallbackHelper9() {}
 
   virtual void call(bool nonconst_force_copy, const M0Event& e0, const M1Event& e1, const M2Event& e2, const M3Event& e3,
                     const M4Event& e4, const M5Event& e5, const M6Event& e6, const M7Event& e7, const M8Event& e8) = 0;
 
-  typedef boost::shared_ptr<CallbackHelper9> Ptr;
+  typedef std::shared_ptr<CallbackHelper9> Ptr;
 };
 
 template<typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6, typename P7, typename P8>
@@ -104,7 +100,7 @@ private:
   typedef typename A8::Event M8Event;
 
 public:
-  typedef boost::function<void(typename A0::Parameter, typename A1::Parameter, typename A2::Parameter,
+  typedef std::function<void(typename A0::Parameter, typename A1::Parameter, typename A2::Parameter,
                                typename A3::Parameter, typename A4::Parameter, typename A5::Parameter,
                                typename A6::Parameter, typename A7::Parameter, typename A8::Parameter)> Callback;
 
@@ -143,128 +139,128 @@ private:
 template<typename M0, typename M1, typename M2, typename M3, typename M4, typename M5, typename M6, typename M7, typename M8>
 class Signal9
 {
-  typedef boost::shared_ptr<CallbackHelper9<M0, M1, M2, M3, M4, M5, M6, M7, M8> > CallbackHelper9Ptr;
+  typedef std::shared_ptr<CallbackHelper9<M0, M1, M2, M3, M4, M5, M6, M7, M8> > CallbackHelper9Ptr;
   typedef std::vector<CallbackHelper9Ptr> V_CallbackHelper9;
 
 public:
-  typedef ros::MessageEvent<M0 const> M0Event;
-  typedef ros::MessageEvent<M1 const> M1Event;
-  typedef ros::MessageEvent<M2 const> M2Event;
-  typedef ros::MessageEvent<M3 const> M3Event;
-  typedef ros::MessageEvent<M4 const> M4Event;
-  typedef ros::MessageEvent<M5 const> M5Event;
-  typedef ros::MessageEvent<M6 const> M6Event;
-  typedef ros::MessageEvent<M7 const> M7Event;
-  typedef ros::MessageEvent<M8 const> M8Event;
-  typedef boost::shared_ptr<M0 const> M0ConstPtr;
-  typedef boost::shared_ptr<M1 const> M1ConstPtr;
-  typedef boost::shared_ptr<M2 const> M2ConstPtr;
-  typedef boost::shared_ptr<M3 const> M3ConstPtr;
-  typedef boost::shared_ptr<M4 const> M4ConstPtr;
-  typedef boost::shared_ptr<M5 const> M5ConstPtr;
-  typedef boost::shared_ptr<M6 const> M6ConstPtr;
-  typedef boost::shared_ptr<M7 const> M7ConstPtr;
-  typedef boost::shared_ptr<M8 const> M8ConstPtr;
-  typedef const boost::shared_ptr<NullType const>& NullP;
+  typedef MessageEvent<M0 const> M0Event;
+  typedef MessageEvent<M1 const> M1Event;
+  typedef MessageEvent<M2 const> M2Event;
+  typedef MessageEvent<M3 const> M3Event;
+  typedef MessageEvent<M4 const> M4Event;
+  typedef MessageEvent<M5 const> M5Event;
+  typedef MessageEvent<M6 const> M6Event;
+  typedef MessageEvent<M7 const> M7Event;
+  typedef MessageEvent<M8 const> M8Event;
+  typedef std::shared_ptr<M0 const> M0ConstPtr;
+  typedef std::shared_ptr<M1 const> M1ConstPtr;
+  typedef std::shared_ptr<M2 const> M2ConstPtr;
+  typedef std::shared_ptr<M3 const> M3ConstPtr;
+  typedef std::shared_ptr<M4 const> M4ConstPtr;
+  typedef std::shared_ptr<M5 const> M5ConstPtr;
+  typedef std::shared_ptr<M6 const> M6ConstPtr;
+  typedef std::shared_ptr<M7 const> M7ConstPtr;
+  typedef std::shared_ptr<M8 const> M8ConstPtr;
+  typedef const std::shared_ptr<NullType const>& NullP;
 
   template<typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6, typename P7, typename P8>
-  Connection addCallback(const boost::function<void(P0, P1, P2, P3, P4, P5, P6, P7, P8)>& callback)
+  Connection addCallback(const std::function<void(P0, P1, P2, P3, P4, P5, P6, P7, P8)>& callback)
   {
     CallbackHelper9T<P0, P1, P2, P3, P4, P5, P6, P7, P8>* helper = new CallbackHelper9T<P0, P1, P2, P3, P4, P5, P6, P7, P8>(callback);
 
-    boost::mutex::scoped_lock lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     callbacks_.push_back(CallbackHelper9Ptr(helper));
-    return Connection(boost::bind(&Signal9::removeCallback, this, callbacks_.back()));
+    return Connection(std::bind(&Signal9::removeCallback, this, callbacks_.back()));
   }
 
   template<typename P0, typename P1>
   Connection addCallback(void(*callback)(P0, P1))
   {
-    return addCallback(boost::function<void(P0, P1, NullP, NullP, NullP, NullP, NullP, NullP, NullP)>(boost::bind(callback, _1, _2)));
+    return addCallback(std::function<void(P0, P1, NullP, NullP, NullP, NullP, NullP, NullP, NullP)>(std::bind(callback, _1, _2)));
   }
 
   template<typename P0, typename P1, typename P2>
   Connection addCallback(void(*callback)(P0, P1, P2))
   {
-    return addCallback(boost::function<void(P0, P1, P2, NullP, NullP, NullP, NullP, NullP, NullP)>(boost::bind(callback, _1, _2, _3)));
+    return addCallback(std::function<void(P0, P1, P2, NullP, NullP, NullP, NullP, NullP, NullP)>(std::bind(callback, _1, _2, _3)));
   }
 
   template<typename P0, typename P1, typename P2, typename P3>
   Connection addCallback(void(*callback)(P0, P1, P2, P3))
   {
-    return addCallback(boost::function<void(P0, P1, P2, P3, NullP, NullP, NullP, NullP, NullP)>(boost::bind(callback, _1, _2, _3, _4)));
+    return addCallback(std::function<void(P0, P1, P2, P3, NullP, NullP, NullP, NullP, NullP)>(std::bind(callback, _1, _2, _3, _4)));
   }
 
   template<typename P0, typename P1, typename P2, typename P3, typename P4>
   Connection addCallback(void(*callback)(P0, P1, P2, P3, P4))
   {
-    return addCallback(boost::function<void(P0, P1, P2, P3, P4, NullP, NullP, NullP, NullP)>(boost::bind(callback, _1, _2, _3, _4, _5)));
+    return addCallback(std::function<void(P0, P1, P2, P3, P4, NullP, NullP, NullP, NullP)>(std::bind(callback, _1, _2, _3, _4, _5)));
   }
 
   template<typename P0, typename P1, typename P2, typename P3, typename P4, typename P5>
   Connection addCallback(void(*callback)(P0, P1, P2, P3, P4, P5))
   {
-    return addCallback(boost::function<void(P0, P1, P2, P3, P4, P5, NullP, NullP, NullP)>(boost::bind(callback, _1, _2, _3, _4, _5, _6)));
+    return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, NullP, NullP, NullP)>(std::bind(callback, _1, _2, _3, _4, _5, _6)));
   }
 
   template<typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6>
   Connection addCallback(void(*callback)(P0, P1, P2, P3, P4, P5, P6))
   {
-    return addCallback(boost::function<void(P0, P1, P2, P3, P4, P5, P6, NullP, NullP)>(boost::bind(callback, _1, _2, _3, _4, _5, _6, _7)));
+    return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, P6, NullP, NullP)>(std::bind(callback, _1, _2, _3, _4, _5, _6, _7)));
   }
 
   template<typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6, typename P7>
   Connection addCallback(void(*callback)(P0, P1, P2, P3, P4, P5, P6, P7))
   {
-    return addCallback(boost::function<void(P0, P1, P2, P3, P4, P5, P6, P7, NullP)>(boost::bind(callback, _1, _2, _3, _4, _5, _6, _7, _8)));
+    return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, P6, P7, NullP)>(std::bind(callback, _1, _2, _3, _4, _5, _6, _7, _8)));
   }
 
   template<typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6, typename P7, typename P8>
   Connection addCallback(void(*callback)(P0, P1, P2, P3, P4, P5, P6, P7, P8))
   {
-    return addCallback(boost::function<void(P0, P1, P2, P3, P4, P5, P6, P7, P8)>(boost::bind(callback, _1, _2, _3, _4, _5, _6, _7, _8, _9)));
+    return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, P6, P7, P8)>(std::bind(callback, _1, _2, _3, _4, _5, _6, _7, _8, _9)));
   }
 
   template<typename T, typename P0, typename P1>
   Connection addCallback(void(T::*callback)(P0, P1), T* t)
   {
-    return addCallback(boost::function<void(P0, P1, NullP, NullP, NullP, NullP, NullP, NullP, NullP)>(boost::bind(callback, t, _1, _2)));
+    return addCallback(std::function<void(P0, P1, NullP, NullP, NullP, NullP, NullP, NullP, NullP)>(std::bind(callback, t, _1, _2)));
   }
 
   template<typename T, typename P0, typename P1, typename P2>
   Connection addCallback(void(T::*callback)(P0, P1, P2), T* t)
   {
-    return addCallback(boost::function<void(P0, P1, P2, NullP, NullP, NullP, NullP, NullP, NullP)>(boost::bind(callback, t, _1, _2, _3)));
+    return addCallback(std::function<void(P0, P1, P2, NullP, NullP, NullP, NullP, NullP, NullP)>(std::bind(callback, t, _1, _2, _3)));
   }
 
   template<typename T, typename P0, typename P1, typename P2, typename P3>
   Connection addCallback(void(T::*callback)(P0, P1, P2, P3), T* t)
   {
-    return addCallback(boost::function<void(P0, P1, P2, P3, NullP, NullP, NullP, NullP, NullP)>(boost::bind(callback, t, _1, _2, _3, _4)));
+    return addCallback(std::function<void(P0, P1, P2, P3, NullP, NullP, NullP, NullP, NullP)>(std::bind(callback, t, _1, _2, _3, _4)));
   }
 
   template<typename T, typename P0, typename P1, typename P2, typename P3, typename P4>
   Connection addCallback(void(T::*callback)(P0, P1, P2, P3, P4), T* t)
   {
-    return addCallback(boost::function<void(P0, P1, P2, P3, P4, NullP, NullP, NullP, NullP)>(boost::bind(callback, t, _1, _2, _3, _4, _5)));
+    return addCallback(std::function<void(P0, P1, P2, P3, P4, NullP, NullP, NullP, NullP)>(std::bind(callback, t, _1, _2, _3, _4, _5)));
   }
 
   template<typename T, typename P0, typename P1, typename P2, typename P3, typename P4, typename P5>
   Connection addCallback(void(T::*callback)(P0, P1, P2, P3, P4, P5), T* t)
   {
-    return addCallback(boost::function<void(P0, P1, P2, P3, P4, P5, NullP, NullP, NullP)>(boost::bind(callback, t, _1, _2, _3, _4, _5, _6)));
+    return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, NullP, NullP, NullP)>(std::bind(callback, t, _1, _2, _3, _4, _5, _6)));
   }
 
   template<typename T, typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6>
   Connection addCallback(void(T::*callback)(P0, P1, P2, P3, P4, P5, P6), T* t)
   {
-    return addCallback(boost::function<void(P0, P1, P2, P3, P4, P5, P6, NullP, NullP)>(boost::bind(callback, t, _1, _2, _3, _4, _5, _6, _7)));
+    return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, P6, NullP, NullP)>(std::bind(callback, t, _1, _2, _3, _4, _5, _6, _7)));
   }
 
   template<typename T, typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6, typename P7>
   Connection addCallback(void(T::*callback)(P0, P1, P2, P3, P4, P5, P6, P7), T* t)
   {
-    return addCallback(boost::function<void(P0, P1, P2, P3, P4, P5, P6, P7, NullP)>(boost::bind(callback, t, _1, _2, _3, _4, _5, _6, _7, _8)));
+    return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, P6, P7, NullP)>(std::bind(callback, t, _1, _2, _3, _4, _5, _6, _7, _8)));
   }
 
   template<typename C>
@@ -278,12 +274,12 @@ public:
                      const M5ConstPtr&,
                      const M6ConstPtr&,
                      const M7ConstPtr&,
-                     const M8ConstPtr&>(boost::bind(callback, _1, _2, _3, _4, _5, _6, _7, _8, _9));
+                     const M8ConstPtr&>(std::bind(callback, _1, _2, _3, _4, _5, _6, _7, _8, _9));
   }
 
   void removeCallback(const CallbackHelper9Ptr& helper)
   {
-    boost::mutex::scoped_lock lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     typename V_CallbackHelper9::iterator it = std::find(callbacks_.begin(), callbacks_.end(), helper);
     if (it != callbacks_.end())
     {
@@ -294,7 +290,7 @@ public:
   void call(const M0Event& e0, const M1Event& e1, const M2Event& e2, const M3Event& e3, const M4Event& e4,
             const M5Event& e5, const M6Event& e6, const M7Event& e7, const M8Event& e8)
   {
-    boost::mutex::scoped_lock lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     bool nonconst_force_copy = callbacks_.size() > 1;
     typename V_CallbackHelper9::iterator it = callbacks_.begin();
     typename V_CallbackHelper9::iterator end = callbacks_.end();
@@ -306,7 +302,7 @@ public:
   }
 
 private:
-  boost::mutex mutex_;
+  std::mutex mutex_;
   V_CallbackHelper9 callbacks_;
 };
 

--- a/include/message_filters/simple_filter.h
+++ b/include/message_filters/simple_filter.h
@@ -43,7 +43,7 @@
 
 namespace message_filters
 {
-using namespace std::placeholders;
+
 /**
  * \brief Convenience base-class for simple filters which output a single message
  *
@@ -88,7 +88,7 @@ public:
   template<typename P>
   Connection registerCallback(void(*callback)(P))
   {
-    typename CallbackHelper1<M>::Ptr helper = signal_.template addCallback<P>(std::bind(callback, _1));
+    typename CallbackHelper1<M>::Ptr helper = signal_.template addCallback<P>(std::bind(callback, std::placeholders::_1));
     return Connection(std::bind(&Signal::removeCallback, &signal_, helper));
   }
 
@@ -99,7 +99,7 @@ public:
   template<typename T, typename P>
   Connection registerCallback(void(T::*callback)(P), T* t)
   {
-    typename CallbackHelper1<M>::Ptr helper = signal_.template addCallback<P>(std::bind(callback, t, _1));
+    typename CallbackHelper1<M>::Ptr helper = signal_.template addCallback<P>(std::bind(callback, t, std::placeholders::_1));
     return Connection(std::bind(&Signal::removeCallback, &signal_, helper));
   }
 
@@ -142,4 +142,3 @@ private:
 }
 
 #endif
-

--- a/include/message_filters/simple_filter.h
+++ b/include/message_filters/simple_filter.h
@@ -34,21 +34,16 @@
 
 #ifndef MESSAGE_FILTERS_SIMPLE_FILTER_H
 #define MESSAGE_FILTERS_SIMPLE_FILTER_H
-
-#include <boost/noncopyable.hpp>
-
+#include <functional>
+#include <memory>
 #include "connection.h"
 #include "signal1.h"
-#include <ros/message_event.h>
-#include <ros/subscription_callback_helper.h>
-
-#include <boost/bind.hpp>
-
+#include "message_event.h"
 #include <string>
 
 namespace message_filters
 {
-
+using namespace std::placeholders;
 /**
  * \brief Convenience base-class for simple filters which output a single message
  *
@@ -57,13 +52,13 @@ namespace message_filters
  * purposes.
  */
 template<class M>
-class SimpleFilter : public boost::noncopyable
+class SimpleFilter : public noncopyable
 {
 public:
-  typedef boost::shared_ptr<M const> MConstPtr;
-  typedef boost::function<void(const MConstPtr&)> Callback;
-  typedef ros::MessageEvent<M const> EventType;
-  typedef boost::function<void(const EventType&)> EventCallback;
+  typedef std::shared_ptr<M const> MConstPtr;
+  typedef std::function<void(const MConstPtr&)> Callback;
+  typedef MessageEvent<M const> EventType;
+  typedef std::function<void(const EventType&)> EventCallback;
 
   /**
    * \brief Register a callback to be called when this filter has passed
@@ -73,7 +68,7 @@ public:
   Connection registerCallback(const C& callback)
   {
     typename CallbackHelper1<M>::Ptr helper = signal_.addCallback(Callback(callback));
-    return Connection(boost::bind(&Signal::removeCallback, &signal_, helper));
+    return Connection(std::bind(&Signal::removeCallback, &signal_, helper));
   }
 
   /**
@@ -81,9 +76,9 @@ public:
    * \param callback The callback to call
    */
   template<typename P>
-  Connection registerCallback(const boost::function<void(P)>& callback)
+  Connection registerCallback(const std::function<void(P)>& callback)
   {
-    return Connection(boost::bind(&Signal::removeCallback, &signal_, signal_.addCallback(callback)));
+    return Connection(std::bind(&Signal::removeCallback, &signal_, signal_.addCallback(callback)));
   }
 
   /**
@@ -93,8 +88,8 @@ public:
   template<typename P>
   Connection registerCallback(void(*callback)(P))
   {
-    typename CallbackHelper1<M>::Ptr helper = signal_.template addCallback<P>(boost::bind(callback, _1));
-    return Connection(boost::bind(&Signal::removeCallback, &signal_, helper));
+    typename CallbackHelper1<M>::Ptr helper = signal_.template addCallback<P>(std::bind(callback, _1));
+    return Connection(std::bind(&Signal::removeCallback, &signal_, helper));
   }
 
   /**
@@ -104,8 +99,8 @@ public:
   template<typename T, typename P>
   Connection registerCallback(void(T::*callback)(P), T* t)
   {
-    typename CallbackHelper1<M>::Ptr helper = signal_.template addCallback<P>(boost::bind(callback, t, _1));
-    return Connection(boost::bind(&Signal::removeCallback, &signal_, helper));
+    typename CallbackHelper1<M>::Ptr helper = signal_.template addCallback<P>(std::bind(callback, t, _1));
+    return Connection(std::bind(&Signal::removeCallback, &signal_, helper));
   }
 
   /**
@@ -123,7 +118,7 @@ protected:
    */
   void signalMessage(const MConstPtr& msg)
   {
-    ros::MessageEvent<M const> event(msg);
+    MessageEvent<M const> event(msg);
 
     signal_.call(event);
   }
@@ -131,7 +126,7 @@ protected:
   /**
    * \brief Call all registered callbacks, passing them the specified message
    */
-  void signalMessage(const ros::MessageEvent<M const>& event)
+  void signalMessage(const MessageEvent<M const>& event)
   {
     signal_.call(event);
   }

--- a/include/message_filters/subscriber.h
+++ b/include/message_filters/subscriber.h
@@ -52,13 +52,11 @@ public:
    *
    * If this Subscriber is already subscribed to a topic, this function will first unsubscribe.
    *
-   * \param nh The ros::NodeHandle to use to subscribe.
+   * \param node The rclcpp::Node::ShardPtr to use to subscribe.
    * \param topic The topic to subscribe to.
-   * \param queue_size The subscription queue size
-   * \param transport_hints The transport hints to pass along
-   * \param callback_queue The callback queue to pass along
+   * \param qos (optional) The rmw qos profile to use to subscribe
    */
-  virtual void subscribe(rclcpp::Node* nh, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default) = 0;
+  virtual void subscribe(rclcpp::Node::SharedPtr node, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default) = 0;
   /**
    * \brief Re-subscribe to a topic.  Only works if this subscriber has previously been subscribed to a topic.
    */
@@ -98,17 +96,15 @@ public:
   /**
    * \brief Constructor
    *
-   * See the ros::NodeHandle::subscribe() variants for more information on the parameters
+   * See the rclcpp::Node::subscribe() variants for more information on the parameters
    *
-   * \param nh The ros::NodeHandle to use to subscribe.
+   * \param node The rclcpp::Node::SharedPtr to use to subscribe.
    * \param topic The topic to subscribe to.
-   * \param queue_size The subscription queue size
-   * \param transport_hints The transport hints to pass along
-   * \param callback_queue The callback queue to pass along
+   * \param qos (optional) The rmw qos profile to use to subscribe
    */
-  Subscriber(rclcpp::Node* nh, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default)
+  Subscriber(rclcpp::Node::SharedPtr node, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default)
   {
-    subscribe(nh, topic, qos);
+    subscribe(node, topic, qos);
   }
 
   /**
@@ -128,13 +124,11 @@ public:
    *
    * If this Subscriber is already subscribed to a topic, this function will first unsubscribe.
    *
-   * \param nh The ros::NodeHandle to use to subscribe.
+   * \param node The rclcpp::Node::SharedPtr to use to subscribe.
    * \param topic The topic to subscribe to.
-   * \param queue_size The subscription queue size
-   * \param transport_hints The transport hints to pass along
-   * \param callback_queue The callback queue to pass along
+   * \param qos (optional) The rmw qos profile to use to subscribe
    */
-  void subscribe(rclcpp::Node* nh, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default)
+  void subscribe(rclcpp::Node::SharedPtr node, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default)
   {
     unsubscribe();
 
@@ -142,11 +136,11 @@ public:
     {
       topic_ = topic;
       qos_ = qos;
-      sub_ = nh->create_subscription<M>(topic,
+      sub_ = node->create_subscription<M>(topic,
                [this](std::shared_ptr<M const> msg) {
                  this->cb(EventType(msg));
                }, qos);
-      nh_ = nh;
+      node_ = node;
     }
   }
 
@@ -159,7 +153,7 @@ public:
 
     if (!topic_.empty())
     {
-      subscribe(nh_, topic_, qos_);
+      subscribe(node_, topic_, qos_);
     }
   }
 
@@ -206,7 +200,7 @@ private:
   }
 
   typename rclcpp::Subscription<M>::SharedPtr sub_;
-  rclcpp::Node* nh_;
+  rclcpp::Node::SharedPtr node_;
   std::string topic_;
   rmw_qos_profile_t qos_;
 };

--- a/include/message_filters/subscriber.h
+++ b/include/message_filters/subscriber.h
@@ -35,9 +35,7 @@
 #ifndef MESSAGE_FILTERS_SUBSCRIBER_H
 #define MESSAGE_FILTERS_SUBSCRIBER_H
 
-#include <ros/ros.h>
-
-#include <boost/thread/mutex.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 #include "connection.h"
 #include "simple_filter.h"
@@ -60,7 +58,7 @@ public:
    * \param transport_hints The transport hints to pass along
    * \param callback_queue The callback queue to pass along
    */
-  virtual void subscribe(ros::NodeHandle& nh, const std::string& topic, uint32_t queue_size, const ros::TransportHints& transport_hints = ros::TransportHints(), ros::CallbackQueueInterface* callback_queue = 0) = 0;
+  virtual void subscribe(rclcpp::Node* nh, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default) = 0;
   /**
    * \brief Re-subscribe to a topic.  Only works if this subscriber has previously been subscribed to a topic.
    */
@@ -70,7 +68,7 @@ public:
    */
   virtual void unsubscribe() = 0;
 };
-typedef boost::shared_ptr<SubscriberBase> SubscriberBasePtr;
+typedef std::shared_ptr<SubscriberBase> SubscriberBasePtr;
 
 /**
  * \brief ROS subscription filter.
@@ -88,15 +86,14 @@ typedef boost::shared_ptr<SubscriberBase> SubscriberBasePtr;
  *
  * The output connection for the Subscriber object is the same signature as for roscpp subscription callbacks, ie.
 \verbatim
-void callback(const boost::shared_ptr<M const>&);
+void callback(const std::shared_ptr<M const>&);
 \endverbatim
  */
 template<class M>
 class Subscriber : public SubscriberBase, public SimpleFilter<M>
 {
 public:
-  typedef boost::shared_ptr<M const> MConstPtr;
-  typedef ros::MessageEvent<M const> EventType;
+  typedef MessageEvent<M const> EventType;
 
   /**
    * \brief Constructor
@@ -109,9 +106,9 @@ public:
    * \param transport_hints The transport hints to pass along
    * \param callback_queue The callback queue to pass along
    */
-  Subscriber(ros::NodeHandle& nh, const std::string& topic, uint32_t queue_size, const ros::TransportHints& transport_hints = ros::TransportHints(), ros::CallbackQueueInterface* callback_queue = 0)
+  Subscriber(rclcpp::Node* nh, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default)
   {
-    subscribe(nh, topic, queue_size, transport_hints, callback_queue);
+    subscribe(nh, topic, qos);
   }
 
   /**
@@ -137,16 +134,18 @@ public:
    * \param transport_hints The transport hints to pass along
    * \param callback_queue The callback queue to pass along
    */
-  void subscribe(ros::NodeHandle& nh, const std::string& topic, uint32_t queue_size, const ros::TransportHints& transport_hints = ros::TransportHints(), ros::CallbackQueueInterface* callback_queue = 0)
+  void subscribe(rclcpp::Node* nh, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default)
   {
     unsubscribe();
 
     if (!topic.empty())
     {
-      ops_.template initByFullCallbackType<const EventType&>(topic, queue_size, boost::bind(&Subscriber<M>::cb, this, _1));
-      ops_.callback_queue = callback_queue;
-      ops_.transport_hints = transport_hints;
-      sub_ = nh.subscribe(ops_);
+      topic_ = topic;
+      qos_ = qos;
+      sub_ = nh->create_subscription<M>(topic,
+               [this](std::shared_ptr<M const> msg) {
+                 this->cb(EventType(msg));
+               }, qos);
       nh_ = nh;
     }
   }
@@ -158,9 +157,9 @@ public:
   {
     unsubscribe();
 
-    if (!ops_.topic.empty())
+    if (!topic_.empty())
     {
-      sub_ = nh_.subscribe(ops_);
+      subscribe(nh_, topic_, qos_);
     }
   }
 
@@ -169,18 +168,18 @@ public:
    */
   void unsubscribe()
   {
-    sub_.shutdown();
+    sub_.reset();
   }
 
   std::string getTopic() const
   {
-    return ops_.topic;
+    return this->topic_;
   }
 
   /**
    * \brief Returns the internal ros::Subscriber object
    */
-  const ros::Subscriber& getSubscriber() const { return sub_; }
+  const typename rclcpp::Subscription<M>::SharedPtr getSubscriber() const { return sub_; }
 
   /**
    * \brief Does nothing.  Provided so that Subscriber may be used in a message_filters::Chain
@@ -206,9 +205,10 @@ private:
     this->signalMessage(e);
   }
 
-  ros::Subscriber sub_;
-  ros::SubscribeOptions ops_;
-  ros::NodeHandle nh_;
+  typename rclcpp::Subscription<M>::SharedPtr sub_;
+  rclcpp::Node* nh_;
+  std::string topic_;
+  rmw_qos_profile_t qos_;
 };
 
 }

--- a/include/message_filters/subscriber.h
+++ b/include/message_filters/subscriber.h
@@ -82,7 +82,7 @@ typedef std::shared_ptr<SubscriberBase> SubscriberBasePtr;
  *
  * Subscriber has no input connection.
  *
- * The output connection for the Subscriber object is the same signature as for roscpp subscription callbacks, ie.
+ * The output connection for the Subscriber object is the same signature as for rclcpp subscription callbacks, ie.
 \verbatim
 void callback(const std::shared_ptr<M const>&);
 \endverbatim
@@ -171,7 +171,7 @@ public:
   }
 
   /**
-   * \brief Returns the internal ros::Subscriber object
+   * \brief Returns the internal rclcpp::Subscription<M>::SharedPtr object
    */
   const typename rclcpp::Subscription<M>::SharedPtr getSubscriber() const { return sub_; }
 

--- a/include/message_filters/sync_policies/approximate_time.h
+++ b/include/message_filters/sync_policies/approximate_time.h
@@ -39,33 +39,19 @@
 #include "message_filters/connection.h"
 #include "message_filters/null_types.h"
 #include "message_filters/signal9.h"
+#include "message_filters/message_traits.h"
 
-#include <boost/tuple/tuple.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/function.hpp>
-#include <boost/thread/mutex.hpp>
-
-#include <boost/bind.hpp>
-#include <boost/type_traits/is_same.hpp>
-#include <boost/noncopyable.hpp>
-#include <boost/mpl/or.hpp>
-#include <boost/mpl/at.hpp>
-#include <boost/mpl/vector.hpp>
-
-#include <ros/assert.h>
-#include <ros/message_traits.h>
-#include <ros/message_event.h>
-
+#include <rclcpp/rclcpp.hpp>
+#include <cassert>
 #include <deque>
 #include <vector>
 #include <string>
+#include <tuple>
 
 namespace message_filters
 {
 namespace sync_policies
 {
-
-namespace mpl = boost::mpl;
 
 template<typename M0, typename M1, typename M2 = NullType, typename M3 = NullType, typename M4 = NullType,
          typename M5 = NullType, typename M6 = NullType, typename M7 = NullType, typename M8 = NullType>
@@ -104,25 +90,26 @@ struct ApproximateTime : public PolicyBase<M0, M1, M2, M3, M4, M5, M6, M7, M8>
   typedef std::vector<M6Event> M6Vector;
   typedef std::vector<M7Event> M7Vector;
   typedef std::vector<M8Event> M8Vector;
-  typedef boost::tuple<M0Event, M1Event, M2Event, M3Event, M4Event, M5Event, M6Event, M7Event, M8Event> Tuple;
-  typedef boost::tuple<M0Deque, M1Deque, M2Deque, M3Deque, M4Deque, M5Deque, M6Deque, M7Deque, M8Deque> DequeTuple;
-  typedef boost::tuple<M0Vector, M1Vector, M2Vector, M3Vector, M4Vector, M5Vector, M6Vector, M7Vector, M8Vector> VectorTuple;
+  typedef Events Tuple;
+  typedef std::tuple<M0Deque, M1Deque, M2Deque, M3Deque, M4Deque, M5Deque, M6Deque, M7Deque, M8Deque> DequeTuple;
+  typedef std::tuple<M0Vector, M1Vector, M2Vector, M3Vector, M4Vector, M5Vector, M6Vector, M7Vector, M8Vector> VectorTuple;
 
   ApproximateTime(uint32_t queue_size)
   : parent_(0)
   , queue_size_(queue_size)
   , num_non_empty_deques_(0)
   , pivot_(NO_PIVOT)
-  , max_interval_duration_(ros::DURATION_MAX)
+  , max_interval_duration_(rclcpp::Duration(std::numeric_limits<int32_t>::max(),999999999))
   , age_penalty_(0.1)
   , has_dropped_messages_(9, false)
-  , inter_message_lower_bounds_(9, ros::Duration(0))
+  , inter_message_lower_bounds_(9, rclcpp::Duration(0, 0))
   , warned_about_incorrect_bound_(9, false)
   {
-    ROS_ASSERT(queue_size_ > 0);  // The synchronizer will tend to drop many messages with a queue size of 1. At least 2 is recommended.
+    assert(queue_size_ > 0);  // The synchronizer will tend to drop many messages with a queue size of 1. At least 2 is recommended.
   }
 
   ApproximateTime(const ApproximateTime& e)
+  : max_interval_duration_(rclcpp::Duration(std::numeric_limits<int32_t>::max(),999999999))
   {
     *this = e;
   }
@@ -155,17 +142,17 @@ struct ApproximateTime : public PolicyBase<M0, M1, M2, M3, M4, M5, M6, M7, M8>
   template<int i>
   void checkInterMessageBound()
   {
-    namespace mt = ros::message_traits;
+    namespace mt = message_filters::message_traits;
     if (warned_about_incorrect_bound_[i])
     {
       return;
     }
-    std::deque<typename mpl::at_c<Events, i>::type>& deque = boost::get<i>(deques_);
-    std::vector<typename mpl::at_c<Events, i>::type>& v = boost::get<i>(past_);
-    ROS_ASSERT(!deque.empty());
-    const typename mpl::at_c<Messages, i>::type &msg = *(deque.back()).getMessage();
-    ros::Time msg_time = mt::TimeStamp<typename mpl::at_c<Messages, i>::type>::value(msg);
-    ros::Time previous_msg_time;
+    std::deque<typename std::tuple_element<i, Events>::type>& deque = std::get<i>(deques_);
+    std::vector<typename std::tuple_element<i, Events>::type>& v = std::get<i>(past_);
+    assert(!deque.empty());
+    const typename std::tuple_element<i, Messages>::type &msg = *(deque.back()).getMessage();
+    rclcpp::Time msg_time = mt::TimeStamp<typename std::tuple_element<i, Messages>::type>::value(msg);
+    rclcpp::Time previous_msg_time;
     if (deque.size() == (size_t) 1)
     {
       if (v.empty())
@@ -173,36 +160,37 @@ struct ApproximateTime : public PolicyBase<M0, M1, M2, M3, M4, M5, M6, M7, M8>
 	// We have already published (or have never received) the previous message, we cannot check the bound
 	return;
       }
-      const typename mpl::at_c<Messages, i>::type &previous_msg = *(v.back()).getMessage();
-      previous_msg_time = mt::TimeStamp<typename mpl::at_c<Messages, i>::type>::value(previous_msg);
+      const typename std::tuple_element<i, Messages>::type &previous_msg = *(v.back()).getMessage();
+      previous_msg_time = mt::TimeStamp<typename std::tuple_element<i, Messages>::type>::value(previous_msg);
     }
     else
     {
       // There are at least 2 elements in the deque. Check that the gap respects the bound if it was provided.
-      const typename mpl::at_c<Messages, i>::type &previous_msg = *(deque[deque.size()-2]).getMessage();
-      previous_msg_time =  mt::TimeStamp<typename mpl::at_c<Messages, i>::type>::value(previous_msg);
+      const typename std::tuple_element<i, Messages>::type &previous_msg = *(deque[deque.size()-2]).getMessage();
+      previous_msg_time = mt::TimeStamp<typename std::tuple_element<i, Messages>::type>::value(previous_msg);
     }
     if (msg_time < previous_msg_time)
     {
-      ROS_WARN_STREAM("Messages of type " << i << " arrived out of order (will print only once)");
+      std::cout << "Messages of type " << i << " arrived out of order (will print only once)";
       warned_about_incorrect_bound_[i] = true;
     }
     else if ((msg_time - previous_msg_time) < inter_message_lower_bounds_[i])
     {
-      ROS_WARN_STREAM("Messages of type " << i << " arrived closer (" << (msg_time - previous_msg_time)
-		      << ") than the lower bound you provided (" << inter_message_lower_bounds_[i]
-		      << ") (will print only once)");
+      std::cout << "Messages of type " << i << " arrived closer (" <<
+        (msg_time - previous_msg_time).nanoseconds() <<
+        ") than the lower bound you provided (" <<
+        inter_message_lower_bounds_[i].nanoseconds() << ") (will print only once)";
       warned_about_incorrect_bound_[i] = true;
     }
   }
 
 
   template<int i>
-  void add(const typename mpl::at_c<Events, i>::type& evt)
+  void add(const typename std::tuple_element<i, Events>::type& evt)
   {
-    boost::mutex::scoped_lock lock(data_mutex_);
+    std::lock_guard<std::mutex> lock(data_mutex_);
 
-    std::deque<typename mpl::at_c<Events, i>::type>& deque = boost::get<i>(deques_);
+    std::deque<typename std::tuple_element<i, Events>::type>& deque = std::get<i>(deques_);
     deque.push_back(evt);
     if (deque.size() == (size_t)1) {
       // We have just added the first message, so it was empty before
@@ -219,7 +207,7 @@ struct ApproximateTime : public PolicyBase<M0, M1, M2, M3, M4, M5, M6, M7, M8>
     }
     // Check whether we have more messages than allowed in the queue.
     // Note that during the above call to process(), queue i may contain queue_size_+1 messages.
-    std::vector<typename mpl::at_c<Events, i>::type>& past = boost::get<i>(past_);
+    std::vector<typename std::tuple_element<i, Events>::type>& past = std::get<i>(past_);
     if (deque.size() + past.size() > queue_size_)
     {
       // Cancel ongoing candidate search, if any:
@@ -234,7 +222,7 @@ struct ApproximateTime : public PolicyBase<M0, M1, M2, M3, M4, M5, M6, M7, M8>
       recover<7>();
       recover<8>();
       // Drop the oldest message in the offending topic
-      ROS_ASSERT(!deque.empty());
+      assert(!deque.empty());
       deque.pop_front();
       has_dropped_messages_[i] = true;
       if (pivot_ != NO_PIVOT)
@@ -251,19 +239,19 @@ struct ApproximateTime : public PolicyBase<M0, M1, M2, M3, M4, M5, M6, M7, M8>
   void setAgePenalty(double age_penalty)
   {
     // For correctness we only need age_penalty > -1.0, but most likely a negative age_penalty is a mistake.
-    ROS_ASSERT(age_penalty >= 0);
+    assert(age_penalty >= 0);
     age_penalty_ = age_penalty;
   }
 
-  void setInterMessageLowerBound(int i, ros::Duration lower_bound) {
+  void setInterMessageLowerBound(int i, rclcpp::Duration lower_bound) {
     // For correctness we only need age_penalty > -1.0, but most likely a negative age_penalty is a mistake.
-    ROS_ASSERT(lower_bound >= ros::Duration(0,0));
+    assert(lower_bound >= rclcpp::Duration(0,0));
     inter_message_lower_bounds_[i] = lower_bound;
   }
 
-  void setMaxIntervalDuration(ros::Duration max_interval_duration) {
+  void setMaxIntervalDuration(rclcpp::Duration max_interval_duration) {
     // For correctness we only need age_penalty > -1.0, but most likely a negative age_penalty is a mistake.
-    ROS_ASSERT(max_interval_duration >= ros::Duration(0,0));
+    assert(max_interval_duration >= rclcpp::Duration(0,0));
     max_interval_duration_ = max_interval_duration;
   }
 
@@ -272,8 +260,8 @@ private:
   template<int i>
   void dequeDeleteFront()
   {
-    std::deque<typename mpl::at_c<Events, i>::type>& deque = boost::get<i>(deques_);
-    ROS_ASSERT(!deque.empty());
+    std::deque<typename std::tuple_element<i, Events>::type>& deque = std::get<i>(deques_);
+    assert(!deque.empty());
     deque.pop_front();
     if (deque.empty())
     {
@@ -314,7 +302,7 @@ private:
       dequeDeleteFront<8>();
       break;
     default:
-      ROS_BREAK();
+      std::abort();
     }
   }
 
@@ -322,9 +310,9 @@ private:
   template<int i>
   void dequeMoveFrontToPast()
   {
-    std::deque<typename mpl::at_c<Events, i>::type>& deque = boost::get<i>(deques_);
-    std::vector<typename mpl::at_c<Events, i>::type>& vector = boost::get<i>(past_);
-    ROS_ASSERT(!deque.empty());
+    std::deque<typename std::tuple_element<i, Events>::type>& deque = std::get<i>(deques_);
+    std::vector<typename std::tuple_element<i, Events>::type>& vector = std::get<i>(past_);
+    assert(!deque.empty());
     vector.push_back(deque.front());
     deque.pop_front();
     if (deque.empty())
@@ -365,7 +353,7 @@ private:
       dequeMoveFrontToPast<8>();
       break;
     default:
-      ROS_BREAK();
+      std::abort();
     }
   }
 
@@ -374,29 +362,29 @@ private:
     //printf("Creating candidate\n");
     // Create candidate tuple
     candidate_ = Tuple(); // Discards old one if any
-    boost::get<0>(candidate_) = boost::get<0>(deques_).front();
-    boost::get<1>(candidate_) = boost::get<1>(deques_).front();
+    std::get<0>(candidate_) = std::get<0>(deques_).front();
+    std::get<1>(candidate_) = std::get<1>(deques_).front();
     if (RealTypeCount::value > 2)
     {
-      boost::get<2>(candidate_) = boost::get<2>(deques_).front();
+      std::get<2>(candidate_) = std::get<2>(deques_).front();
       if (RealTypeCount::value > 3)
       {
-	boost::get<3>(candidate_) = boost::get<3>(deques_).front();
+	std::get<3>(candidate_) = std::get<3>(deques_).front();
 	if (RealTypeCount::value > 4)
 	{
-	  boost::get<4>(candidate_) = boost::get<4>(deques_).front();
+	  std::get<4>(candidate_) = std::get<4>(deques_).front();
 	  if (RealTypeCount::value > 5)
 	  {
-	    boost::get<5>(candidate_) = boost::get<5>(deques_).front();
+	    std::get<5>(candidate_) = std::get<5>(deques_).front();
 	    if (RealTypeCount::value > 6)
 	    {
-	      boost::get<6>(candidate_) = boost::get<6>(deques_).front();
+	      std::get<6>(candidate_) = std::get<6>(deques_).front();
 	      if (RealTypeCount::value > 7)
 	      {
-		boost::get<7>(candidate_) = boost::get<7>(deques_).front();
+		std::get<7>(candidate_) = std::get<7>(deques_).front();
 		if (RealTypeCount::value > 8)
 		{
-		  boost::get<8>(candidate_) = boost::get<8>(deques_).front();
+		  std::get<8>(candidate_) = std::get<8>(deques_).front();
 		}
 	      }
 	    }
@@ -405,15 +393,15 @@ private:
       }
     }
     // Delete all past messages, since we have found a better candidate
-    boost::get<0>(past_).clear();
-    boost::get<1>(past_).clear();
-    boost::get<2>(past_).clear();
-    boost::get<3>(past_).clear();
-    boost::get<4>(past_).clear();
-    boost::get<5>(past_).clear();
-    boost::get<6>(past_).clear();
-    boost::get<7>(past_).clear();
-    boost::get<8>(past_).clear();
+    std::get<0>(past_).clear();
+    std::get<1>(past_).clear();
+    std::get<2>(past_).clear();
+    std::get<3>(past_).clear();
+    std::get<4>(past_).clear();
+    std::get<5>(past_).clear();
+    std::get<6>(past_).clear();
+    std::get<7>(past_).clear();
+    std::get<8>(past_).clear();
     //printf("Candidate created\n");
   }
 
@@ -427,9 +415,9 @@ private:
       return;
     }
 
-    std::vector<typename mpl::at_c<Events, i>::type>& v = boost::get<i>(past_);
-    std::deque<typename mpl::at_c<Events, i>::type>& q = boost::get<i>(deques_);
-    ROS_ASSERT(num_messages <= v.size());
+    std::vector<typename std::tuple_element<i, Events>::type>& v = std::get<i>(past_);
+    std::deque<typename std::tuple_element<i, Events>::type>& q = std::get<i>(deques_);
+    assert(num_messages <= v.size());
     while (num_messages > 0)
     {
       q.push_front(v.back());
@@ -452,8 +440,8 @@ private:
       return;
     }
 
-    std::vector<typename mpl::at_c<Events, i>::type>& v = boost::get<i>(past_);
-    std::deque<typename mpl::at_c<Events, i>::type>& q = boost::get<i>(deques_);
+    std::vector<typename std::tuple_element<i, Events>::type>& v = std::get<i>(past_);
+    std::deque<typename std::tuple_element<i, Events>::type>& q = std::get<i>(deques_);
     while (!v.empty())
     {
       q.push_front(v.back());
@@ -475,15 +463,15 @@ private:
       return;
     }
 
-    std::vector<typename mpl::at_c<Events, i>::type>& v = boost::get<i>(past_);
-    std::deque<typename mpl::at_c<Events, i>::type>& q = boost::get<i>(deques_);
+    std::vector<typename std::tuple_element<i, Events>::type>& v = std::get<i>(past_);
+    std::deque<typename std::tuple_element<i, Events>::type>& q = std::get<i>(deques_);
     while (!v.empty())
     {
       q.push_front(v.back());
       v.pop_back();
     }
 
-    ROS_ASSERT(!q.empty());
+    assert(!q.empty());
 
     q.pop_front();
     if (!q.empty())
@@ -497,9 +485,9 @@ private:
   {
     //printf("Publishing candidate\n");
     // Publish
-    parent_->signal(boost::get<0>(candidate_), boost::get<1>(candidate_), boost::get<2>(candidate_), boost::get<3>(candidate_),
-                    boost::get<4>(candidate_), boost::get<5>(candidate_), boost::get<6>(candidate_), boost::get<7>(candidate_),
-                    boost::get<8>(candidate_));
+    parent_->signal(std::get<0>(candidate_), std::get<1>(candidate_), std::get<2>(candidate_), std::get<3>(candidate_),
+                    std::get<4>(candidate_), std::get<5>(candidate_), std::get<6>(candidate_), std::get<7>(candidate_),
+                    std::get<8>(candidate_));
     // Delete this candidate
     candidate_ = Tuple();
     pivot_ = NO_PIVOT;
@@ -519,7 +507,7 @@ private:
 
   // Assumes: all deques are non empty, i.e. num_non_empty_deques_ == RealTypeCount::value
   // Returns: the oldest message on the deques
-  void getCandidateStart(uint32_t &start_index, ros::Time &start_time)
+  void getCandidateStart(uint32_t &start_index, rclcpp::Time &start_time)
   {
     return getCandidateBoundary(start_index, start_time, false);
   }
@@ -527,7 +515,7 @@ private:
   // Assumes: all deques are non empty, i.e. num_non_empty_deques_ == RealTypeCount::value
   // Returns: the latest message among the heads of the deques, i.e. the minimum
   //          time to end an interval started at getCandidateStart_index()
-  void getCandidateEnd(uint32_t &end_index, ros::Time &end_time)
+  void getCandidateEnd(uint32_t &end_index, rclcpp::Time &end_time)
   {
     return getCandidateBoundary(end_index, end_time, true);
   }
@@ -535,16 +523,16 @@ private:
   // ASSUMES: all deques are non-empty
   // end = true: look for the latest head of deque
   //       false: look for the earliest head of deque
-  void getCandidateBoundary(uint32_t &index, ros::Time &time, bool end)
+  void getCandidateBoundary(uint32_t &index, rclcpp::Time &time, bool end)
   {
-    namespace mt = ros::message_traits;
+    namespace mt = message_filters::message_traits;
 
-    M0Event& m0 = boost::get<0>(deques_).front();
+    M0Event& m0 = std::get<0>(deques_).front();
     time = mt::TimeStamp<M0>::value(*m0.getMessage());
     index = 0;
     if (RealTypeCount::value > 1)
     {
-      M1Event& m1 = boost::get<1>(deques_).front();
+      M1Event& m1 = std::get<1>(deques_).front();
       if ((mt::TimeStamp<M1>::value(*m1.getMessage()) < time) ^ end)
       {
         time = mt::TimeStamp<M1>::value(*m1.getMessage());
@@ -553,7 +541,7 @@ private:
     }
     if (RealTypeCount::value > 2)
     {
-      M2Event& m2 = boost::get<2>(deques_).front();
+      M2Event& m2 = std::get<2>(deques_).front();
       if ((mt::TimeStamp<M2>::value(*m2.getMessage()) < time) ^ end)
       {
         time = mt::TimeStamp<M2>::value(*m2.getMessage());
@@ -562,7 +550,7 @@ private:
     }
     if (RealTypeCount::value > 3)
     {
-      M3Event& m3 = boost::get<3>(deques_).front();
+      M3Event& m3 = std::get<3>(deques_).front();
       if ((mt::TimeStamp<M3>::value(*m3.getMessage()) < time) ^ end)
       {
         time = mt::TimeStamp<M3>::value(*m3.getMessage());
@@ -571,7 +559,7 @@ private:
     }
     if (RealTypeCount::value > 4)
     {
-      M4Event& m4 = boost::get<4>(deques_).front();
+      M4Event& m4 = std::get<4>(deques_).front();
       if ((mt::TimeStamp<M4>::value(*m4.getMessage()) < time) ^ end)
       {
         time = mt::TimeStamp<M4>::value(*m4.getMessage());
@@ -580,7 +568,7 @@ private:
     }
     if (RealTypeCount::value > 5)
     {
-      M5Event& m5 = boost::get<5>(deques_).front();
+      M5Event& m5 = std::get<5>(deques_).front();
       if ((mt::TimeStamp<M5>::value(*m5.getMessage()) < time) ^ end)
       {
         time = mt::TimeStamp<M5>::value(*m5.getMessage());
@@ -589,7 +577,7 @@ private:
     }
     if (RealTypeCount::value > 6)
     {
-      M6Event& m6 = boost::get<6>(deques_).front();
+      M6Event& m6 = std::get<6>(deques_).front();
       if ((mt::TimeStamp<M6>::value(*m6.getMessage()) < time) ^ end)
       {
         time = mt::TimeStamp<M6>::value(*m6.getMessage());
@@ -598,7 +586,7 @@ private:
     }
     if (RealTypeCount::value > 7)
     {
-      M7Event& m7 = boost::get<7>(deques_).front();
+      M7Event& m7 = std::get<7>(deques_).front();
       if ((mt::TimeStamp<M7>::value(*m7.getMessage()) < time) ^ end)
       {
         time = mt::TimeStamp<M7>::value(*m7.getMessage());
@@ -607,7 +595,7 @@ private:
     }
     if (RealTypeCount::value > 8)
     {
-      M8Event& m8 = boost::get<8>(deques_).front();
+      M8Event& m8 = std::get<8>(deques_).front();
       if ((mt::TimeStamp<M8>::value(*m8.getMessage()) < time) ^ end)
       {
         time = mt::TimeStamp<M8>::value(*m8.getMessage());
@@ -619,42 +607,42 @@ private:
 
   // ASSUMES: we have a pivot and candidate
   template<int i>
-  ros::Time getVirtualTime()
+  rclcpp::Time getVirtualTime()
   {
-    namespace mt = ros::message_traits;
+    namespace mt = message_filters::message_traits;
 
     if (i >= RealTypeCount::value)
     {
-      return ros::Time(0,0);  // Dummy return value
+      return rclcpp::Time(0,0);  // Dummy return value
     }
-    ROS_ASSERT(pivot_ != NO_PIVOT);
+    assert(pivot_ != NO_PIVOT);
 
-    std::vector<typename mpl::at_c<Events, i>::type>& v = boost::get<i>(past_);
-    std::deque<typename mpl::at_c<Events, i>::type>& q = boost::get<i>(deques_);
+    std::vector<typename std::tuple_element<i, Events>::type>& v = std::get<i>(past_);
+    std::deque<typename std::tuple_element<i, Events>::type>& q = std::get<i>(deques_);
     if (q.empty())
     {
-      ROS_ASSERT(!v.empty());  // Because we have a candidate
-      ros::Time last_msg_time = mt::TimeStamp<typename mpl::at_c<Messages, i>::type>::value(*(v.back()).getMessage());
-      ros::Time msg_time_lower_bound = last_msg_time + inter_message_lower_bounds_[i];
+      assert(!v.empty());  // Because we have a candidate
+      rclcpp::Time last_msg_time = mt::TimeStamp<typename std::tuple_element<i, Messages>::type>::value(*(v.back()).getMessage());
+      rclcpp::Time msg_time_lower_bound = last_msg_time + inter_message_lower_bounds_[i];
       if (msg_time_lower_bound > pivot_time_)  // Take the max
       {
         return msg_time_lower_bound;
       }
       return pivot_time_;
     }
-    ros::Time current_msg_time = mt::TimeStamp<typename mpl::at_c<Messages, i>::type>::value(*(q.front()).getMessage());
+    rclcpp::Time current_msg_time = mt::TimeStamp<typename std::tuple_element<i, Messages>::type>::value(*(q.front()).getMessage());
     return current_msg_time;
   }
 
 
   // ASSUMES: we have a pivot and candidate
-  void getVirtualCandidateStart(uint32_t &start_index, ros::Time &start_time)
+  void getVirtualCandidateStart(uint32_t &start_index, rclcpp::Time &start_time)
   {
     return getVirtualCandidateBoundary(start_index, start_time, false);
   }
 
   // ASSUMES: we have a pivot and candidate
-  void getVirtualCandidateEnd(uint32_t &end_index, ros::Time &end_time)
+  void getVirtualCandidateEnd(uint32_t &end_index, rclcpp::Time &end_time)
   {
     return getVirtualCandidateBoundary(end_index, end_time, true);
   }
@@ -662,11 +650,9 @@ private:
   // ASSUMES: we have a pivot and candidate
   // end = true: look for the latest head of deque
   //       false: look for the earliest head of deque
-  void getVirtualCandidateBoundary(uint32_t &index, ros::Time &time, bool end)
+  void getVirtualCandidateBoundary(uint32_t &index, rclcpp::Time &time, bool end)
   {
-    namespace mt = ros::message_traits;
-
-    std::vector<ros::Time> virtual_times(9);
+    std::vector<rclcpp::Time> virtual_times(9);
     virtual_times[0] = getVirtualTime<0>();
     virtual_times[1] = getVirtualTime<1>();
     virtual_times[2] = getVirtualTime<2>();
@@ -700,7 +686,7 @@ private:
       //printf("Entering while loop in this state [\n");
       //show_internal_state();
       //printf("]\n");
-      ros::Time end_time, start_time;
+      rclcpp::Time end_time, start_time;
       uint32_t end_index, start_index;
       getCandidateEnd(end_index, end_time);
       getCandidateStart(start_index, start_time);
@@ -759,7 +745,7 @@ private:
         }
       }
       // INVARIANT: we have a candidate and pivot
-      ROS_ASSERT(pivot_ != NO_PIVOT);
+      assert(pivot_ != NO_PIVOT);
       //printf("start_index == %d, pivot_ == %d\n", start_index, pivot_);
       if (start_index == pivot_)  // TODO: replace with start_time == pivot_time_
       {
@@ -783,7 +769,7 @@ private:
         std::vector<int> num_virtual_moves(9,0);
         while (1)
         {
-          ros::Time end_time, start_time;
+          rclcpp::Time end_time, start_time;
           uint32_t end_index, start_index;
           getVirtualCandidateEnd(end_index, end_time);
           getVirtualCandidateStart(start_index, start_time);
@@ -812,14 +798,14 @@ private:
 	    recover<7>(num_virtual_moves[7]);
 	    recover<8>(num_virtual_moves[8]);
             (void)num_non_empty_deques_before_virtual_search; // unused variable warning stopper
-            ROS_ASSERT(num_non_empty_deques_before_virtual_search == num_non_empty_deques_);
+            assert(num_non_empty_deques_before_virtual_search == num_non_empty_deques_);
             break;
           }
           // Note: we cannot reach this point with start_index == pivot_ since in that case we would
           //       have start_time == pivot_time, in which case the two tests above are the negation
           //       of each other, so that one must be true. Therefore the while loop always terminates.
-	  ROS_ASSERT(start_index != pivot_);
-	  ROS_ASSERT(start_time < pivot_time_);
+	  assert(start_index != pivot_);
+	  assert(start_time < pivot_time_);
           dequeMoveFrontToPast(start_index);
           num_virtual_moves[start_index]++;
         } // while(1)
@@ -836,17 +822,17 @@ private:
   uint32_t num_non_empty_deques_;
   VectorTuple past_;
   Tuple candidate_;  // NULL if there is no candidate, in which case there is no pivot.
-  ros::Time candidate_start_;
-  ros::Time candidate_end_;
-  ros::Time pivot_time_;
+  rclcpp::Time candidate_start_;
+  rclcpp::Time candidate_end_;
+  rclcpp::Time pivot_time_;
   uint32_t pivot_;  // Equal to NO_PIVOT if there is no candidate
-  boost::mutex data_mutex_;  // Protects all of the above
+  std::mutex data_mutex_;  // Protects all of the above
 
-  ros::Duration max_interval_duration_; // TODO: initialize with a parameter
+  rclcpp::Duration max_interval_duration_; // TODO: initialize with a parameter
   double age_penalty_;
 
   std::vector<bool> has_dropped_messages_;
-  std::vector<ros::Duration> inter_message_lower_bounds_;
+  std::vector<rclcpp::Duration> inter_message_lower_bounds_;
   std::vector<bool> warned_about_incorrect_bound_;
 };
 

--- a/include/message_filters/sync_policies/exact_time.h
+++ b/include/message_filters/sync_policies/exact_time.h
@@ -42,7 +42,6 @@
 #include "message_filters/message_traits.h"
 
 #include <rclcpp/rclcpp.hpp>
-#include <cassert>
 #include <deque>
 #include <string>
 #include <tuple>
@@ -102,7 +101,7 @@ struct ExactTime : public PolicyBase<M0, M1, M2, M3, M4, M5, M6, M7, M8>
   template<int i>
   void add(const typename std::tuple_element<i, Events>::type& evt)
   {
-    assert(parent_);
+    RCUTILS_ASSERT(parent_);
 
     namespace mt = message_filters::message_traits;
 

--- a/include/message_filters/synchronizer.h
+++ b/include/message_filters/synchronizer.h
@@ -35,60 +35,48 @@
 #ifndef MESSAGE_FILTERS_SYNCHRONIZER_H
 #define MESSAGE_FILTERS_SYNCHRONIZER_H
 
-#include <boost/tuple/tuple.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/function.hpp>
-#include <boost/thread/mutex.hpp>
-
-#include <boost/bind.hpp>
-#include <boost/type_traits/is_same.hpp>
-#include <boost/noncopyable.hpp>
-#include <boost/mpl/or.hpp>
-#include <boost/mpl/at.hpp>
-#include <boost/mpl/vector.hpp>
-#include <boost/function_types/function_arity.hpp>
-#include <boost/function_types/is_nonmember_callable_builtin.hpp>
-
 #include "connection.h"
 #include "null_types.h"
 #include "signal9.h"
-#include <ros/message_traits.h>
-#include <ros/message_event.h>
+#include "message_event.h"
 
+#include <type_traits>
 #include <deque>
+#include <tuple>
 #include <vector>
 #include <string>
 
 namespace message_filters
 {
 
-namespace mpl = boost::mpl;
-
 template<class Policy>
-class Synchronizer : public boost::noncopyable, public Policy
+class Synchronizer : public noncopyable, public Policy
 {
 public:
   typedef typename Policy::Messages Messages;
   typedef typename Policy::Events Events;
   typedef typename Policy::Signal Signal;
-  typedef typename mpl::at_c<Messages, 0>::type M0;
-  typedef typename mpl::at_c<Messages, 1>::type M1;
-  typedef typename mpl::at_c<Messages, 2>::type M2;
-  typedef typename mpl::at_c<Messages, 3>::type M3;
-  typedef typename mpl::at_c<Messages, 4>::type M4;
-  typedef typename mpl::at_c<Messages, 5>::type M5;
-  typedef typename mpl::at_c<Messages, 6>::type M6;
-  typedef typename mpl::at_c<Messages, 7>::type M7;
-  typedef typename mpl::at_c<Messages, 8>::type M8;
-  typedef typename mpl::at_c<Events, 0>::type M0Event;
-  typedef typename mpl::at_c<Events, 1>::type M1Event;
-  typedef typename mpl::at_c<Events, 2>::type M2Event;
-  typedef typename mpl::at_c<Events, 3>::type M3Event;
-  typedef typename mpl::at_c<Events, 4>::type M4Event;
-  typedef typename mpl::at_c<Events, 5>::type M5Event;
-  typedef typename mpl::at_c<Events, 6>::type M6Event;
-  typedef typename mpl::at_c<Events, 7>::type M7Event;
-  typedef typename mpl::at_c<Events, 8>::type M8Event;
+
+  typedef typename std::tuple_element<0, Messages>::type M0;
+  typedef typename std::tuple_element<1, Messages>::type M1;
+  typedef typename std::tuple_element<2, Messages>::type M2;
+  typedef typename std::tuple_element<3, Messages>::type M3;
+  typedef typename std::tuple_element<4, Messages>::type M4;
+  typedef typename std::tuple_element<5, Messages>::type M5;
+  typedef typename std::tuple_element<6, Messages>::type M6;
+  typedef typename std::tuple_element<7, Messages>::type M7;
+  typedef typename std::tuple_element<8, Messages>::type M8;
+
+
+  typedef typename std::tuple_element<0, Events>::type M0Event;
+  typedef typename std::tuple_element<1, Events>::type M1Event;
+  typedef typename std::tuple_element<2, Events>::type M2Event;
+  typedef typename std::tuple_element<3, Events>::type M3Event;
+  typedef typename std::tuple_element<4, Events>::type M4Event;
+  typedef typename std::tuple_element<5, Events>::type M5Event;
+  typedef typename std::tuple_element<6, Events>::type M6Event;
+  typedef typename std::tuple_element<7, Events>::type M7Event;
+  typedef typename std::tuple_element<8, Events>::type M8Event;
 
   static const uint8_t MAX_MESSAGES = 9;
 
@@ -287,15 +275,15 @@ public:
   {
     disconnectAll();
 
-    input_connections_[0] = f0.registerCallback(boost::function<void(const M0Event&)>(boost::bind(&Synchronizer::template cb<0>, this, _1)));
-    input_connections_[1] = f1.registerCallback(boost::function<void(const M1Event&)>(boost::bind(&Synchronizer::template cb<1>, this, _1)));
-    input_connections_[2] = f2.registerCallback(boost::function<void(const M2Event&)>(boost::bind(&Synchronizer::template cb<2>, this, _1)));
-    input_connections_[3] = f3.registerCallback(boost::function<void(const M3Event&)>(boost::bind(&Synchronizer::template cb<3>, this, _1)));
-    input_connections_[4] = f4.registerCallback(boost::function<void(const M4Event&)>(boost::bind(&Synchronizer::template cb<4>, this, _1)));
-    input_connections_[5] = f5.registerCallback(boost::function<void(const M5Event&)>(boost::bind(&Synchronizer::template cb<5>, this, _1)));
-    input_connections_[6] = f6.registerCallback(boost::function<void(const M6Event&)>(boost::bind(&Synchronizer::template cb<6>, this, _1)));
-    input_connections_[7] = f7.registerCallback(boost::function<void(const M7Event&)>(boost::bind(&Synchronizer::template cb<7>, this, _1)));
-    input_connections_[8] = f8.registerCallback(boost::function<void(const M8Event&)>(boost::bind(&Synchronizer::template cb<8>, this, _1)));
+    input_connections_[0] = f0.registerCallback(std::function<void(const M0Event&)>(std::bind(&Synchronizer::template cb<0>, this, _1)));
+    input_connections_[1] = f1.registerCallback(std::function<void(const M1Event&)>(std::bind(&Synchronizer::template cb<1>, this, _1)));
+    input_connections_[2] = f2.registerCallback(std::function<void(const M2Event&)>(std::bind(&Synchronizer::template cb<2>, this, _1)));
+    input_connections_[3] = f3.registerCallback(std::function<void(const M3Event&)>(std::bind(&Synchronizer::template cb<3>, this, _1)));
+    input_connections_[4] = f4.registerCallback(std::function<void(const M4Event&)>(std::bind(&Synchronizer::template cb<4>, this, _1)));
+    input_connections_[5] = f5.registerCallback(std::function<void(const M5Event&)>(std::bind(&Synchronizer::template cb<5>, this, _1)));
+    input_connections_[6] = f6.registerCallback(std::function<void(const M6Event&)>(std::bind(&Synchronizer::template cb<6>, this, _1)));
+    input_connections_[7] = f7.registerCallback(std::function<void(const M7Event&)>(std::bind(&Synchronizer::template cb<7>, this, _1)));
+    input_connections_[8] = f8.registerCallback(std::function<void(const M8Event&)>(std::bind(&Synchronizer::template cb<8>, this, _1)));
   }
 
   template<class C>
@@ -337,9 +325,9 @@ public:
   using Policy::add;
 
   template<int i>
-  void add(const boost::shared_ptr<typename mpl::at_c<Messages, i>::type const>& msg)
+  void add(const std::shared_ptr<typename std::tuple_element<i, Messages>::type const>& msg)
   {
-    this->template add<i>(typename mpl::at_c<Events, i>::type(msg));
+    this->template add<i>(typename std::tuple_element<i, Events>::type(msg));
   }
 
 private:
@@ -353,7 +341,7 @@ private:
   }
 
   template<int i>
-  void cb(const typename mpl::at_c<Events, i>::type& evt)
+  void cb(const typename std::tuple_element<i, Events>::type& evt)
   {
     this->template add<i>(evt);
   }
@@ -367,25 +355,45 @@ private:
   std::string name_;
 };
 
+template<class... T> struct mp_plus;
+template<> struct mp_plus<>
+{
+  using type = std::integral_constant<int, 0>;
+};
+template<class T1, class... T> struct mp_plus<T1, T...>
+{
+  static constexpr auto _v = !T1::value + mp_plus<T...>::type::value;
+  using type = std::integral_constant<
+    typename std::remove_const<decltype(_v)>::type, _v>;
+};
+
+template<class L, class V> struct mp_count;
+template<template<class...> class L, class... T, class V>
+  struct mp_count<L<T...>, V>
+{
+  using type = typename mp_plus<std::is_same<T, V>...>::type;
+};
+
 template<typename M0, typename M1, typename M2, typename M3, typename M4,
          typename M5, typename M6, typename M7, typename M8>
 struct PolicyBase
 {
-  typedef mpl::vector<M0, M1, M2, M3, M4, M5, M6, M7, M8> Messages;
+  typedef typename mp_count<std::tuple<M0, M1, M2, M3, M4, M5, M6, M7, M8>, NullType>::type RealTypeCount;
+  typedef std::tuple<M0, M1, M2, M3, M4, M5, M6, M7, M8> Messages;
   typedef Signal9<M0, M1, M2, M3, M4, M5, M6, M7, M8> Signal;
-  typedef mpl::vector<ros::MessageEvent<M0 const>, ros::MessageEvent<M1 const>, ros::MessageEvent<M2 const>, ros::MessageEvent<M3 const>,
-                      ros::MessageEvent<M4 const>, ros::MessageEvent<M5 const>, ros::MessageEvent<M6 const>, ros::MessageEvent<M7 const>,
-                      ros::MessageEvent<M8 const> > Events;
-  typedef typename mpl::fold<Messages, mpl::int_<0>, mpl::if_<mpl::not_<boost::is_same<mpl::_2, NullType> >, mpl::next<mpl::_1>, mpl::_1> >::type RealTypeCount;
-  typedef typename mpl::at_c<Events, 0>::type M0Event;
-  typedef typename mpl::at_c<Events, 1>::type M1Event;
-  typedef typename mpl::at_c<Events, 2>::type M2Event;
-  typedef typename mpl::at_c<Events, 3>::type M3Event;
-  typedef typename mpl::at_c<Events, 4>::type M4Event;
-  typedef typename mpl::at_c<Events, 5>::type M5Event;
-  typedef typename mpl::at_c<Events, 6>::type M6Event;
-  typedef typename mpl::at_c<Events, 7>::type M7Event;
-  typedef typename mpl::at_c<Events, 8>::type M8Event;
+  typedef std::tuple<MessageEvent<M0 const>, MessageEvent<M1 const>, MessageEvent<M2 const>,
+                     MessageEvent<M3 const>, MessageEvent<M4 const>, MessageEvent<M5 const>,
+                     MessageEvent<M6 const>, MessageEvent<M7 const>, MessageEvent<M8 const> > Events;
+
+  typedef typename std::tuple_element<0, Events>::type M0Event;
+  typedef typename std::tuple_element<1, Events>::type M1Event;
+  typedef typename std::tuple_element<2, Events>::type M2Event;
+  typedef typename std::tuple_element<3, Events>::type M3Event;
+  typedef typename std::tuple_element<4, Events>::type M4Event;
+  typedef typename std::tuple_element<5, Events>::type M5Event;
+  typedef typename std::tuple_element<6, Events>::type M6Event;
+  typedef typename std::tuple_element<7, Events>::type M7Event;
+  typedef typename std::tuple_element<8, Events>::type M8Event;
 };
 
 } // namespace message_filters

--- a/include/message_filters/synchronizer.h
+++ b/include/message_filters/synchronizer.h
@@ -275,15 +275,15 @@ public:
   {
     disconnectAll();
 
-    input_connections_[0] = f0.registerCallback(std::function<void(const M0Event&)>(std::bind(&Synchronizer::template cb<0>, this, _1)));
-    input_connections_[1] = f1.registerCallback(std::function<void(const M1Event&)>(std::bind(&Synchronizer::template cb<1>, this, _1)));
-    input_connections_[2] = f2.registerCallback(std::function<void(const M2Event&)>(std::bind(&Synchronizer::template cb<2>, this, _1)));
-    input_connections_[3] = f3.registerCallback(std::function<void(const M3Event&)>(std::bind(&Synchronizer::template cb<3>, this, _1)));
-    input_connections_[4] = f4.registerCallback(std::function<void(const M4Event&)>(std::bind(&Synchronizer::template cb<4>, this, _1)));
-    input_connections_[5] = f5.registerCallback(std::function<void(const M5Event&)>(std::bind(&Synchronizer::template cb<5>, this, _1)));
-    input_connections_[6] = f6.registerCallback(std::function<void(const M6Event&)>(std::bind(&Synchronizer::template cb<6>, this, _1)));
-    input_connections_[7] = f7.registerCallback(std::function<void(const M7Event&)>(std::bind(&Synchronizer::template cb<7>, this, _1)));
-    input_connections_[8] = f8.registerCallback(std::function<void(const M8Event&)>(std::bind(&Synchronizer::template cb<8>, this, _1)));
+    input_connections_[0] = f0.registerCallback(std::function<void(const M0Event&)>(std::bind(&Synchronizer::template cb<0>, this, std::placeholders::_1)));
+    input_connections_[1] = f1.registerCallback(std::function<void(const M1Event&)>(std::bind(&Synchronizer::template cb<1>, this, std::placeholders::_1)));
+    input_connections_[2] = f2.registerCallback(std::function<void(const M2Event&)>(std::bind(&Synchronizer::template cb<2>, this, std::placeholders::_1)));
+    input_connections_[3] = f3.registerCallback(std::function<void(const M3Event&)>(std::bind(&Synchronizer::template cb<3>, this, std::placeholders::_1)));
+    input_connections_[4] = f4.registerCallback(std::function<void(const M4Event&)>(std::bind(&Synchronizer::template cb<4>, this, std::placeholders::_1)));
+    input_connections_[5] = f5.registerCallback(std::function<void(const M5Event&)>(std::bind(&Synchronizer::template cb<5>, this, std::placeholders::_1)));
+    input_connections_[6] = f6.registerCallback(std::function<void(const M6Event&)>(std::bind(&Synchronizer::template cb<6>, this, std::placeholders::_1)));
+    input_connections_[7] = f7.registerCallback(std::function<void(const M7Event&)>(std::bind(&Synchronizer::template cb<7>, this, std::placeholders::_1)));
+    input_connections_[8] = f8.registerCallback(std::function<void(const M8Event&)>(std::bind(&Synchronizer::template cb<8>, this, std::placeholders::_1)));
   }
 
   template<class C>

--- a/include/message_filters/time_sequencer.h
+++ b/include/message_filters/time_sequencer.h
@@ -85,14 +85,14 @@ public:
    * \param delay The minimum time to hold a message before passing it through.
    * \param update_rate The rate at which to check for messages which have passed "delay"
    * \param queue_size The number of messages to store
-   * \param nh (optional) The NodeHandle to use to create the ros::SteadyTimer that runs at update_rate
+   * \param node The Node to use to create the ros::SteadyTimer that runs at update_rate
    */
   template<class F>
-  TimeSequencer(F& f, rclcpp::Duration delay, rclcpp::Duration update_rate, uint32_t queue_size, rclcpp::Node::SharedPtr nh = std::make_shared<rclcpp::Node>("test_node"))
+  TimeSequencer(F& f, rclcpp::Duration delay, rclcpp::Duration update_rate, uint32_t queue_size, rclcpp::Node::SharedPtr node)
   : delay_(delay)
   , update_rate_(update_rate)
   , queue_size_(queue_size)
-  , nh_(nh)
+  , node_(node)
   {
     init();
     connectInput(f);
@@ -106,13 +106,13 @@ public:
    * \param delay The minimum time to hold a message before passing it through.
    * \param update_rate The rate at which to check for messages which have passed "delay"
    * \param queue_size The number of messages to store
-   * \param nh (optional) The NodeHandle to use to create the ros::SteadyTimer that runs at update_rate
+   * \param node The Node to use to create the ros::SteadyTimer that runs at update_rate
    */
-  TimeSequencer(rclcpp::Duration delay, rclcpp::Duration update_rate, uint32_t queue_size, rclcpp::Node::SharedPtr nh = std::make_shared<rclcpp::Node>("test_node"))
+  TimeSequencer(rclcpp::Duration delay, rclcpp::Duration update_rate, uint32_t queue_size, rclcpp::Node::SharedPtr node)
   : delay_(delay)
   , update_rate_(update_rate)
   , queue_size_(queue_size)
-  , nh_(nh)
+  , node_(node)
   {
     init();
   }
@@ -214,14 +214,9 @@ private:
     }
   }
 
-  void update(const ros::SteadyTimerEvent&)
-  {
-    dispatch();
-  }
-
   void init()
   {
-    update_timer_ = nh_->create_wall_timer(std::chrono::nanoseconds(update_rate_.nanoseconds()), [this]() {
+    update_timer_ = node_->create_wall_timer(std::chrono::nanoseconds(update_rate_.nanoseconds()), [this]() {
       dispatch();
       });
   }
@@ -229,7 +224,7 @@ private:
   rclcpp::Duration delay_;
   rclcpp::Duration update_rate_;
   uint32_t queue_size_;
-  rclcpp::Node::SharedPtr nh_;
+  rclcpp::Node::SharedPtr node_;
   rclcpp::TimerBase::SharedPtr update_timer_;
   Connection incoming_connection_;
 

--- a/include/message_filters/time_sequencer.h
+++ b/include/message_filters/time_sequencer.h
@@ -124,7 +124,7 @@ public:
   void connectInput(F& f)
   {
     incoming_connection_.disconnect();
-    incoming_connection_ = f.registerCallback(typename SimpleFilter<M>::EventCallback(std::bind(&TimeSequencer::cb, this, _1)));
+    incoming_connection_ = f.registerCallback(typename SimpleFilter<M>::EventCallback(std::bind(&TimeSequencer::cb, this, std::placeholders::_1)));
   }
 
   ~TimeSequencer()

--- a/include/message_filters/time_sequencer.h
+++ b/include/message_filters/time_sequencer.h
@@ -53,7 +53,7 @@ namespace message_filters
  *
  * \section behavior BEHAVIOR
 
- * At construction, the TimeSequencer takes a ros::Duration
+ * At construction, the TimeSequencer takes a rclcpp::Duration
  * "delay" which specifies how long to queue up messages to
  * provide a time sequencing over them.  As messages arrive they are
  * sorted according to their time stamps.  A callback for a message is
@@ -66,7 +66,7 @@ namespace message_filters
  *
  * \section connections CONNECTIONS
  *
- * TimeSequencer's input and output connections are both of the same signature as roscpp subscription callbacks, ie.
+ * TimeSequencer's input and output connections are both of the same signature as rclcpp subscription callbacks, ie.
 \verbatim
 void callback(const std::shared_ptr<M const>&);
 \endverbatim
@@ -85,7 +85,7 @@ public:
    * \param delay The minimum time to hold a message before passing it through.
    * \param update_rate The rate at which to check for messages which have passed "delay"
    * \param queue_size The number of messages to store
-   * \param node The Node to use to create the ros::SteadyTimer that runs at update_rate
+   * \param node The Node to use to create the rclcpp::SteadyTimer that runs at update_rate
    */
   template<class F>
   TimeSequencer(F& f, rclcpp::Duration delay, rclcpp::Duration update_rate, uint32_t queue_size, rclcpp::Node::SharedPtr node)
@@ -106,7 +106,7 @@ public:
    * \param delay The minimum time to hold a message before passing it through.
    * \param update_rate The rate at which to check for messages which have passed "delay"
    * \param queue_size The number of messages to store
-   * \param node The Node to use to create the ros::SteadyTimer that runs at update_rate
+   * \param node The Node to use to create the rclcpp::SteadyTimer that runs at update_rate
    */
   TimeSequencer(rclcpp::Duration delay, rclcpp::Duration update_rate, uint32_t queue_size, rclcpp::Node::SharedPtr node)
   : delay_(delay)

--- a/include/message_filters/time_sequencer.h
+++ b/include/message_filters/time_sequencer.h
@@ -35,10 +35,11 @@
 #ifndef MESSAGE_FILTERS_TIME_SEQUENCER_H
 #define MESSAGE_FILTERS_TIME_SEQUENCER_H
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
 #include "connection.h"
 #include "simple_filter.h"
+#include "message_traits.h"
 
 namespace message_filters
 {
@@ -67,7 +68,7 @@ namespace message_filters
  *
  * TimeSequencer's input and output connections are both of the same signature as roscpp subscription callbacks, ie.
 \verbatim
-void callback(const boost::shared_ptr<M const>&);
+void callback(const std::shared_ptr<M const>&);
 \endverbatim
  *
  */
@@ -75,8 +76,8 @@ template<class M>
 class TimeSequencer : public SimpleFilter<M>
 {
 public:
-  typedef boost::shared_ptr<M const> MConstPtr;
-  typedef ros::MessageEvent<M const> EventType;
+  typedef std::shared_ptr<M const> MConstPtr;
+  typedef MessageEvent<M const> EventType;
 
   /**
    * \brief Constructor
@@ -87,7 +88,7 @@ public:
    * \param nh (optional) The NodeHandle to use to create the ros::SteadyTimer that runs at update_rate
    */
   template<class F>
-  TimeSequencer(F& f, ros::Duration delay, ros::Duration update_rate, uint32_t queue_size, ros::NodeHandle nh = ros::NodeHandle())
+  TimeSequencer(F& f, rclcpp::Duration delay, rclcpp::Duration update_rate, uint32_t queue_size, rclcpp::Node::SharedPtr nh = std::make_shared<rclcpp::Node>("test_node"))
   : delay_(delay)
   , update_rate_(update_rate)
   , queue_size_(queue_size)
@@ -107,7 +108,7 @@ public:
    * \param queue_size The number of messages to store
    * \param nh (optional) The NodeHandle to use to create the ros::SteadyTimer that runs at update_rate
    */
-  TimeSequencer(ros::Duration delay, ros::Duration update_rate, uint32_t queue_size, ros::NodeHandle nh = ros::NodeHandle())
+  TimeSequencer(rclcpp::Duration delay, rclcpp::Duration update_rate, uint32_t queue_size, rclcpp::Node::SharedPtr nh = std::make_shared<rclcpp::Node>("test_node"))
   : delay_(delay)
   , update_rate_(update_rate)
   , queue_size_(queue_size)
@@ -123,20 +124,20 @@ public:
   void connectInput(F& f)
   {
     incoming_connection_.disconnect();
-    incoming_connection_ = f.registerCallback(typename SimpleFilter<M>::EventCallback(boost::bind(&TimeSequencer::cb, this, _1)));
+    incoming_connection_ = f.registerCallback(typename SimpleFilter<M>::EventCallback(std::bind(&TimeSequencer::cb, this, _1)));
   }
 
   ~TimeSequencer()
   {
-    update_timer_.stop();
+    update_timer_->cancel();
     incoming_connection_.disconnect();
   }
 
   void add(const EventType& evt)
   {
-    namespace mt = ros::message_traits;
+    namespace mt = message_filters::message_traits;
 
-    boost::mutex::scoped_lock lock(messages_mutex_);
+    std::lock_guard<std::mutex> lock(messages_mutex_);
     if (mt::TimeStamp<M>::value(*evt.getMessage()) < last_time_)
     {
       return;
@@ -165,7 +166,7 @@ private:
   public:
     bool operator()(const EventType& lhs, const EventType& rhs) const
     {
-      namespace mt = ros::message_traits;
+      namespace mt = message_filters::message_traits;
       return mt::TimeStamp<M>::value(*lhs.getMessage()) < mt::TimeStamp<M>::value(*rhs.getMessage());
     }
   };
@@ -179,18 +180,18 @@ private:
 
   void dispatch()
   {
-    namespace mt = ros::message_traits;
+    namespace mt = message_filters::message_traits;
 
     V_Message to_call;
 
     {
-      boost::mutex::scoped_lock lock(messages_mutex_);
+      std::lock_guard<std::mutex> lock(messages_mutex_);
 
       while (!messages_.empty())
       {
         const EventType& e = *messages_.begin();
-        ros::Time stamp = mt::TimeStamp<M>::value(*e.getMessage());
-        if (stamp + delay_ <= ros::Time::now())
+        rclcpp::Time stamp = mt::TimeStamp<M>::value(*e.getMessage());
+        if ((stamp + delay_) <= rclcpp::Clock().now())
         {
           last_time_ = stamp;
           to_call.push_back(e);
@@ -220,22 +221,22 @@ private:
 
   void init()
   {
-    update_timer_ = nh_.createSteadyTimer(ros::WallDuration(update_rate_.toSec()), &TimeSequencer::update, this);
+    update_timer_ = nh_->create_wall_timer(std::chrono::nanoseconds(update_rate_.nanoseconds()), [this]() {
+      dispatch();
+      });
   }
 
-  ros::Duration delay_;
-  ros::Duration update_rate_;
+  rclcpp::Duration delay_;
+  rclcpp::Duration update_rate_;
   uint32_t queue_size_;
-  ros::NodeHandle nh_;
-
-  ros::SteadyTimer update_timer_;
-
+  rclcpp::Node::SharedPtr nh_;
+  rclcpp::TimerBase::SharedPtr update_timer_;
   Connection incoming_connection_;
 
 
   S_Message messages_;
-  boost::mutex messages_mutex_;
-  ros::Time last_time_;
+  std::mutex messages_mutex_;
+  rclcpp::Time last_time_;
 };
 
 }

--- a/include/message_filters/time_synchronizer.h
+++ b/include/message_filters/time_synchronizer.h
@@ -38,13 +38,11 @@
 #include "synchronizer.h"
 #include "sync_policies/exact_time.h"
 
-#include <boost/shared_ptr.hpp>
-
-#include <ros/message_event.h>
+#include <memory>
+#include "message_event.h"
 
 namespace message_filters
 {
-namespace mpl = boost::mpl;
 
 /**
  * \brief Synchronizes up to 9 messages by their timestamps.
@@ -60,12 +58,12 @@ namespace mpl = boost::mpl;
  *
  * The input connections for the TimeSynchronizer object is the same signature as for roscpp subscription callbacks, ie.
 \verbatim
-void callback(const boost::shared_ptr<M const>&);
+void callback(const std::shared_ptr<M const>&);
 \endverbatim
  * The output connection for the TimeSynchronizer object is dependent on the number of messages being synchronized.  For
  * a 3-message synchronizer for example, it would be:
 \verbatim
-void callback(const boost::shared_ptr<M0 const>&, const boost::shared_ptr<M1 const>&, const boost::shared_ptr<M2 const>&);
+void callback(const std::shared_ptr<M0 const>&, const std::shared_ptr<M1 const>&, const std::shared_ptr<M2 const>&);
 \endverbatim
  * \section usage USAGE
  * Example usage would be:
@@ -87,15 +85,15 @@ class TimeSynchronizer : public Synchronizer<sync_policies::ExactTime<M0, M1, M2
 public:
   typedef sync_policies::ExactTime<M0, M1, M2, M3, M4, M5, M6, M7, M8> Policy;
   typedef Synchronizer<Policy> Base;
-  typedef boost::shared_ptr<M0 const> M0ConstPtr;
-  typedef boost::shared_ptr<M1 const> M1ConstPtr;
-  typedef boost::shared_ptr<M2 const> M2ConstPtr;
-  typedef boost::shared_ptr<M3 const> M3ConstPtr;
-  typedef boost::shared_ptr<M4 const> M4ConstPtr;
-  typedef boost::shared_ptr<M5 const> M5ConstPtr;
-  typedef boost::shared_ptr<M6 const> M6ConstPtr;
-  typedef boost::shared_ptr<M7 const> M7ConstPtr;
-  typedef boost::shared_ptr<M8 const> M8ConstPtr;
+  typedef std::shared_ptr<M0 const> M0ConstPtr;
+  typedef std::shared_ptr<M1 const> M1ConstPtr;
+  typedef std::shared_ptr<M2 const> M2ConstPtr;
+  typedef std::shared_ptr<M3 const> M3ConstPtr;
+  typedef std::shared_ptr<M4 const> M4ConstPtr;
+  typedef std::shared_ptr<M5 const> M5ConstPtr;
+  typedef std::shared_ptr<M6 const> M6ConstPtr;
+  typedef std::shared_ptr<M7 const> M7ConstPtr;
+  typedef std::shared_ptr<M8 const> M8ConstPtr;
 
   using Base::add;
   using Base::connectInput;

--- a/include/message_filters/time_synchronizer.h
+++ b/include/message_filters/time_synchronizer.h
@@ -56,7 +56,7 @@ namespace message_filters
  *
  * \section connections CONNECTIONS
  *
- * The input connections for the TimeSynchronizer object is the same signature as for roscpp subscription callbacks, ie.
+ * The input connections for the TimeSynchronizer object is the same signature as for rclcpp subscription callbacks, ie.
 \verbatim
 void callback(const std::shared_ptr<M const>&);
 \endverbatim

--- a/mainpage.dox
+++ b/mainpage.dox
@@ -28,8 +28,8 @@ Here's a simple example of using a Subscriber with a Cache:
 void myCallback(const robot_msgs::Pose::ConstPtr& pose)
 {}
 
-ros::NodeHandle nh;
-message_filters::Subscriber<robot_msgs::Pose> sub(nh, "pose_topic", 1);
+rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_node");
+message_filters::Subscriber<robot_msgs::Pose> sub(nh, "pose_topic");
 message_filters::Cache<robot_msgs::Pose> cache(sub, 10);
 cache.registerCallback(myCallback);
 \endverbatim

--- a/package.xml
+++ b/package.xml
@@ -1,29 +1,32 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
   <name>message_filters</name>
-  <version>1.14.2</version>
+  <version>2.0.0</version>
   <description>
-    A set of message filters which take in messages and may output those messages at a later time, based on the conditions that filter needs met.
+    A set of ROS2 message filters which take in messages and may output those messages at a later time, based on the conditions that filter needs met.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="ethan.gao@linux.intel.com">Ethan Gao</maintainer>
   <license>BSD</license>
-
-  <url>http://ros.org/wiki/message_filters</url>
-
+  <url>https://github.com/intel/ros2_message_filters</url>
   <author>Josh Faust</author>
   <author>Vijay Pradeep</author>
+  <author>Dirk Thomas</author>
+  <author>Jing Wang</author>
 
-  <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>boost</build_depend>
-  <build_depend>rosconsole</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>rostest</build_depend>
-  <build_depend>rosunit</build_depend>
+  <build_depend>builtin_interfaces</build_depend>
+  <build_depend>rclcpp</build_depend>
+  <build_depend>rclpy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
 
-  <run_depend>rosconsole</run_depend>
-  <run_depend>roscpp</run_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
 
   <export>
-    <rosdoc config="rosdoc.yaml"/>
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -19,12 +19,12 @@
   <build_depend>builtin_interfaces</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>rclpy</build_depend>
-  <build_depend>std_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>std_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -43,12 +43,6 @@ Connection::Connection(const VoidDisconnectFunction& func)
 {
 }
 
-Connection::Connection(const WithConnectionDisconnectFunction& func, boost::signals2::connection c)
-: connection_disconnect_(func)
-, connection_(c)
-{
-}
-
 void Connection::disconnect()
 {
   if (void_disconnect_)

--- a/test/test_approximate_time_policy.cpp
+++ b/test/test_approximate_time_policy.cpp
@@ -34,18 +34,18 @@
 *********************************************************************/
 
 #include <gtest/gtest.h>
+#include <rclcpp/rclcpp.hpp>
 #include "message_filters/synchronizer.h"
 #include "message_filters/sync_policies/approximate_time.h"
+#include "message_filters/message_traits.h"
 #include <vector>
-#include <ros/ros.h>
-//#include <pair>
 
 using namespace message_filters;
 using namespace message_filters::sync_policies;
 
 struct Header
 {
-  ros::Time stamp;
+  rclcpp::Time stamp;
 };
 
 
@@ -54,17 +54,16 @@ struct Msg
   Header header;
   int data;
 };
-typedef boost::shared_ptr<Msg> MsgPtr;
-typedef boost::shared_ptr<Msg const> MsgConstPtr;
-
-namespace ros
+typedef std::shared_ptr<Msg> MsgPtr;
+typedef std::shared_ptr<Msg const> MsgConstPtr;
+namespace message_filters
 {
 namespace message_traits
 {
 template<>
 struct TimeStamp<Msg>
 {
-  static ros::Time value(const Msg& m)
+  static rclcpp::Time value(const Msg& m)
   {
     return m.header.stamp;
   }
@@ -72,18 +71,18 @@ struct TimeStamp<Msg>
 }
 }
 
-typedef std::pair<ros::Time, ros::Time> TimePair;
-typedef std::pair<ros::Time, unsigned int> TimeAndTopic;
+typedef std::pair<rclcpp::Time, rclcpp::Time> TimePair;
+typedef std::pair<rclcpp::Time, unsigned int> TimeAndTopic;
 struct TimeQuad
 {
-  TimeQuad(ros::Time p, ros::Time q, ros::Time r, ros::Time s)
+  TimeQuad(rclcpp::Time p, rclcpp::Time q, rclcpp::Time r, rclcpp::Time s)
   {
     time[0] = p;
     time[1] = q;
     time[2] = r;
     time[3] = s;
   }
-  ros::Time time[4];
+  rclcpp::Time time[4];
 };
 
 
@@ -99,7 +98,7 @@ public:
 				  uint32_t queue_size) :
     input_(input), output_(output), output_position_(0), sync_(queue_size)
   {
-    sync_.registerCallback(boost::bind(&ApproximateTimeSynchronizerTest::callback, this, _1, _2));
+    sync_.registerCallback(std::bind(&ApproximateTimeSynchronizerTest::callback, this, _1, _2));
   }
 
   void callback(const MsgConstPtr& p, const MsgConstPtr& q)
@@ -120,13 +119,13 @@ public:
     {
       if (input_[i].second == 0)
       {
-        MsgPtr p(boost::make_shared<Msg>());
+        MsgPtr p(std::make_shared<Msg>());
         p->header.stamp = input_[i].first;
         sync_.add<0>(p);
       }
       else
       {
-        MsgPtr q(boost::make_shared<Msg>());
+        MsgPtr q(std::make_shared<Msg>());
         q->header.stamp = input_[i].first;
         sync_.add<1>(q);
       }
@@ -157,7 +156,7 @@ public:
 				      uint32_t queue_size) :
     input_(input), output_(output), output_position_(0), sync_(queue_size)
   {
-    sync_.registerCallback(boost::bind(&ApproximateTimeSynchronizerTestQuad::callback, this, _1, _2, _3, _4));
+    sync_.registerCallback(std::bind(&ApproximateTimeSynchronizerTestQuad::callback, this, _1, _2, _3, _4));
   }
 
     void callback(const MsgConstPtr& p, const MsgConstPtr& q, const MsgConstPtr& r, const MsgConstPtr& s)
@@ -180,7 +179,7 @@ public:
   {
     for (unsigned int i = 0; i < input_.size(); i++)
     {
-      MsgPtr p(boost::make_shared<Msg>());
+      MsgPtr p(std::make_shared<Msg>());
       p->header.stamp = input_[i].first;
       switch (input_[i].second)
       {
@@ -223,8 +222,8 @@ TEST(ApproxTimeSync, ExactMatch) {
   std::vector<TimeAndTopic> input;
   std::vector<TimePair> output;
 
-  ros::Time t(0, 0);
-  ros::Duration s(1, 0);
+  rclcpp::Time t(0, 0);
+  rclcpp::Duration s(1, 0);
 
   input.push_back(TimeAndTopic(t,0));     // a
   input.push_back(TimeAndTopic(t,1));   // A
@@ -249,8 +248,8 @@ TEST(ApproxTimeSync, PerfectMatch) {
   std::vector<TimeAndTopic> input;
   std::vector<TimePair> output;
 
-  ros::Time t(0, 0);
-  ros::Duration s(1, 0);
+  rclcpp::Time t(0, 0);
+  rclcpp::Duration s(1, 0);
 
   input.push_back(TimeAndTopic(t,0));     // a
   input.push_back(TimeAndTopic(t+s,1));   // A
@@ -274,8 +273,8 @@ TEST(ApproxTimeSync, ImperfectMatch) {
   std::vector<TimeAndTopic> input;
   std::vector<TimePair> output;
 
-  ros::Time t(0, 0);
-  ros::Duration s(1, 0);
+  rclcpp::Time t(0, 0);
+  rclcpp::Duration s(1, 0);
 
   input.push_back(TimeAndTopic(t,0));     // a
   input.push_back(TimeAndTopic(t+s,1));   // A
@@ -301,8 +300,8 @@ TEST(ApproxTimeSync, Acceleration) {
   std::vector<TimeAndTopic> input;
   std::vector<TimePair> output;
 
-  ros::Time t(0, 0);
-  ros::Duration s(1, 0);
+  rclcpp::Time t(0, 0);
+  rclcpp::Duration s(1, 0);
 
   input.push_back(TimeAndTopic(t,0));      // a
   input.push_back(TimeAndTopic(t+s*7,1));  // A
@@ -328,8 +327,8 @@ TEST(ApproxTimeSync, DroppedMessages) {
   std::vector<TimeAndTopic> input;
   std::vector<TimePair> output;
 
-  ros::Time t(0, 0);
-  ros::Duration s(1, 0);
+  rclcpp::Time t(0, 0);
+  rclcpp::Duration s(1, 0);
 
   input.push_back(TimeAndTopic(t,0));     // a
   input.push_back(TimeAndTopic(t+s,1));   // A
@@ -374,26 +373,26 @@ TEST(ApproxTimeSync, LongQueue) {
   std::vector<TimeAndTopic> input;
   std::vector<TimePair> output;
 
-  ros::Time t(0, 0);
-  ros::Duration s(1, 0);
+  rclcpp::Time t(0, 0);
+  rclcpp::Duration s(1, 0);
 
-  input.push_back(TimeAndTopic(t,0));     // a
-  input.push_back(TimeAndTopic(t+s,0));   // b
-  input.push_back(TimeAndTopic(t+s*2,0));   // c
-  input.push_back(TimeAndTopic(t+s*3,0));   // d
-  input.push_back(TimeAndTopic(t+s*4,0));   // e
-  input.push_back(TimeAndTopic(t+s*5,0));   // f
-  input.push_back(TimeAndTopic(t+s*6,0));   // g
-  input.push_back(TimeAndTopic(t+s*7,0));   // h
-  input.push_back(TimeAndTopic(t+s*8,0));   // i
-  input.push_back(TimeAndTopic(t+s*3,1));   // j
-  input.push_back(TimeAndTopic(t+s*9,0));   // k
-  input.push_back(TimeAndTopic(t+s*10,0));   // l
-  input.push_back(TimeAndTopic(t+s*11,0));   // m
-  input.push_back(TimeAndTopic(t+s*12,0));   // n
-  input.push_back(TimeAndTopic(t+s*10,1));   // o
-  input.push_back(TimeAndTopic(t+s*13,0));   // l
-  output.push_back(TimePair(t+s*10, t+s*10));
+  input.push_back(TimeAndTopic(t, 0));     // a
+  input.push_back(TimeAndTopic(t + rclcpp::Duration(1, 0), 0));   // b
+  input.push_back(TimeAndTopic(t + rclcpp::Duration(2, 0), 0));   // c
+  input.push_back(TimeAndTopic(t + rclcpp::Duration(3, 0), 0));   // d
+  input.push_back(TimeAndTopic(t + rclcpp::Duration(4, 0), 0));   // e
+  input.push_back(TimeAndTopic(t + rclcpp::Duration(5, 0), 0));   // f
+  input.push_back(TimeAndTopic(t + rclcpp::Duration(6, 0), 0));   // g
+  input.push_back(TimeAndTopic(t + rclcpp::Duration(7, 0), 0));   // h
+  input.push_back(TimeAndTopic(t + rclcpp::Duration(8, 0), 0));   // i
+  input.push_back(TimeAndTopic(t + rclcpp::Duration(3, 0), 1));   // j
+  input.push_back(TimeAndTopic(t + rclcpp::Duration(9, 0), 0));   // k
+  input.push_back(TimeAndTopic(t + rclcpp::Duration(10, 0), 0));   // l
+  input.push_back(TimeAndTopic(t + rclcpp::Duration(11, 0), 0));   // m
+  input.push_back(TimeAndTopic(t + rclcpp::Duration(12, 0), 0));   // n
+  input.push_back(TimeAndTopic(t + rclcpp::Duration(10, 0), 1));   // o
+  input.push_back(TimeAndTopic(t + rclcpp::Duration(13, 0), 0));   // l
+  output.push_back(TimePair(t + rclcpp::Duration(10, 0), t + rclcpp::Duration(10, 0)));
 
   ApproximateTimeSynchronizerTest sync_test(input, output, 5);
   sync_test.run();
@@ -411,15 +410,15 @@ TEST(ApproxTimeSync, DoublePublish) {
   std::vector<TimeAndTopic> input;
   std::vector<TimePair> output;
 
-  ros::Time t(0, 0);
-  ros::Duration s(1, 0);
+  rclcpp::Time t(0, 0);
+  rclcpp::Duration s(1, 0);
 
   input.push_back(TimeAndTopic(t,0));     // a
   input.push_back(TimeAndTopic(t+s,1));   // A
-  input.push_back(TimeAndTopic(t+s*3,1)); // B
-  input.push_back(TimeAndTopic(t+s*3,0)); // b
+  input.push_back(TimeAndTopic(t+rclcpp::Duration(3, 0), 1)); // B
+  input.push_back(TimeAndTopic(t+rclcpp::Duration(3, 0), 0)); // b
   output.push_back(TimePair(t, t+s));
-  output.push_back(TimePair(t+s*3, t+s*3));
+  output.push_back(TimePair(t+rclcpp::Duration(3, 0), t+rclcpp::Duration(3, 0)));
 
   ApproximateTimeSynchronizerTest sync_test(input, output, 10);
   sync_test.run();
@@ -439,27 +438,27 @@ TEST(ApproxTimeSync, FourTopics) {
   std::vector<TimeAndTopic> input;
   std::vector<TimeQuad> output;
 
-  ros::Time t(0, 0);
-  ros::Duration s(1, 0);
+  rclcpp::Time t(0, 0);
+  rclcpp::Duration s(1, 0);
 
   input.push_back(TimeAndTopic(t,0));     // a
   input.push_back(TimeAndTopic(t+s,1));   // b
-  input.push_back(TimeAndTopic(t+s*2,2));   // c
-  input.push_back(TimeAndTopic(t+s*3,3));   // d 
-  input.push_back(TimeAndTopic(t+s*5,0));   // e
-  input.push_back(TimeAndTopic(t+s*5,3));   // f
-  input.push_back(TimeAndTopic(t+s*6,1));   // g
-  input.push_back(TimeAndTopic(t+s*6,2));   // h
-  input.push_back(TimeAndTopic(t+s*8,0));   // i
-  input.push_back(TimeAndTopic(t+s*9,1));   // j
-  input.push_back(TimeAndTopic(t+s*10,2));   // k
-  input.push_back(TimeAndTopic(t+s*11,3));   // l
-  input.push_back(TimeAndTopic(t+s*10,0));   // m
-  input.push_back(TimeAndTopic(t+s*13,0));   // n
-  input.push_back(TimeAndTopic(t+s*14,1));   // o
-  output.push_back(TimeQuad(t, t+s, t+s*2, t+s*3));
-  output.push_back(TimeQuad(t+s*5, t+s*6, t+s*6, t+s*5));
-  output.push_back(TimeQuad(t+s*10, t+s*9, t+s*10, t+s*11));
+  input.push_back(TimeAndTopic(t+rclcpp::Duration(2, 0),2));   // c
+  input.push_back(TimeAndTopic(t+rclcpp::Duration(3, 0),3));   // d
+  input.push_back(TimeAndTopic(t+rclcpp::Duration(5, 0),0));   // e
+  input.push_back(TimeAndTopic(t+rclcpp::Duration(5, 0),3));   // f
+  input.push_back(TimeAndTopic(t+rclcpp::Duration(6, 0),1));   // g
+  input.push_back(TimeAndTopic(t+rclcpp::Duration(6, 0),2));   // h
+  input.push_back(TimeAndTopic(t+rclcpp::Duration(8, 0),0));   // i
+  input.push_back(TimeAndTopic(t+rclcpp::Duration(9, 0),1));   // j
+  input.push_back(TimeAndTopic(t+rclcpp::Duration(10, 0),2));   // k
+  input.push_back(TimeAndTopic(t+rclcpp::Duration(11, 0),3));   // l
+  input.push_back(TimeAndTopic(t+rclcpp::Duration(10, 0),0));   // m
+  input.push_back(TimeAndTopic(t+rclcpp::Duration(13, 0),0));   // n
+  input.push_back(TimeAndTopic(t+rclcpp::Duration(14, 0),1));   // o
+  output.push_back(TimeQuad(t, t+s, t+rclcpp::Duration(2, 0), t+rclcpp::Duration(3, 0)));
+  output.push_back(TimeQuad(t+rclcpp::Duration(5, 0), t+rclcpp::Duration(6, 0), t+rclcpp::Duration(6, 0), t+rclcpp::Duration(5, 0)));
+  output.push_back(TimeQuad(t+rclcpp::Duration(10, 0), t+rclcpp::Duration(9, 0), t+rclcpp::Duration(10, 0), t+rclcpp::Duration(11, 0)));
 
   ApproximateTimeSynchronizerTestQuad sync_test(input, output, 10);
   sync_test.run();
@@ -479,8 +478,8 @@ TEST(ApproxTimeSync, EarlyPublish) {
   std::vector<TimeAndTopic> input;
   std::vector<TimeQuad> output;
 
-  ros::Time t(0, 0);
-  ros::Duration s(1, 0);
+  rclcpp::Time t(0, 0);
+  rclcpp::Duration s(1, 0);
 
   input.push_back(TimeAndTopic(t,0));     // a
   input.push_back(TimeAndTopic(t+s,1));   // b
@@ -503,8 +502,8 @@ TEST(ApproxTimeSync, RateBound) {
   std::vector<TimeAndTopic> input;
   std::vector<TimePair> output;
 
-  ros::Time t(0, 0);
-  ros::Duration s(1, 0);
+  rclcpp::Time t(0, 0);
+  rclcpp::Duration s(1, 0);
 
   input.push_back(TimeAndTopic(t,0));     // a
   input.push_back(TimeAndTopic(t+s,1));   // A
@@ -536,8 +535,7 @@ TEST(ApproxTimeSync, RateBound) {
 
 int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);
-  ros::init(argc, argv, "blah");
-  ros::Time::init();
+  rclcpp::init(argc, argv);
 
   return RUN_ALL_TESTS();
 }

--- a/test/test_approximate_time_policy.cpp
+++ b/test/test_approximate_time_policy.cpp
@@ -40,6 +40,7 @@
 #include "message_filters/message_traits.h"
 #include <vector>
 
+using namespace std::placeholders;
 using namespace message_filters;
 using namespace message_filters::sync_policies;
 
@@ -484,7 +485,7 @@ TEST(ApproxTimeSync, EarlyPublish) {
   input.push_back(TimeAndTopic(t,0));     // a
   input.push_back(TimeAndTopic(t+s,1));   // b
   input.push_back(TimeAndTopic(t+s*2,2));   // c
-  input.push_back(TimeAndTopic(t+s*3,3));   // d 
+  input.push_back(TimeAndTopic(t+s*3,3));   // d
   input.push_back(TimeAndTopic(t+s*7,0));   // e
   output.push_back(TimeQuad(t, t+s, t+s*2, t+s*3));
 

--- a/test/test_chain.cpp
+++ b/test/test_chain.cpp
@@ -34,8 +34,7 @@
 
 #include <gtest/gtest.h>
 
-#include "ros/time.h"
-#include <ros/init.h>
+#include <rclcpp/rclcpp.hpp>
 #include "message_filters/chain.h"
 
 using namespace message_filters;
@@ -43,8 +42,8 @@ using namespace message_filters;
 struct Msg
 {
 };
-typedef boost::shared_ptr<Msg> MsgPtr;
-typedef boost::shared_ptr<Msg const> MsgConstPtr;
+typedef std::shared_ptr<Msg> MsgPtr;
+typedef std::shared_ptr<Msg const> MsgConstPtr;
 
 class Helper
 {
@@ -61,18 +60,18 @@ public:
   int32_t count_;
 };
 
-typedef boost::shared_ptr<PassThrough<Msg> > PassThroughPtr;
+typedef std::shared_ptr<PassThrough<Msg> > PassThroughPtr;
 
 TEST(Chain, simple)
 {
   Helper h;
   Chain<Msg> c;
-  c.addFilter(boost::make_shared<PassThrough<Msg> >());
-  c.registerCallback(boost::bind(&Helper::cb, &h));
+  c.addFilter(std::make_shared<PassThrough<Msg> >());
+  c.registerCallback(std::bind(&Helper::cb, &h));
 
-  c.add(boost::make_shared<Msg>());
+  c.add(std::make_shared<Msg>());
   EXPECT_EQ(h.count_, 1);
-  c.add(boost::make_shared<Msg>());
+  c.add(std::make_shared<Msg>());
   EXPECT_EQ(h.count_, 2);
 }
 
@@ -80,15 +79,15 @@ TEST(Chain, multipleFilters)
 {
   Helper h;
   Chain<Msg> c;
-  c.addFilter(boost::make_shared<PassThrough<Msg> >());
-  c.addFilter(boost::make_shared<PassThrough<Msg> >());
-  c.addFilter(boost::make_shared<PassThrough<Msg> >());
-  c.addFilter(boost::make_shared<PassThrough<Msg> >());
-  c.registerCallback(boost::bind(&Helper::cb, &h));
+  c.addFilter(std::make_shared<PassThrough<Msg> >());
+  c.addFilter(std::make_shared<PassThrough<Msg> >());
+  c.addFilter(std::make_shared<PassThrough<Msg> >());
+  c.addFilter(std::make_shared<PassThrough<Msg> >());
+  c.registerCallback(std::bind(&Helper::cb, &h));
 
-  c.add(boost::make_shared<Msg>());
+  c.add(std::make_shared<Msg>());
   EXPECT_EQ(h.count_, 1);
-  c.add(boost::make_shared<Msg>());
+  c.add(std::make_shared<Msg>());
   EXPECT_EQ(h.count_, 2);
 }
 
@@ -96,17 +95,17 @@ TEST(Chain, addingFilters)
 {
   Helper h;
   Chain<Msg> c;
-  c.addFilter(boost::make_shared<PassThrough<Msg> >());
-  c.addFilter(boost::make_shared<PassThrough<Msg> >());
-  c.registerCallback(boost::bind(&Helper::cb, &h));
+  c.addFilter(std::make_shared<PassThrough<Msg> >());
+  c.addFilter(std::make_shared<PassThrough<Msg> >());
+  c.registerCallback(std::bind(&Helper::cb, &h));
 
-  c.add(boost::make_shared<Msg>());
+  c.add(std::make_shared<Msg>());
   EXPECT_EQ(h.count_, 1);
 
-  c.addFilter(boost::make_shared<PassThrough<Msg> >());
-  c.addFilter(boost::make_shared<PassThrough<Msg> >());
+  c.addFilter(std::make_shared<PassThrough<Msg> >());
+  c.addFilter(std::make_shared<PassThrough<Msg> >());
 
-  c.add(boost::make_shared<Msg>());
+  c.add(std::make_shared<Msg>());
   EXPECT_EQ(h.count_, 2);
 }
 
@@ -114,15 +113,15 @@ TEST(Chain, inputFilter)
 {
   Helper h;
   Chain<Msg> c;
-  c.addFilter(boost::make_shared<PassThrough<Msg> >());
-  c.registerCallback(boost::bind(&Helper::cb, &h));
+  c.addFilter(std::make_shared<PassThrough<Msg> >());
+  c.registerCallback(std::bind(&Helper::cb, &h));
 
   PassThrough<Msg> p;
   c.connectInput(p);
-  p.add(boost::make_shared<Msg>());
+  p.add(std::make_shared<Msg>());
   EXPECT_EQ(h.count_, 1);
 
-  p.add(boost::make_shared<Msg>());
+  p.add(std::make_shared<Msg>());
   EXPECT_EQ(h.count_, 2);
 }
 
@@ -132,11 +131,11 @@ TEST(Chain, nonSharedPtrFilter)
   Chain<Msg> c;
   PassThrough<Msg> p;
   c.addFilter(&p);
-  c.registerCallback(boost::bind(&Helper::cb, &h));
+  c.registerCallback(std::bind(&Helper::cb, &h));
 
-  c.add(boost::make_shared<Msg>());
+  c.add(std::make_shared<Msg>());
   EXPECT_EQ(h.count_, 1);
-  c.add(boost::make_shared<Msg>());
+  c.add(std::make_shared<Msg>());
   EXPECT_EQ(h.count_, 2);
 }
 
@@ -146,7 +145,7 @@ TEST(Chain, retrieveFilter)
 
   ASSERT_FALSE(c.getFilter<PassThrough<Msg> >(0));
 
-  c.addFilter(boost::make_shared<PassThrough<Msg> >());
+  c.addFilter(std::make_shared<PassThrough<Msg> >());
 
   ASSERT_TRUE(c.getFilter<PassThrough<Msg> >(0));
   ASSERT_FALSE(c.getFilter<PassThrough<Msg> >(1));
@@ -159,7 +158,7 @@ TEST(Chain, retrieveFilterThroughBaseClass)
 
   ASSERT_FALSE(cb->getFilter<PassThrough<Msg> >(0));
 
-  c.addFilter(boost::make_shared<PassThrough<Msg> >());
+  c.addFilter(std::make_shared<PassThrough<Msg> >());
 
   ASSERT_TRUE(cb->getFilter<PassThrough<Msg> >(0));
   ASSERT_FALSE(cb->getFilter<PassThrough<Msg> >(1));
@@ -173,15 +172,14 @@ struct PTDerived : public PassThrough<Msg>
 TEST(Chain, retrieveBaseClass)
 {
   Chain<Msg> c;
-  c.addFilter(boost::make_shared<PTDerived>());
+  c.addFilter(std::make_shared<PTDerived>());
   ASSERT_TRUE(c.getFilter<PassThrough<Msg> >(0));
   ASSERT_TRUE(c.getFilter<PTDerived>(0));
 }
 
 int main(int argc, char **argv){
   testing::InitGoogleTest(&argc, argv);
-  ros::init(argc, argv, "blah");
-  ros::Time::init();
+  rclcpp::init(argc, argv);
   return RUN_ALL_TESTS();
 }
 

--- a/test/test_fuzz.cpp
+++ b/test/test_fuzz.cpp
@@ -1,0 +1,158 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2008, Willow Garage, Inc.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#include <gtest/gtest.h>
+#include <random>
+
+#include <rclcpp/rclcpp.hpp>
+#include "message_filters/subscriber.h"
+#include "message_filters/time_sequencer.h"
+#include "message_filters/time_synchronizer.h"
+#include "message_filters/chain.h"
+#include "sensor_msgs/msg/imu.hpp"
+
+using namespace message_filters;
+typedef sensor_msgs::msg::Imu Msg;
+typedef std::shared_ptr<sensor_msgs::msg::Imu const> MsgConstPtr;
+typedef std::shared_ptr<sensor_msgs::msg::Imu> MsgPtr;
+
+class Helper
+{
+public:
+  Helper()
+  : count_(0)
+  {}
+
+  void cb(const MsgConstPtr&)
+  {
+    ++count_;
+  }
+
+  void cb2(const MsgConstPtr&, const MsgConstPtr&)
+  {
+    ++count_;
+  }
+  int32_t count_;
+};
+
+static void fuzz_msg(MsgPtr msg) {
+    static std::random_device seeder;
+    std::mt19937 gen(seeder());
+    std::uniform_real_distribution<float> distr(1.0, 3.0);
+    msg->linear_acceleration.x = distr(gen);
+    msg->linear_acceleration.y = distr(gen);
+    msg->linear_acceleration.z = distr(gen);
+}
+
+TEST(TimeSequencer, fuzz_sequencer)
+{
+  rclcpp::Node::SharedPtr nh = std::make_shared<rclcpp::Node>("test_node");
+  TimeSequencer<Msg> seq(rclcpp::Duration(0, 10000000), rclcpp::Duration(0, 1000000), 10, nh);
+  Helper h;
+  seq.registerCallback(std::bind(&Helper::cb, &h, _1));
+  rclcpp::Clock ros_clock;
+  auto start = ros_clock.now();
+  auto msg = std::make_shared<Msg>();
+  while ((ros_clock.now() - start) < rclcpp::Duration(5.0, 0)) {
+    h.count_ = 0;
+    fuzz_msg(msg);
+    msg->header.stamp = ros_clock.now();
+    seq.add(msg);
+
+    rclcpp::Rate(20).sleep();
+    ASSERT_EQ(h.count_, 0);
+    rclcpp::spin_some(seq.get_node());
+    rclcpp::Rate(100).sleep();
+    rclcpp::spin_some(seq.get_node());
+    ASSERT_EQ(h.count_, 1);
+  }
+}
+
+TEST(TimeSynchronizer, fuzz_synchronizer)
+{
+  TimeSynchronizer<Msg, Msg> sync(1);
+  Helper h;
+  sync.registerCallback(std::bind(&Helper::cb2, &h, _1, _2));
+
+  rclcpp::Clock ros_clock;
+  auto start = ros_clock.now();
+  auto msg1 = std::make_shared<Msg>();
+  auto msg2 = std::make_shared<Msg>();
+  while ((ros_clock.now() - start) < rclcpp::Duration(5.0, 0))
+  {
+    h.count_ = 0;
+    fuzz_msg(msg1);
+    msg1->header.stamp = rclcpp::Clock().now();
+    fuzz_msg(msg2);
+    msg2->header.stamp = msg1->header.stamp;
+    sync.add0(msg1);
+    ASSERT_EQ(h.count_, 0);
+    sync.add1(msg2);
+    ASSERT_EQ(h.count_, 1);
+    rclcpp::Rate(50).sleep();
+  }
+}
+
+TEST(Subscriber, fuzz_subscriber)
+{
+  auto nh = std::make_shared<rclcpp::Node>("test_node");
+  Helper h;
+  Subscriber<Msg> sub(nh.get(), "test_topic");
+  sub.registerCallback(std::bind(&Helper::cb, &h, _1));
+  auto pub = nh->create_publisher<Msg>("test_topic");
+  rclcpp::Clock ros_clock;
+  auto start = ros_clock.now();
+  auto msg = std::make_shared<Msg>();
+  while ((ros_clock.now() - start) < rclcpp::Duration(5.0, 0))
+  {
+    h.count_ = 0;
+    fuzz_msg(msg);
+    msg->header.stamp = ros_clock.now();
+    pub->publish(msg);
+    rclcpp::Rate(50).sleep();
+    rclcpp::spin_some(nh);
+    ASSERT_EQ(h.count_, 1);
+  }
+  rclcpp::spin_some(nh);
+}
+
+int main(int argc, char **argv){
+  testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(argc, argv);
+
+  return RUN_ALL_TESTS();
+}
+
+

--- a/test/test_fuzz.cpp
+++ b/test/test_fuzz.cpp
@@ -126,11 +126,11 @@ TEST(TimeSynchronizer, fuzz_synchronizer)
 
 TEST(Subscriber, fuzz_subscriber)
 {
-  auto nh = std::make_shared<rclcpp::Node>("test_node");
+  auto node = std::make_shared<rclcpp::Node>("test_node");
   Helper h;
-  Subscriber<Msg> sub(nh.get(), "test_topic");
+  Subscriber<Msg> sub(node, "test_topic");
   sub.registerCallback(std::bind(&Helper::cb, &h, _1));
-  auto pub = nh->create_publisher<Msg>("test_topic");
+  auto pub = node->create_publisher<Msg>("test_topic");
   rclcpp::Clock ros_clock;
   auto start = ros_clock.now();
   auto msg = std::make_shared<Msg>();
@@ -141,10 +141,10 @@ TEST(Subscriber, fuzz_subscriber)
     msg->header.stamp = ros_clock.now();
     pub->publish(msg);
     rclcpp::Rate(50).sleep();
-    rclcpp::spin_some(nh);
+    rclcpp::spin_some(node);
     ASSERT_EQ(h.count_, 1);
   }
-  rclcpp::spin_some(nh);
+  rclcpp::spin_some(node);
 }
 
 int main(int argc, char **argv){

--- a/test/test_fuzz.cpp
+++ b/test/test_fuzz.cpp
@@ -77,8 +77,8 @@ static void fuzz_msg(MsgPtr msg) {
 
 TEST(TimeSequencer, fuzz_sequencer)
 {
-  rclcpp::Node::SharedPtr nh = std::make_shared<rclcpp::Node>("test_node");
-  TimeSequencer<Msg> seq(rclcpp::Duration(0, 10000000), rclcpp::Duration(0, 1000000), 10, nh);
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_node");
+  TimeSequencer<Msg> seq(rclcpp::Duration(0, 10000000), rclcpp::Duration(0, 1000000), 10, node);
   Helper h;
   seq.registerCallback(std::bind(&Helper::cb, &h, _1));
   rclcpp::Clock ros_clock;
@@ -92,9 +92,9 @@ TEST(TimeSequencer, fuzz_sequencer)
 
     rclcpp::Rate(20).sleep();
     ASSERT_EQ(h.count_, 0);
-    rclcpp::spin_some(seq.get_node());
+    rclcpp::spin_some(node);
     rclcpp::Rate(100).sleep();
-    rclcpp::spin_some(seq.get_node());
+    rclcpp::spin_some(node);
     ASSERT_EQ(h.count_, 1);
   }
 }
@@ -154,5 +154,3 @@ int main(int argc, char **argv){
 
   return RUN_ALL_TESTS();
 }
-
-

--- a/test/test_fuzz.cpp
+++ b/test/test_fuzz.cpp
@@ -42,6 +42,7 @@
 #include "message_filters/chain.h"
 #include "sensor_msgs/msg/imu.hpp"
 
+using namespace std::placeholders;
 using namespace message_filters;
 typedef sensor_msgs::msg::Imu Msg;
 typedef std::shared_ptr<sensor_msgs::msg::Imu const> MsgConstPtr;

--- a/test/test_subscriber.cpp
+++ b/test/test_subscriber.cpp
@@ -61,18 +61,18 @@ public:
 
 TEST(Subscriber, simple)
 {
-  auto nh = std::make_shared<rclcpp::Node>("test_node");
+  auto node = std::make_shared<rclcpp::Node>("test_node");
   Helper h;
-  Subscriber<Msg> sub(nh.get(), "test_topic");
+  Subscriber<Msg> sub(node, "test_topic");
   sub.registerCallback(std::bind(&Helper::cb, &h, _1));
-  auto pub = nh->create_publisher<Msg>("test_topic");
+  auto pub = node->create_publisher<Msg>("test_topic");
   rclcpp::Clock ros_clock;
   auto start = ros_clock.now();
   while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1.0, 0))
   {
     pub->publish(std::make_shared<Msg>());
     rclcpp::Rate(50).sleep();
-    rclcpp::spin_some(nh);
+    rclcpp::spin_some(node);
   }
 
   ASSERT_GT(h.count_, 0);
@@ -80,11 +80,11 @@ TEST(Subscriber, simple)
 
 TEST(Subscriber, subUnsubSub)
 {
-  auto nh = std::make_shared<rclcpp::Node>("test_node");
+  auto node = std::make_shared<rclcpp::Node>("test_node");
   Helper h;
-  Subscriber<Msg> sub(nh.get(), "test_topic");
+  Subscriber<Msg> sub(node, "test_topic");
   sub.registerCallback(std::bind(&Helper::cb, &h, _1));
-  auto pub = nh->create_publisher<Msg>("test_topic");
+  auto pub = node->create_publisher<Msg>("test_topic");
 
   sub.unsubscribe();
   sub.subscribe();
@@ -95,7 +95,7 @@ TEST(Subscriber, subUnsubSub)
   {
     pub->publish(std::make_shared<Msg>());
     rclcpp::Rate(50).sleep();
-    rclcpp::spin_some(nh);
+    rclcpp::spin_some(node);
   }
 
   ASSERT_GT(h.count_, 0);
@@ -103,12 +103,12 @@ TEST(Subscriber, subUnsubSub)
 
 TEST(Subscriber, subInChain)
 {
-  auto nh = std::make_shared<rclcpp::Node>("test_node");
+  auto node = std::make_shared<rclcpp::Node>("test_node");
   Helper h;
   Chain<Msg> c;
-  c.addFilter(std::make_shared<Subscriber<Msg> >(nh.get(), "test_topic"));
+  c.addFilter(std::make_shared<Subscriber<Msg> >(node, "test_topic"));
   c.registerCallback(std::bind(&Helper::cb, &h, _1));
-  auto pub = nh->create_publisher<Msg>("test_topic");
+  auto pub = node->create_publisher<Msg>("test_topic");
 
   rclcpp::Clock ros_clock;
   auto start = ros_clock.now();
@@ -116,7 +116,7 @@ TEST(Subscriber, subInChain)
   {
     pub->publish(std::make_shared<Msg>());
     rclcpp::Rate(50).sleep();
-    rclcpp::spin_some(nh);
+    rclcpp::spin_some(node);
   }
 
   ASSERT_GT(h.count_, 0);
@@ -144,15 +144,15 @@ struct NonConstHelper
 
 TEST(Subscriber, singleNonConstCallback)
 {
-  auto nh = std::make_shared<rclcpp::Node>("test_node");
+  auto node = std::make_shared<rclcpp::Node>("test_node");
   NonConstHelper h;
-  Subscriber<Msg> sub(nh.get(), "test_topic");
+  Subscriber<Msg> sub(node, "test_topic");
   sub.registerCallback(&NonConstHelper::cb, &h);
-  auto pub = nh->create_publisher<Msg>("test_topic");
+  auto pub = node->create_publisher<Msg>("test_topic");
   pub->publish(std::make_shared<Msg>());
 
   rclcpp::Rate(50).sleep();
-  rclcpp::spin_some(nh);
+  rclcpp::spin_some(node);
 
   ASSERT_TRUE(h.msg_);
   // ASSERT_EQ(msg.get(), h.msg_.get());
@@ -160,15 +160,16 @@ TEST(Subscriber, singleNonConstCallback)
 
 TEST(Subscriber, multipleNonConstCallbacksFilterSubscriber)
 {
-  auto nh = std::make_shared<rclcpp::Node>("test_node");
+  auto node = std::make_shared<rclcpp::Node>("test_node");
   NonConstHelper h, h2;
-  Subscriber<Msg> sub(nh.get(), "test_topic");
+  Subscriber<Msg> sub(node, "test_topic");
   sub.registerCallback(&NonConstHelper::cb, &h);
   sub.registerCallback(&NonConstHelper::cb, &h2);
-  auto pub = nh->create_publisher<Msg>("test_topic");
+  auto pub = node->create_publisher<Msg>("test_topic");
   pub->publish(std::make_shared<Msg>());
 
-  rclcpp::spin_some(nh);
+  rclcpp::Rate(50).sleep();
+  rclcpp::spin_some(node);
 
   ASSERT_TRUE(h.msg_);
   ASSERT_TRUE(h2.msg_);
@@ -179,15 +180,16 @@ TEST(Subscriber, multipleNonConstCallbacksFilterSubscriber)
 
 TEST(Subscriber, multipleCallbacksSomeFilterSomeDirect)
 {
-  auto nh = std::make_shared<rclcpp::Node>("test_node");
+  auto node = std::make_shared<rclcpp::Node>("test_node");
   NonConstHelper h, h2;
-  Subscriber<Msg> sub(nh.get(), "test_topic");
+  Subscriber<Msg> sub(node, "test_topic");
   sub.registerCallback(&NonConstHelper::cb, &h);
 
-  auto pub = nh->create_publisher<Msg>("test_topic");
+  auto pub = node->create_publisher<Msg>("test_topic");
   pub->publish(std::make_shared<Msg>());
 
-  rclcpp::spin_some(nh);
+  rclcpp::Rate(50).sleep();
+  rclcpp::spin_some(node);
 
   ASSERT_TRUE(h.msg_);
   ASSERT_TRUE(h2.msg_);
@@ -204,5 +206,3 @@ int main(int argc, char **argv){
 
   return RUN_ALL_TESTS();
 }
-
-

--- a/test/test_subscriber.cpp
+++ b/test/test_subscriber.cpp
@@ -149,13 +149,14 @@ TEST(Subscriber, singleNonConstCallback)
   Subscriber<Msg> sub(node, "test_topic");
   sub.registerCallback(&NonConstHelper::cb, &h);
   auto pub = node->create_publisher<Msg>("test_topic");
-  pub->publish(std::make_shared<Msg>());
+  auto msg = std::make_shared<Msg>();
+  pub->publish(msg);
 
   rclcpp::Rate(50).sleep();
   rclcpp::spin_some(node);
 
   ASSERT_TRUE(h.msg_);
-  // ASSERT_EQ(msg.get(), h.msg_.get());
+  ASSERT_EQ(*msg.get(), *h.msg_.get());
 }
 
 TEST(Subscriber, multipleNonConstCallbacksFilterSubscriber)
@@ -166,7 +167,8 @@ TEST(Subscriber, multipleNonConstCallbacksFilterSubscriber)
   sub.registerCallback(&NonConstHelper::cb, &h);
   sub.registerCallback(&NonConstHelper::cb, &h2);
   auto pub = node->create_publisher<Msg>("test_topic");
-  pub->publish(std::make_shared<Msg>());
+  auto msg = std::make_shared<Msg>();
+  pub->publish(msg);
 
   rclcpp::Rate(50).sleep();
   rclcpp::spin_some(node);
@@ -184,10 +186,14 @@ TEST(Subscriber, multipleCallbacksSomeFilterSomeDirect)
   NonConstHelper h, h2;
   Subscriber<Msg> sub(node, "test_topic");
   sub.registerCallback(&NonConstHelper::cb, &h);
+  auto sub2 = node->create_subscription<Msg>("test_topic", std::bind(&NonConstHelper::cb, &h2, std::placeholders::_1));
 
   auto pub = node->create_publisher<Msg>("test_topic");
-  pub->publish(std::make_shared<Msg>());
+  auto msg = std::make_shared<Msg>();
+  pub->publish(msg);
 
+  rclcpp::Rate(50).sleep();
+  rclcpp::spin_some(node);
   rclcpp::Rate(50).sleep();
   rclcpp::spin_some(node);
 

--- a/test/test_subscriber.cpp
+++ b/test/test_subscriber.cpp
@@ -64,7 +64,7 @@ TEST(Subscriber, simple)
   auto node = std::make_shared<rclcpp::Node>("test_node");
   Helper h;
   Subscriber<Msg> sub(node, "test_topic");
-  sub.registerCallback(std::bind(&Helper::cb, &h, _1));
+  sub.registerCallback(std::bind(&Helper::cb, &h, std::placeholders::_1));
   auto pub = node->create_publisher<Msg>("test_topic");
   rclcpp::Clock ros_clock;
   auto start = ros_clock.now();
@@ -83,7 +83,7 @@ TEST(Subscriber, subUnsubSub)
   auto node = std::make_shared<rclcpp::Node>("test_node");
   Helper h;
   Subscriber<Msg> sub(node, "test_topic");
-  sub.registerCallback(std::bind(&Helper::cb, &h, _1));
+  sub.registerCallback(std::bind(&Helper::cb, &h,  std::placeholders::_1));
   auto pub = node->create_publisher<Msg>("test_topic");
 
   sub.unsubscribe();
@@ -107,7 +107,7 @@ TEST(Subscriber, subInChain)
   Helper h;
   Chain<Msg> c;
   c.addFilter(std::make_shared<Subscriber<Msg> >(node, "test_topic"));
-  c.registerCallback(std::bind(&Helper::cb, &h, _1));
+  c.registerCallback(std::bind(&Helper::cb, &h,  std::placeholders::_1));
   auto pub = node->create_publisher<Msg>("test_topic");
 
   rclcpp::Clock ros_clock;

--- a/test/test_subscriber.cpp
+++ b/test/test_subscriber.cpp
@@ -51,7 +51,7 @@ public:
   : count_(0)
   {}
 
-  void cb(const MsgConstPtr&)
+  void cb(const MsgConstPtr)
   {
     ++count_;
   }
@@ -124,7 +124,7 @@ TEST(Subscriber, subInChain)
 
 struct ConstHelper
 {
-  void cb(const MsgConstPtr& msg)
+  void cb(const MsgConstPtr msg)
   {
     msg_ = msg;
   }
@@ -134,7 +134,7 @@ struct ConstHelper
 
 struct NonConstHelper
 {
-  void cb(const MsgPtr& msg)
+  void cb(const MsgPtr msg)
   {
     msg_ = msg;
   }

--- a/test/test_subscriber.xml
+++ b/test/test_subscriber.xml
@@ -1,4 +1,0 @@
-<launch>
-  <test test-name="test_subscriber" pkg="message_filters" type="message_filters-test_subscriber"/>
-</launch>
-

--- a/test/test_synchronizer.cpp
+++ b/test/test_synchronizer.cpp
@@ -34,16 +34,16 @@
 
 #include <gtest/gtest.h>
 
-#include "ros/time.h"
-#include <ros/init.h>
+#include <rclcpp/rclcpp.hpp>
 #include "message_filters/synchronizer.h"
-#include <boost/array.hpp>
+#include <array>
 
 using namespace message_filters;
+using namespace std::placeholders;
 
 struct Header
 {
-  ros::Time stamp;
+  rclcpp::Time stamp;
 };
 
 
@@ -52,8 +52,8 @@ struct Msg
   Header header;
   int data;
 };
-typedef boost::shared_ptr<Msg> MsgPtr;
-typedef boost::shared_ptr<Msg const> MsgConstPtr;
+typedef std::shared_ptr<Msg> MsgPtr;
+typedef std::shared_ptr<Msg const> MsgConstPtr;
 
 
 template<typename M0, typename M1, typename M2 = NullType, typename M3 = NullType, typename M4 = NullType,
@@ -80,12 +80,12 @@ struct NullPolicy : public PolicyBase<M0, M1, M2, M3, M4, M5, M6, M7, M8>
   }
 
   template<int i>
-  void add(const typename mpl::at_c<Events, i>::type&)
+  void add(const typename std::tuple_element<i, Events>::type&)
   {
     ++added_.at(i);
   }
 
-  boost::array<int32_t, RealTypeCount::value> added_;
+  std::array<int32_t, RealTypeCount::value> added_;
 };
 typedef NullPolicy<Msg, Msg> Policy2;
 typedef NullPolicy<Msg, Msg, Msg> Policy3;
@@ -151,7 +151,7 @@ void function5(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const
 void function6(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&) {}
 void function7(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&) {}
 void function8(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&) {}
-void function9(const MsgConstPtr&, MsgConstPtr, const MsgPtr&, MsgPtr, const Msg&, Msg, const ros::MessageEvent<Msg const>&, const ros::MessageEvent<Msg>&, const MsgConstPtr&) {}
+void function9(const MsgConstPtr&, MsgConstPtr, const MsgPtr&, MsgPtr, const Msg&, Msg, const MessageEvent<Msg const>&, const MessageEvent<Msg>&, const MsgConstPtr&) {}
 
 TEST(Synchronizer, compileFunction2)
 {
@@ -209,7 +209,7 @@ struct MethodHelper
   void method5(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&) {}
   void method6(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&) {}
   void method7(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&) {}
-  void method8(const MsgConstPtr&, MsgConstPtr, const MsgPtr&, MsgPtr, const Msg&, Msg, const ros::MessageEvent<Msg const>&, const ros::MessageEvent<Msg>&) {}
+  void method8(const MsgConstPtr&, MsgConstPtr, const MsgPtr&, MsgPtr, const Msg&, Msg, const MessageEvent<Msg const>&, const MessageEvent<Msg>&) {}
   // Can only do 8 here because the object instance counts as a parameter and bind only supports 9
 };
 
@@ -265,7 +265,7 @@ TEST(Synchronizer, compileMethod8)
 TEST(Synchronizer, add2)
 {
   Synchronizer<Policy2> sync;
-  MsgPtr m(boost::make_shared<Msg>());
+  MsgPtr m(std::make_shared<Msg>());
 
   ASSERT_EQ(sync.added_[0], 0);
   sync.add<0>(m);
@@ -278,7 +278,7 @@ TEST(Synchronizer, add2)
 TEST(Synchronizer, add3)
 {
   Synchronizer<Policy3> sync;
-  MsgPtr m(boost::make_shared<Msg>());
+  MsgPtr m(std::make_shared<Msg>());
 
   ASSERT_EQ(sync.added_[0], 0);
   sync.add<0>(m);
@@ -294,7 +294,7 @@ TEST(Synchronizer, add3)
 TEST(Synchronizer, add4)
 {
   Synchronizer<Policy4> sync;
-  MsgPtr m(boost::make_shared<Msg>());
+  MsgPtr m(std::make_shared<Msg>());
 
   ASSERT_EQ(sync.added_[0], 0);
   sync.add<0>(m);
@@ -313,7 +313,7 @@ TEST(Synchronizer, add4)
 TEST(Synchronizer, add5)
 {
   Synchronizer<Policy5> sync;
-  MsgPtr m(boost::make_shared<Msg>());
+  MsgPtr m(std::make_shared<Msg>());
 
   ASSERT_EQ(sync.added_[0], 0);
   sync.add<0>(m);
@@ -335,7 +335,7 @@ TEST(Synchronizer, add5)
 TEST(Synchronizer, add6)
 {
   Synchronizer<Policy6> sync;
-  MsgPtr m(boost::make_shared<Msg>());
+  MsgPtr m(std::make_shared<Msg>());
 
   ASSERT_EQ(sync.added_[0], 0);
   sync.add<0>(m);
@@ -360,7 +360,7 @@ TEST(Synchronizer, add6)
 TEST(Synchronizer, add7)
 {
   Synchronizer<Policy7> sync;
-  MsgPtr m(boost::make_shared<Msg>());
+  MsgPtr m(std::make_shared<Msg>());
 
   ASSERT_EQ(sync.added_[0], 0);
   sync.add<0>(m);
@@ -388,7 +388,7 @@ TEST(Synchronizer, add7)
 TEST(Synchronizer, add8)
 {
   Synchronizer<Policy8> sync;
-  MsgPtr m(boost::make_shared<Msg>());
+  MsgPtr m(std::make_shared<Msg>());
 
   ASSERT_EQ(sync.added_[0], 0);
   sync.add<0>(m);
@@ -419,7 +419,7 @@ TEST(Synchronizer, add8)
 TEST(Synchronizer, add9)
 {
   Synchronizer<Policy9> sync;
-  MsgPtr m(boost::make_shared<Msg>());
+  MsgPtr m(std::make_shared<Msg>());
 
   ASSERT_EQ(sync.added_[0], 0);
   sync.add<0>(m);
@@ -452,11 +452,6 @@ TEST(Synchronizer, add9)
 
 int main(int argc, char **argv){
   testing::InitGoogleTest(&argc, argv);
-  ros::init(argc, argv, "blah");
-
-  ros::Time::init();
-  ros::Time::setNow(ros::Time());
-
   return RUN_ALL_TESTS();
 }
 

--- a/test/time_sequencer_unittest.cpp
+++ b/test/time_sequencer_unittest.cpp
@@ -85,7 +85,8 @@ public:
 
 TEST(TimeSequencer, simple)
 {
-  TimeSequencer<Msg> seq(rclcpp::Duration(1, 0), rclcpp::Duration(0, 10000000), 10);
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_node");
+  TimeSequencer<Msg> seq(rclcpp::Duration(1, 0), rclcpp::Duration(0, 10000000), 10, node);
   Helper h;
   seq.registerCallback(std::bind(&Helper::cb, &h, _1));
   MsgPtr msg(std::make_shared<Msg>());
@@ -93,19 +94,20 @@ TEST(TimeSequencer, simple)
   seq.add(msg);
 
   rclcpp::Rate(10).sleep();
-  rclcpp::spin_some(seq.get_node());
+  rclcpp::spin_some(node);
   ASSERT_EQ(h.count_, 0);
 
   rclcpp::Rate(1).sleep();
-  rclcpp::spin_some(seq.get_node());
+  rclcpp::spin_some(node);
 
   ASSERT_EQ(h.count_, 1);
 }
 
 TEST(TimeSequencer, compilation)
 {
-  TimeSequencer<Msg> seq(rclcpp::Duration(1, 0), rclcpp::Duration(0, 10000000), 10);
-  TimeSequencer<Msg> seq2(rclcpp::Duration(1, 0), rclcpp::Duration(0, 10000000), 10);
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_node");
+  TimeSequencer<Msg> seq(rclcpp::Duration(1, 0), rclcpp::Duration(0, 10000000), 10, node);
+  TimeSequencer<Msg> seq2(rclcpp::Duration(1, 0), rclcpp::Duration(0, 10000000), 10, node);
   seq2.connectInput(seq);
 }
 
@@ -148,5 +150,3 @@ int main(int argc, char **argv){
 
   return RUN_ALL_TESTS();
 }
-
-

--- a/test/time_sequencer_unittest.cpp
+++ b/test/time_sequencer_unittest.cpp
@@ -86,7 +86,7 @@ public:
 TEST(TimeSequencer, simple)
 {
   rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_node");
-  TimeSequencer<Msg> seq(rclcpp::Duration(1, 0), rclcpp::Duration(0, 10000000), 10, node);
+  TimeSequencer<Msg> seq(rclcpp::Duration(0, 250000000), rclcpp::Duration(0, 10000000), 10, node);
   Helper h;
   seq.registerCallback(std::bind(&Helper::cb, &h, _1));
   MsgPtr msg(std::make_shared<Msg>());
@@ -97,7 +97,8 @@ TEST(TimeSequencer, simple)
   rclcpp::spin_some(node);
   ASSERT_EQ(h.count_, 0);
 
-  rclcpp::Rate(1).sleep();
+  // Must be longer than the first duration above
+  rclcpp::Rate(3).sleep();
   rclcpp::spin_some(node);
 
   ASSERT_EQ(h.count_, 1);

--- a/test/time_sequencer_unittest.cpp
+++ b/test/time_sequencer_unittest.cpp
@@ -88,7 +88,7 @@ TEST(TimeSequencer, simple)
   rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_node");
   TimeSequencer<Msg> seq(rclcpp::Duration(0, 250000000), rclcpp::Duration(0, 10000000), 10, node);
   Helper h;
-  seq.registerCallback(std::bind(&Helper::cb, &h, _1));
+  seq.registerCallback(std::bind(&Helper::cb, &h, std::placeholders::_1));
   MsgPtr msg(std::make_shared<Msg>());
   msg->header.stamp = rclcpp::Clock().now();
   seq.add(msg);

--- a/test/time_sequencer_unittest.xml
+++ b/test/time_sequencer_unittest.xml
@@ -1,4 +1,0 @@
-<launch>
-  <test test-name="time_sequencer" pkg="message_filters" type="message_filters-time_sequencer_unittest"/>
-</launch>
-

--- a/test/time_synchronizer_unittest.cpp
+++ b/test/time_synchronizer_unittest.cpp
@@ -34,16 +34,16 @@
 
 #include <gtest/gtest.h>
 
-#include "ros/time.h"
 #include "message_filters/time_synchronizer.h"
 #include "message_filters/pass_through.h"
-#include <ros/init.h>
+#include "message_filters/message_traits.h"
+#include <rclcpp/rclcpp.hpp>
 
 using namespace message_filters;
 
 struct Header
 {
-  ros::Time stamp;
+  rclcpp::Time stamp;
 };
 
 
@@ -52,17 +52,17 @@ struct Msg
   Header header;
   int data;
 };
-typedef boost::shared_ptr<Msg> MsgPtr;
-typedef boost::shared_ptr<Msg const> MsgConstPtr;
+typedef std::shared_ptr<Msg> MsgPtr;
+typedef std::shared_ptr<Msg const> MsgConstPtr;
 
-namespace ros
+namespace message_filters
 {
 namespace message_traits
 {
 template<>
 struct TimeStamp<Msg>
 {
-  static ros::Time value(const Msg& m)
+  static rclcpp::Time value(const Msg& m)
   {
     return m.header.stamp;
   }
@@ -147,7 +147,7 @@ void function5(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const
 void function6(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&) {}
 void function7(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&) {}
 void function8(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&) {}
-void function9(const MsgConstPtr&, MsgConstPtr, const MsgPtr&, MsgPtr, const Msg&, Msg, const ros::MessageEvent<Msg const>&, const ros::MessageEvent<Msg>&, const MsgConstPtr&) {}
+void function9(const MsgConstPtr&, MsgConstPtr, const MsgPtr&, MsgPtr, const Msg&, Msg, const MessageEvent<Msg const>&, const MessageEvent<Msg>&, const MsgConstPtr&) {}
 
 TEST(TimeSynchronizer, compileFunction2)
 {
@@ -205,7 +205,7 @@ struct MethodHelper
   void method5(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&) {}
   void method6(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&) {}
   void method7(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&) {}
-  void method8(const MsgConstPtr&, MsgConstPtr, const MsgPtr&, MsgPtr, const Msg&, Msg, const ros::MessageEvent<Msg const>&, const ros::MessageEvent<Msg>&) {}
+  void method8(const MsgConstPtr&, MsgConstPtr, const MsgPtr&, MsgPtr, const Msg&, Msg, const MessageEvent<Msg const>&, const MessageEvent<Msg>&) {}
   // Can only do 8 here because the object instance counts as a parameter and bind only supports 9
 };
 
@@ -262,9 +262,9 @@ TEST(TimeSynchronizer, immediate2)
 {
   TimeSynchronizer<Msg, Msg> sync(1);
   Helper h;
-  sync.registerCallback(boost::bind(&Helper::cb, &h));
-  MsgPtr m(boost::make_shared<Msg>());
-  m->header.stamp = ros::Time::now();
+  sync.registerCallback(std::bind(&Helper::cb, &h));
+  MsgPtr m(std::make_shared<Msg>());
+  m->header.stamp = rclcpp::Clock().now();
 
   sync.add0(m);
   ASSERT_EQ(h.count_, 0);
@@ -276,9 +276,9 @@ TEST(TimeSynchronizer, immediate3)
 {
   TimeSynchronizer<Msg, Msg, Msg> sync(1);
   Helper h;
-  sync.registerCallback(boost::bind(&Helper::cb, &h));
-  MsgPtr m(boost::make_shared<Msg>());
-  m->header.stamp = ros::Time::now();
+  sync.registerCallback(std::bind(&Helper::cb, &h));
+  MsgPtr m(std::make_shared<Msg>());
+  m->header.stamp = rclcpp::Clock().now();
 
   sync.add0(m);
   ASSERT_EQ(h.count_, 0);
@@ -292,9 +292,9 @@ TEST(TimeSynchronizer, immediate4)
 {
   TimeSynchronizer<Msg, Msg, Msg, Msg> sync(1);
   Helper h;
-  sync.registerCallback(boost::bind(&Helper::cb, &h));
-  MsgPtr m(boost::make_shared<Msg>());
-  m->header.stamp = ros::Time::now();
+  sync.registerCallback(std::bind(&Helper::cb, &h));
+  MsgPtr m(std::make_shared<Msg>());
+  m->header.stamp = rclcpp::Clock().now();
 
   sync.add0(m);
   ASSERT_EQ(h.count_, 0);
@@ -310,9 +310,9 @@ TEST(TimeSynchronizer, immediate5)
 {
   TimeSynchronizer<Msg, Msg, Msg, Msg, Msg> sync(1);
   Helper h;
-  sync.registerCallback(boost::bind(&Helper::cb, &h));
-  MsgPtr m(boost::make_shared<Msg>());
-  m->header.stamp = ros::Time::now();
+  sync.registerCallback(std::bind(&Helper::cb, &h));
+  MsgPtr m(std::make_shared<Msg>());
+  m->header.stamp = rclcpp::Clock().now();
 
   sync.add0(m);
   ASSERT_EQ(h.count_, 0);
@@ -330,9 +330,9 @@ TEST(TimeSynchronizer, immediate6)
 {
   TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
   Helper h;
-  sync.registerCallback(boost::bind(&Helper::cb, &h));
-  MsgPtr m(boost::make_shared<Msg>());
-  m->header.stamp = ros::Time::now();
+  sync.registerCallback(std::bind(&Helper::cb, &h));
+  MsgPtr m(std::make_shared<Msg>());
+  m->header.stamp = rclcpp::Clock().now();
 
   sync.add0(m);
   ASSERT_EQ(h.count_, 0);
@@ -352,9 +352,9 @@ TEST(TimeSynchronizer, immediate7)
 {
   TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
   Helper h;
-  sync.registerCallback(boost::bind(&Helper::cb, &h));
-  MsgPtr m(boost::make_shared<Msg>());
-  m->header.stamp = ros::Time::now();
+  sync.registerCallback(std::bind(&Helper::cb, &h));
+  MsgPtr m(std::make_shared<Msg>());
+  m->header.stamp = rclcpp::Clock().now();
 
   sync.add0(m);
   ASSERT_EQ(h.count_, 0);
@@ -376,9 +376,9 @@ TEST(TimeSynchronizer, immediate8)
 {
   TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
   Helper h;
-  sync.registerCallback(boost::bind(&Helper::cb, &h));
-  MsgPtr m(boost::make_shared<Msg>());
-  m->header.stamp = ros::Time::now();
+  sync.registerCallback(std::bind(&Helper::cb, &h));
+  MsgPtr m(std::make_shared<Msg>());
+  m->header.stamp = rclcpp::Clock().now();
 
   sync.add0(m);
   ASSERT_EQ(h.count_, 0);
@@ -402,9 +402,9 @@ TEST(TimeSynchronizer, immediate9)
 {
   TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
   Helper h;
-  sync.registerCallback(boost::bind(&Helper::cb, &h));
-  MsgPtr m(boost::make_shared<Msg>());
-  m->header.stamp = ros::Time::now();
+  sync.registerCallback(std::bind(&Helper::cb, &h));
+  MsgPtr m(std::make_shared<Msg>());
+  m->header.stamp = rclcpp::Clock().now();
 
   sync.add0(m);
   ASSERT_EQ(h.count_, 0);
@@ -434,15 +434,15 @@ TEST(TimeSynchronizer, multipleTimes)
 {
   TimeSynchronizer<Msg, Msg, Msg> sync(2);
   Helper h;
-  sync.registerCallback(boost::bind(&Helper::cb, &h));
-  MsgPtr m(boost::make_shared<Msg>());
-  m->header.stamp = ros::Time();
+  sync.registerCallback(std::bind(&Helper::cb, &h));
+  MsgPtr m(std::make_shared<Msg>());
+  m->header.stamp = rclcpp::Time();
 
   sync.add0(m);
   ASSERT_EQ(h.count_, 0);
 
-  m = boost::make_shared<Msg>();
-  m->header.stamp = ros::Time(0.1);
+  m = std::make_shared<Msg>();
+  m->header.stamp = rclcpp::Time(100000000);
   sync.add1(m);
   ASSERT_EQ(h.count_, 0);
   sync.add0(m);
@@ -455,22 +455,22 @@ TEST(TimeSynchronizer, queueSize)
 {
   TimeSynchronizer<Msg, Msg, Msg> sync(1);
   Helper h;
-  sync.registerCallback(boost::bind(&Helper::cb, &h));
-  MsgPtr m(boost::make_shared<Msg>());
-  m->header.stamp = ros::Time();
+  sync.registerCallback(std::bind(&Helper::cb, &h));
+  MsgPtr m(std::make_shared<Msg>());
+  m->header.stamp = rclcpp::Time();
 
   sync.add0(m);
   ASSERT_EQ(h.count_, 0);
   sync.add1(m);
   ASSERT_EQ(h.count_, 0);
 
-  m = boost::make_shared<Msg>();
-  m->header.stamp = ros::Time(0.1);
+  m = std::make_shared<Msg>();
+  m->header.stamp = rclcpp::Time(100000000);
   sync.add1(m);
   ASSERT_EQ(h.count_, 0);
 
-  m = boost::make_shared<Msg>();
-  m->header.stamp = ros::Time(0);
+  m = std::make_shared<Msg>();
+  m->header.stamp = rclcpp::Time();
   sync.add1(m);
   ASSERT_EQ(h.count_, 0);
   sync.add2(m);
@@ -481,14 +481,14 @@ TEST(TimeSynchronizer, dropCallback)
 {
   TimeSynchronizer<Msg, Msg> sync(1);
   Helper h;
-  sync.registerCallback(boost::bind(&Helper::cb, &h));
-  sync.registerDropCallback(boost::bind(&Helper::dropcb, &h));
-  MsgPtr m(boost::make_shared<Msg>());
-  m->header.stamp = ros::Time();
+  sync.registerCallback(std::bind(&Helper::cb, &h));
+  sync.registerDropCallback(std::bind(&Helper::dropcb, &h));
+  MsgPtr m(std::make_shared<Msg>());
+  m->header.stamp = rclcpp::Time(0, 0);
 
   sync.add0(m);
   ASSERT_EQ(h.drop_count_, 0);
-  m->header.stamp = ros::Time(0.1);
+  m->header.stamp = rclcpp::Time(100000000);
   sync.add0(m);
 
   ASSERT_EQ(h.drop_count_, 1);
@@ -496,14 +496,14 @@ TEST(TimeSynchronizer, dropCallback)
 
 struct EventHelper
 {
-  void callback(const ros::MessageEvent<Msg const>& e1, const ros::MessageEvent<Msg const>& e2)
+  void callback(const MessageEvent<Msg const>& e1, const MessageEvent<Msg const>& e2)
   {
     e1_ = e1;
     e2_ = e2;
   }
 
-  ros::MessageEvent<Msg const> e1_;
-  ros::MessageEvent<Msg const> e2_;
+  MessageEvent<Msg const> e1_;
+  MessageEvent<Msg const> e2_;
 };
 
 TEST(TimeSynchronizer, eventInEventOut)
@@ -511,7 +511,7 @@ TEST(TimeSynchronizer, eventInEventOut)
   TimeSynchronizer<Msg, Msg> sync(2);
   EventHelper h;
   sync.registerCallback(&EventHelper::callback, &h);
-  ros::MessageEvent<Msg const> evt(boost::make_shared<Msg>(), ros::Time(4));
+  MessageEvent<Msg const> evt(std::make_shared<Msg>(), rclcpp::Time(4, 0));
 
   sync.add<0>(evt);
   sync.add<1>(evt);
@@ -527,9 +527,9 @@ TEST(TimeSynchronizer, connectConstructor)
   PassThrough<Msg> pt1, pt2;
   TimeSynchronizer<Msg, Msg> sync(pt1, pt2, 1);
   Helper h;
-  sync.registerCallback(boost::bind(&Helper::cb, &h));
-  MsgPtr m(boost::make_shared<Msg>());
-  m->header.stamp = ros::Time::now();
+  sync.registerCallback(std::bind(&Helper::cb, &h));
+  MsgPtr m(std::make_shared<Msg>());
+  m->header.stamp = rclcpp::Clock().now();
 
   pt1.add(m);
   ASSERT_EQ(h.count_, 0);
@@ -541,11 +541,7 @@ TEST(TimeSynchronizer, connectConstructor)
 
 int main(int argc, char **argv){
   testing::InitGoogleTest(&argc, argv);
-  ros::init(argc, argv, "blah");
-
-  ros::Time::init();
-  ros::Time::setNow(ros::Time());
-
+  rclcpp::init(argc, argv);
   return RUN_ALL_TESTS();
 }
 


### PR DESCRIPTION
This is a rework of #4 for better traceability of code origin as well as some cleanup.

I've been splitting it into many different commits for easier auditing. I've separated out copying in files from different locations from converting them to the new syntax.

After that restructuring I've then gone through and been doing reviews of the changes. 

There's now more commits in the history than I plan to have at the end. Several of the later ones are reverting non-essential changes earlier. I plan to find where they were changed and squash the revert of the changes down.



## Outstanding TODOs 

implement correct solutions for 

* [x] ROS_WARN -> cout
* [x] ROS_ASSERT -> assert
* [x] ROS_BREAK -> std::abort
* [x] Commented asserts such as in test_subscriber.cpp
* [x] time_sequencer_unittest.cpp:135
  ros::Time::setNow(ros::Time::now() + ros::Duration(2));
removed from test.



@j-rivero @mjcarroll @gaoethan  If you could take a look and give any feedback/comments suggestions I'll pull them in as i finish my audit and cleanup before a final review.

@mjcarroll Please look closely at c7f8d24 and https://github.com/ros2/message_filters/commit/abe143a5d197e71f54b1e866c636e1e58d282cd8 It's a slight change in the API that I made based on talking with @wjwwood 