### PR TITLE
enable message_filters support of python interfaces and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcutils)
 find_package(builtin_interfaces REQUIRED)
+find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
 include_directories(include)
@@ -23,6 +24,7 @@ add_library(${PROJECT_NAME} SHARED src/connection.cpp)
 ament_target_dependencies(${PROJECT_NAME}
   "rclcpp"
   "rcutils"
+  "std_msgs"
   "builtin_interfaces"
   "sensor_msgs")
 
@@ -108,6 +110,11 @@ if(BUILD_TESTING)
     target_link_libraries(${PROJECT_NAME}-test_fuzz ${PROJECT_NAME})
   endif()
 
+  # python tests with python interfaces of message filters
+  find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(directed.py "test/directed.py")
+  ament_add_pytest_test(test_approxsync.py "test/test_approxsync.py")
+  ament_add_pytest_test(test_message_filters_cache.py "test/test_message_filters_cache.py")
 endif()
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcutils)
 find_package(builtin_interfaces REQUIRED)
-find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
 include_directories(include)
@@ -24,7 +23,6 @@ add_library(${PROJECT_NAME} SHARED src/connection.cpp)
 ament_target_dependencies(${PROJECT_NAME}
   "rclcpp"
   "rcutils"
-  "std_msgs"
   "builtin_interfaces"
   "sensor_msgs")
 

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   <build_depend>builtin_interfaces</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>rclpy</build_depend>
+  <build_depend>std_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -19,7 +19,6 @@
   <build_depend>builtin_interfaces</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>rclpy</build_depend>
-  <build_depend>std_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -35,6 +35,11 @@ import itertools
 import threading
 import rclpy
 
+from rclpy.clock import ROSClock
+from rclpy.duration import Duration
+from rclpy.time import Time
+
+
 class SimpleFilter(object):
 
     def __init__(self):
@@ -118,7 +123,8 @@ class Cache(SimpleFilter):
                               "Use the 'allow_headerless' constructor option to "
                               "auto-assign ROS time to headerless messages.")
                 return
-            stamp = rospy.Time.now()
+
+            stamp = ROSClock().now()
         else:
             stamp = msg.header.stamp
 
@@ -238,7 +244,7 @@ class ApproximateTimeSynchronizer(TimeSynchronizer):
 
     def __init__(self, fs, queue_size, slop, allow_headerless=False):
         TimeSynchronizer.__init__(self, fs, queue_size)
-        self.slop = rospy.Duration.from_sec(slop)
+        self.slop = Duration(seconds=slop).nanoseconds
         self.allow_headerless = allow_headerless
 
     def add(self, msg, my_queue, my_queue_index=None):
@@ -248,7 +254,8 @@ class ApproximateTimeSynchronizer(TimeSynchronizer):
                               "Use the 'allow_headerless' constructor option to "
                               "auto-assign ROS time to headerless messages.")
                 return
-            stamp = rospy.Time.now()
+
+            stamp = ROSClock().now().nanoseconds
         else:
             stamp = msg.header.stamp
 

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -49,7 +49,8 @@ class SimpleFilter(object):
     def registerCallback(self, cb, *args):
         """
         Register a callback function `cb` to be called when this filter
-        has output. The filter calls the function ``cb`` with a filter-dependent
+        has output.
+        The filter calls the function ``cb`` with a filter-dependent
         list of arguments,followed by the call-supplied arguments ``args``.
         """
 

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -291,7 +291,7 @@ class ApproximateTimeSynchronizer(TimeSynchronizer):
                 return
             topic_stamps = sorted(topic_stamps, key=lambda x: x[1])
             stamps.append(topic_stamps)
-        for vv in itertools.product(*[zip(*s)[0] for s in stamps]):
+        for vv in itertools.product(*[list(zip(*s))[0] for s in stamps]):
             vv = list(vv)
             # insert the new message
             if my_queue_index is not None:

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -49,9 +49,8 @@ class SimpleFilter(object):
     def registerCallback(self, cb, *args):
         """
         Register a callback function `cb` to be called when this filter
-        has output.
-        The filter calls the function ``cb`` with a filter-dependent list of arguments,
-        followed by the call-supplied arguments ``args``.
+        has output. The filter calls the function ``cb`` with a filter-dependent
+        list of arguments,followed by the call-supplied arguments ``args``.
         """
 
         conn = len(self.callbacks)
