### PR TITLE
fixed using wrong type of stamp

### DIFF
--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -133,7 +133,7 @@ class Cache(SimpleFilter):
 
             stamp = ROSClock().now()
         else:
-            stamp = msg.header.stamp
+            stamp = Time.from_msg(msg.header.stamp)
 
         # Insert sorted
         self.cache_times.append(stamp)
@@ -269,7 +269,7 @@ class ApproximateTimeSynchronizer(TimeSynchronizer):
 
             stamp = ROSClock().now()
         else:
-            stamp = msg.header.stamp
+            stamp = Time.from_msg(msg.header.stamp)
 
         self.lock.acquire()
         my_queue[stamp.nanoseconds] = msg

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -35,6 +35,7 @@ import itertools
 import threading
 import rclpy
 
+import builtin_interfaces
 from rclpy.clock import ROSClock
 from rclpy.duration import Duration
 from rclpy.logging import LoggingSeverity
@@ -133,8 +134,9 @@ class Cache(SimpleFilter):
 
             stamp = ROSClock().now()
         else:
-            stamp = Time.from_msg(msg.header.stamp)
-
+            stamp = msg.header.stamp
+            if not hasattr(stamp, 'nanoseconds'):
+                stamp = Time.from_msg(stamp)
         # Insert sorted
         self.cache_times.append(stamp)
         self.cache_msgs.append(msg)
@@ -269,8 +271,10 @@ class ApproximateTimeSynchronizer(TimeSynchronizer):
 
             stamp = ROSClock().now()
         else:
-            stamp = Time.from_msg(msg.header.stamp)
-
+            stamp = msg.header.stamp
+            if not hasattr(stamp, 'nanoseconds'):
+                stamp = Time.from_msg(stamp)
+            # print(stamp)
         self.lock.acquire()
         my_queue[stamp.nanoseconds] = msg
         while len(my_queue) > self.queue_size:


### PR DESCRIPTION
In the current code, when stamp = msg.header.stamp, it will raise errors because msg.header.stamp is builtin_interfaces.msg.Time, and it doesn't have nanoseconds attribute. So i fixed this problem :)