@@ -65,10 +64,10 @@ class SimpleFilter(object):
 class Subscriber(SimpleFilter):
     
     """
-    ROS subscription filter.  Identical arguments as :class:`rospy.Subscriber`.
+    ROS2 subscription filter,Identical arguments as :class:`rclpy.Subscriber`.
 
     This class acts as a highest-level filter, simply passing messages
-    from a ROS subscription through to the filters which have connected
+    from a ROS2 subscription through to the filters which have connected
     to it.
     """
     def __init__(self, *args, **kwargs):
@@ -120,10 +119,10 @@ class Cache(SimpleFilter):
     def add(self, msg):
         if not hasattr(msg, 'header') or not hasattr(msg.header, 'stamp'):
             if not self.allow_headerless:
-                rclpy.logging._root_logger.log("can not use message filters "
-                              "for messages without timestamp infomation when "
-                              "'allow_headerless' is disabled. auto assign "
-                              "ROSTIME to headerless messages once enabling "
+                rclpy.logging._root_logger.log("can not use message filters"
+                              "for messages without timestamp infomation when"
+                              "'allow_headerless' is disabled. auto assign"
+                              "ROSTIME to headerless messages once enabling"
                               "constructor option of 'allow_headerless'.",
                               LoggingSeverity.INFO)
 
@@ -192,11 +191,11 @@ class TimeSynchronizer(SimpleFilter):
     Synchronizes messages by their timestamps.
 
     :class:`TimeSynchronizer` synchronizes incoming message filters by the
-    timestamps contained in their messages' headers. TimeSynchronizer
-    listens on multiple input message filters ``fs``, and invokes the callback
-    when it has a collection of messages with matching timestamps.
+    timestamps contained in their messages' headers. TimeSynchronizer listens
+    on multiple input message filters ``fs``, and invokes the callback when
+    it has a collection of messages with matching timestamps.
 
-    The signature of the callback function is::
+    The signature of the callback function is:
 
         def callback(msg1, ... msgN):
 
@@ -239,11 +238,12 @@ class ApproximateTimeSynchronizer(TimeSynchronizer):
     """
     Approximately synchronizes messages by their timestamps.
 
-    :class:`ApproximateTimeSynchronizer` synchronizes incoming message filters by the
-    timestamps contained in their messages' headers. The API is the same as TimeSynchronizer
-    except for an extra `slop` parameter in the constructor that defines the delay (in seconds)
-    with which messages can be synchronized. The ``allow_headerless`` option specifies whether
-    to allow storing headerless messages with current ROS time instead of timestamp. You should
+    :class:`ApproximateTimeSynchronizer` synchronizes incoming message filters
+    by the timestamps contained in their messages' headers. The API is the same
+    as TimeSynchronizer except for an extra `slop` parameter in the constructor
+    that defines the delay (in seconds) with which messages can be synchronized.
+    The ``allow_headerless`` option specifies whether to allow storing
+    headerless messages with current ROS time instead of timestamp. You should
     avoid this as much as you can, since the delays are unpredictable.
     """
 
@@ -255,10 +255,10 @@ class ApproximateTimeSynchronizer(TimeSynchronizer):
     def add(self, msg, my_queue, my_queue_index=None):
         if not hasattr(msg, 'header') or not hasattr(msg.header, 'stamp'):
             if not self.allow_headerless:
-                rclpy.logging._root_logger.log("can not use message filters "
-                              "for messages without timestamp infomation when "
-                              "'allow_headerless' is disabled. auto assign "
-                              "ROSTIME to headerless messages once enabling "
+                rclpy.logging._root_logger.log("can not use message filters"
+                              "for messages without timestamp infomation when"
+                              "'allow_headerless' is disabled. auto assign"
+                              "ROSTIME to headerless messages once enabling"
                               "constructor option of 'allow_headerless'.",
                               LoggingSeverity.INFO)
                 return

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -30,10 +30,10 @@ Message Filter Objects
 ======================
 """
 
+from functools import reduce
 import itertools
 import threading
-import rospy
-
+import rclpy
 
 class SimpleFilter(object):
 
@@ -67,9 +67,10 @@ class Subscriber(SimpleFilter):
     """
     def __init__(self, *args, **kwargs):
         SimpleFilter.__init__(self)
-        self.topic = args[0]
+        self.node = args[0]
+        self.topic = args[2]
         kwargs['callback'] = self.callback
-        self.sub = rospy.Subscriber(*args, **kwargs)
+        self.sub = self.node.create_subscription(*args[1:], **kwargs)
 
     def callback(self, msg):
         self.signalMessage(msg)

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -120,12 +120,14 @@ class Cache(SimpleFilter):
     def add(self, msg):
         if not hasattr(msg, 'header') or not hasattr(msg.header, 'stamp'):
             if not self.allow_headerless:
-                rclpy.logging._root_logger.log("can not use message filters"
-                              "for messages without timestamp infomation when"
-                              "'allow_headerless' is disabled. auto assign"
-                              "ROSTIME to headerless messages once enabling"
-                              "constructor option of 'allow_headerless'.",
-                              LoggingSeverity.INFO)
+                msg_filters_logger = rclpy.logging.get_logger('message_filters_cache')
+                msg_filters_logger.set_level(LoggingSeverity.INFO)
+                msg_filters_logger.warn("can not use message filters messages "
+                                        "without timestamp infomation when "
+                                        "'allow_headerless' is disabled. "
+                                        "auto assign ROSTIME to headerless "
+                                        "messages once enabling constructor "
+                                        "option of 'allow_headerless'.")
 
                 return
 
@@ -256,12 +258,13 @@ class ApproximateTimeSynchronizer(TimeSynchronizer):
     def add(self, msg, my_queue, my_queue_index=None):
         if not hasattr(msg, 'header') or not hasattr(msg.header, 'stamp'):
             if not self.allow_headerless:
-                rclpy.logging._root_logger.log("can not use message filters"
-                              "for messages without timestamp infomation when"
-                              "'allow_headerless' is disabled. auto assign"
-                              "ROSTIME to headerless messages once enabling"
-                              "constructor option of 'allow_headerless'.",
-                              LoggingSeverity.INFO)
+                msg_filters_logger = rclpy.logging.get_logger('message_filters_approx')
+                msg_filters_logger.set_level(LoggingSeverity.INFO)
+                msg_filters_logger.warn("can not use message filters for "
+                              "messages without timestamp infomation when "
+                              "'allow_headerless' is disabled. auto assign "
+                              "ROSTIME to headerless messages once enabling "
+                              "constructor option of 'allow_headerless'.")
                 return
 
             stamp = ROSClock().now()

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -37,6 +37,7 @@ import rclpy
 
 from rclpy.clock import ROSClock
 from rclpy.duration import Duration
+from rclpy.logging import LoggingSeverity
 from rclpy.time import Time
 
 
@@ -119,9 +120,13 @@ class Cache(SimpleFilter):
     def add(self, msg):
         if not hasattr(msg, 'header') or not hasattr(msg.header, 'stamp'):
             if not self.allow_headerless:
-                rospy.logwarn("Cannot use message filters with non-stamped messages. "
-                              "Use the 'allow_headerless' constructor option to "
-                              "auto-assign ROS time to headerless messages.")
+                rclpy.logging._root_logger.log("can not use message filters "
+                              "for messages without timestamp infomation when "
+                              "'allow_headerless' is disabled. auto assign "
+                              "ROSTIME to headerless messages once enabling "
+                              "constructor option of 'allow_headerless'.",
+                              LoggingSeverity.INFO)
+
                 return
 
             stamp = ROSClock().now()
@@ -250,9 +255,12 @@ class ApproximateTimeSynchronizer(TimeSynchronizer):
     def add(self, msg, my_queue, my_queue_index=None):
         if not hasattr(msg, 'header') or not hasattr(msg.header, 'stamp'):
             if not self.allow_headerless:
-                rospy.logwarn("Cannot use message filters with non-stamped messages. "
-                              "Use the 'allow_headerless' constructor option to "
-                              "auto-assign ROS time to headerless messages.")
+                rclpy.logging._root_logger.log("can not use message filters "
+                              "for messages without timestamp infomation when "
+                              "'allow_headerless' is disabled. auto assign "
+                              "ROSTIME to headerless messages once enabling "
+                              "constructor option of 'allow_headerless'.",
+                              LoggingSeverity.INFO)
                 return
 
             stamp = ROSClock().now().nanoseconds

--- a/test/directed.py
+++ b/test/directed.py
@@ -54,7 +54,8 @@ class TestDirected(unittest.TestCase):
                 m1.signalMessage(msg1)
                 self.assertEqual(self.collector, [(msg0, msg1)])
 
-        # Scramble sequences of length N.  Make sure that TimeSequencer recombines them.
+        # Scramble sequences of length N.
+        # Make sure that TimeSequencer recombines them.
         random.seed(0)
         for N in range(1, 10):
             m0 = MockFilter()

--- a/test/directed.py
+++ b/test/directed.py
@@ -13,8 +13,7 @@
 #
 #    wide.registerCallback(boost::bind(&PersonDataRecorder::wideCB, this, _1, _2, _3, _4));
 
-import rostest
-import rospy
+import rclpy
 import random
 import unittest
 
@@ -74,9 +73,6 @@ class TestDirected(unittest.TestCase):
             self.assertEqual(set(self.collector), set(zip(seq0, seq1)))
 
 if __name__ == '__main__':
-   if 0:
-        rostest.unitrun('message_filters', 'directed', TestDirected)
-   else:
-        suite = unittest.TestSuite()
-        suite.addTest(TestDirected('test_synchronizer'))
-        unittest.TextTestRunner(verbosity=2).run(suite)
+    suite = unittest.TestSuite()
+    suite.addTest(TestDirected('test_synchronizer'))
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/test/test_approxsync.py
+++ b/test/test_approxsync.py
@@ -80,13 +80,16 @@ class TestApproxSync(unittest.TestCase):
                 m1.signalMessage(msg1)
                 self.assertEqual(self.collector, [(msg0, msg1)])
 
-        # Scramble sequences of length N.  Make sure that TimeSequencer recombines them.
+        # Scramble sequences of length N.
+        # Make sure that TimeSequencer recombines them.
         random.seed(0)
         for N in range(1, 10):
             m0 = MockFilter()
             m1 = MockFilter()
-            seq0 = [MockMessage(Time(seconds=t).nanoseconds, random.random()) for t in range(N)]
-            seq1 = [MockMessage(Time(seconds=t).nanoseconds, random.random()) for t in range(N)]
+            seq0 = [MockMessage(Time(seconds=t).nanoseconds, random.random())\
+                    for t in range(N)]
+            seq1 = [MockMessage(Time(seconds=t).nanoseconds, random.random())\
+                    for t in range(N)]
             # random.shuffle(seq0)
             ts = ApproximateTimeSynchronizer([m0, m1], N, 0.1)
             ts.registerCallback(self.cb_collector_2msg)
@@ -105,10 +108,12 @@ class TestApproxSync(unittest.TestCase):
             m0 = MockFilter()
             m1 = MockFilter()
             currentRosTime = ROSClock().now().nanoseconds
-            seq0 = [MockMessage((currentRosTime + Duration(seconds=t).nanoseconds), random.random()) for t in range(N)]
+            seq0 = [MockMessage((currentRosTime + Duration(seconds=t).nanoseconds),
+                    random.random()) for t in range(N)]
             seq1 = [MockHeaderlessMessage(random.random()) for t in range(N)]
 
-            ts = ApproximateTimeSynchronizer([m0, m1], N, 10, allow_headerless=True)
+            ts = ApproximateTimeSynchronizer([m0, m1], N, 10,
+                                             allow_headerless=True)
             ts.registerCallback(self.cb_collector_2msg)
             self.collector = []
             for msg in random.sample(seq0, N):

--- a/test/test_approxsync.py
+++ b/test/test_approxsync.py
@@ -64,21 +64,21 @@ class TestApproxSync(unittest.TestCase):
         self.collector.append((msg1, msg2))
 
     def test_approx(self):
+        # Simple case, pairs of messages,
+        # make sure that they get combined
         m0 = MockFilter()
         m1 = MockFilter()
         ts = ApproximateTimeSynchronizer([m0, m1], 1, 0.1)
         ts.registerCallback(self.cb_collector_2msg)
 
-        if 0:
-            # Simple case, pairs of messages, make sure that they get combined
-            for t in range(10):
-                self.collector = []
-                msg0 = MockMessage(t, 33)
-                msg1 = MockMessage(t, 34)
-                m0.signalMessage(msg0)
-                self.assertEqual(self.collector, [])
-                m1.signalMessage(msg1)
-                self.assertEqual(self.collector, [(msg0, msg1)])
+        for t in range(10):
+            self.collector = []
+            msg0 = MockMessage(Time(seconds=t), 33)
+            msg1 = MockMessage(Time(seconds=t), 34)
+            m0.signalMessage(msg0)
+            self.assertEqual(self.collector, [])
+            m1.signalMessage(msg1)
+            self.assertEqual(self.collector, [(msg0, msg1)])
 
         # Scramble sequences of length N.
         # Make sure that TimeSequencer recombines them.
@@ -86,9 +86,9 @@ class TestApproxSync(unittest.TestCase):
         for N in range(1, 10):
             m0 = MockFilter()
             m1 = MockFilter()
-            seq0 = [MockMessage(Time(seconds=t).nanoseconds, random.random())\
+            seq0 = [MockMessage(Time(seconds=t), random.random())\
                     for t in range(N)]
-            seq1 = [MockMessage(Time(seconds=t).nanoseconds, random.random())\
+            seq1 = [MockMessage(Time(seconds=t), random.random())\
                     for t in range(N)]
             # random.shuffle(seq0)
             ts = ApproximateTimeSynchronizer([m0, m1], N, 0.1)
@@ -107,8 +107,7 @@ class TestApproxSync(unittest.TestCase):
         for N in range(1, 10):
             m0 = MockFilter()
             m1 = MockFilter()
-            currentRosTime = ROSClock().now().nanoseconds
-            seq0 = [MockMessage((currentRosTime + Duration(seconds=t).nanoseconds),
+            seq0 = [MockMessage((ROSClock().now() + Duration(seconds=t)),
                     random.random()) for t in range(N)]
             seq1 = [MockHeaderlessMessage(random.random()) for t in range(N)]
 

--- a/test/test_message_filters_cache.py
+++ b/test/test_message_filters_cache.py
@@ -43,7 +43,6 @@ import unittest
 
 PKG = 'message_filters'
 
-
 class AnonymMsg:
     class AnonymHeader:
         stamp = None
@@ -102,11 +101,10 @@ class TestCache(unittest.TestCase):
 
         l = len(cache.getInterval(Time(), Time(seconds=4)))
         self.assertEqual(l, 5, "invalid number of messages" +
-                                " returned in getInterval 3")
+                                " returned in getInterval 5")
 
         s = cache.getElemAfterTime(Time()).header.stamp
-        self.assertEqual(s, Time(),
-                         "invalid msg return by getElemAfterTime")
+        self.assertEqual(s, Time(), "invalid msg return by getElemAfterTime")
 
         s = cache.getElemBeforeTime(Time(seconds=3.5)).header.stamp
         self.assertEqual(s, Time(seconds=3),
@@ -127,8 +125,7 @@ class TestCache(unittest.TestCase):
 
         # Test that it discarded the right one
         s = cache.getOldestTime()
-        self.assertEqual(s, Time(seconds=1),
-                         "wrong message discarded")
+        self.assertEqual(s, Time(seconds=1), "wrong message discarded")
 
     def test_headerless(self):
         sub = Subscriber(self.node, String, "/empty")
@@ -154,11 +151,13 @@ class TestCache(unittest.TestCase):
 
         cache.add(msg)
 
-        s = cache.getInterval(Time(clock_type=ClockType.ROS_TIME), currentRosTime)
+        s = cache.getInterval(Time(clock_type=ClockType.ROS_TIME),
+                              currentRosTime)
         self.assertEqual(s, [msg],
                          "invalid msg returned in headerless scenario")
 
-        s = cache.getInterval(Time(clock_type=ClockType.ROS_TIME), (currentRosTime + Duration(seconds=2)))
+        s = cache.getInterval(Time(clock_type=ClockType.ROS_TIME),
+                              (currentRosTime + Duration(seconds=2)))
         self.assertEqual(s, [msg, msg],
                          "invalid msg returned in headerless scenario")
 

--- a/test/test_message_filters_cache.py
+++ b/test/test_message_filters_cache.py
@@ -31,12 +31,15 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import rospy
-import unittest
-
-from std_msgs.msg import String
-
 from message_filters import Cache, Subscriber
+import rclpy
+from rclpy.time import Time
+from rclpy.clock import ClockType
+from rclpy.clock import ROSClock
+from rclpy.duration import Duration
+from std_msgs.msg import String
+import time
+import unittest
 
 PKG = 'message_filters'
 
@@ -46,7 +49,7 @@ class AnonymMsg:
         stamp = None
 
         def __init__(self):
-            self.stamp = rospy.Time()
+            stamp = Time()
 
     header = None
 
@@ -55,108 +58,113 @@ class AnonymMsg:
 
 
 class TestCache(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = rclpy.create_node('my_node', namespace='/my_ns')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
 
     def test_all_funcs(self):
-        sub = Subscriber("/empty", String)
+        sub = Subscriber(self.node, String, "/empty")
         cache = Cache(sub, 5)
 
         msg = AnonymMsg()
-        msg.header.stamp = rospy.Time(0)
+        msg.header.stamp = Time(seconds=0)
         cache.add(msg)
 
         msg = AnonymMsg()
-        msg.header.stamp = rospy.Time(1)
+        msg.header.stamp = Time(seconds=1)
         cache.add(msg)
 
         msg = AnonymMsg()
-        msg.header.stamp = rospy.Time(2)
+        msg.header.stamp = Time(seconds=2)
         cache.add(msg)
 
         msg = AnonymMsg()
-        msg.header.stamp = rospy.Time(3)
+        msg.header.stamp = Time(seconds=3)
         cache.add(msg)
 
         msg = AnonymMsg()
-        msg.header.stamp = rospy.Time(4)
+        msg.header.stamp = Time(seconds=4)
         cache.add(msg)
 
-        l = len(cache.getInterval(rospy.Time(2.5),
-                                  rospy.Time(3.5)))
-        self.assertEquals(l, 1, "invalid number of messages" +
+        l = len(cache.getInterval(Time(seconds=2.5), Time(seconds=3.5)))
+        self.assertEqual(l, 1, "invalid number of messages" +
                                 " returned in getInterval 1")
 
-        l = len(cache.getInterval(rospy.Time(2),
-                                  rospy.Time(3)))
-        self.assertEquals(l, 2, "invalid number of messages" +
+        l = len(cache.getInterval(Time(seconds=2), Time(seconds=3)))
+        self.assertEqual(l, 2, "invalid number of messages" +
                                 " returned in getInterval 2")
 
-        l = len(cache.getInterval(rospy.Time(0),
-                                  rospy.Time(4)))
-        self.assertEquals(l, 5, "invalid number of messages" +
+        l = len(cache.getInterval(Time(), Time(seconds=4)))
+        self.assertEqual(l, 5, "invalid number of messages" +
                                 " returned in getInterval 3")
 
-        s = cache.getElemAfterTime(rospy.Time(0)).header.stamp
-        self.assertEqual(s, rospy.Time(0),
+        s = cache.getElemAfterTime(Time()).header.stamp
+        self.assertEqual(s, Time(),
                          "invalid msg return by getElemAfterTime")
 
-        s = cache.getElemBeforeTime(rospy.Time(3.5)).header.stamp
-        self.assertEqual(s, rospy.Time(3),
+        s = cache.getElemBeforeTime(Time(seconds=3.5)).header.stamp
+        self.assertEqual(s, Time(seconds=3),
                          "invalid msg return by getElemBeforeTime")
 
         s = cache.getLastestTime()
-        self.assertEqual(s, rospy.Time(4),
+        self.assertEqual(s, Time(seconds=4),
                          "invalid stamp return by getLastestTime")
 
         s = cache.getOldestTime()
-        self.assertEqual(s, rospy.Time(0),
+        self.assertEqual(s, Time(),
                          "invalid stamp return by getOldestTime")
 
         # Add another msg to fill the buffer
         msg = AnonymMsg()
-        msg.header.stamp = rospy.Time(5)
+        msg.header.stamp = Time(seconds=5)
         cache.add(msg)
 
         # Test that it discarded the right one
         s = cache.getOldestTime()
-        self.assertEqual(s, rospy.Time(1),
+        self.assertEqual(s, Time(seconds=1),
                          "wrong message discarded")
 
     def test_headerless(self):
-        sub = Subscriber("/empty", String)
+        sub = Subscriber(self.node, String, "/empty")
         cache = Cache(sub, 5, allow_headerless=False)
 
         msg = String()
         cache.add(msg)
 
-        self.assertIsNone(cache.getElemAfterTime(rospy.Time(0)),
+        self.assertIsNone(cache.getElemAfterTime(Time(clock_type=ClockType.ROS_TIME)),
                           "Headerless message invalidly added.")
 
         cache = Cache(sub, 5, allow_headerless=True)
-
-        rospy.rostime.set_rostime_initialized(True)
-
-        rospy.rostime._set_rostime(rospy.Time(0))
         cache.add(msg)
 
-        s = cache.getElemAfterTime(rospy.Time(0))
+        s = cache.getElemAfterTime(Time(clock_type=ClockType.ROS_TIME))
         self.assertEqual(s, msg,
                          "invalid msg returned in headerless scenario")
 
-        s = cache.getElemAfterTime(rospy.Time(1))
+        currentRosTime = ROSClock().now()
+        s = cache.getElemAfterTime(currentRosTime)
         self.assertIsNone(s, "invalid msg returned in headerless scenario")
 
-        rospy.rostime._set_rostime(rospy.Time(2))
+
         cache.add(msg)
 
-        s = cache.getInterval(rospy.Time(0), rospy.Time(1))
+        s = cache.getInterval(Time(clock_type=ClockType.ROS_TIME), currentRosTime)
         self.assertEqual(s, [msg],
                          "invalid msg returned in headerless scenario")
 
-        s = cache.getInterval(rospy.Time(0), rospy.Time(2))
+        s = cache.getInterval(Time(clock_type=ClockType.ROS_TIME), (currentRosTime + Duration(seconds=2)))
         self.assertEqual(s, [msg, msg],
                          "invalid msg returned in headerless scenario")
 
 
 if __name__ == '__main__':
-    import rosunit
-    rosunit.unitrun(PKG, 'test_message_filters_cache', TestCache)
+    suite = unittest.TestSuite()
+    suite.addTest(TestCache('test_all_funcs'))
+    suite.addTest(TestCache('test_headerless'))
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/test/test_message_filters_cache.py
+++ b/test/test_message_filters_cache.py
@@ -91,15 +91,18 @@ class TestCache(unittest.TestCase):
         msg.header.stamp = Time(seconds=4)
         cache.add(msg)
 
-        l = len(cache.getInterval(Time(seconds=2.5), Time(seconds=3.5)))
+        l = len(cache.getInterval(Time(seconds=2.5),
+                                  Time(seconds=3.5)))
         self.assertEqual(l, 1, "invalid number of messages" +
                                 " returned in getInterval 1")
 
-        l = len(cache.getInterval(Time(seconds=2), Time(seconds=3)))
+        l = len(cache.getInterval(Time(seconds=2),
+                                  Time(seconds=3)))
         self.assertEqual(l, 2, "invalid number of messages" +
                                 " returned in getInterval 2")
 
-        l = len(cache.getInterval(Time(), Time(seconds=4)))
+        l = len(cache.getInterval(Time(),
+                                  Time(seconds=4)))
         self.assertEqual(l, 5, "invalid number of messages" +
                                 " returned in getInterval 5")
 


### PR DESCRIPTION
I ported the message_filters ROS2 python support here and it mainly involves the following changes: 
- replace Subsciber with ROS2 `Subscriber`
- use ROS2 ROSTIME to support headerless messages for `Cache` and `ApproximateTimeSynchronizer`
- use ROS2 `rclpy` root logger for logging
- enable exact timestamp policy for with `TimeSynchronizer` 
- enable approximate timestamp policy for messages with header 
- enable approximate timestamp policy test for headerless messages
- enable message cache for messages with header 
- enable message cache for for headerless messages
- fix doc and coding style issue
- enable the relevant tests with `ament_cmake_pytest`