### PR TITLE
Add message trait support to frame id of message

### DIFF
--- a/include/message_filters/message_traits.h
+++ b/include/message_filters/message_traits.h
@@ -53,8 +53,8 @@ struct HasHeader<M, decltype((void) M::header)> : std::true_type {};
 template<typename M, typename Enable = void>
 struct FrameId
 {
-  static std::string* pointer(M& m) { (void)m; return 0; }
-  static std::string const* pointer(const M& m) { (void)m; return 0; }
+  static std::string* pointer(M& m) { (void)m; return nullptr; }
+  static std::string const* pointer(const M& m) { (void)m; return nullptr; }
 };
  template<typename M>
 struct FrameId<M, typename std::enable_if<HasHeader<M>::value>::type >

--- a/include/message_filters/message_traits.h
+++ b/include/message_filters/message_traits.h
@@ -46,6 +46,25 @@ template <typename M>
 struct HasHeader<M, decltype((void) M::header)> : std::true_type {};
 
 /**
+ * \brief FrameId trait.  In the default implementation pointer()
+ * returns &m.header.frame_id if HasHeader<M>::value is true, otherwise returns NULL.  value()
+ * does not exist, and causes a compile error
+ */
+template<typename M, typename Enable = void>
+struct FrameId
+{
+  static std::string* pointer(M& m) { (void)m; return 0; }
+  static std::string const* pointer(const M& m) { (void)m; return 0; }
+};
+ template<typename M>
+struct FrameId<M, typename std::enable_if<HasHeader<M>::value>::type >
+{
+  static std::string* pointer(M& m) { return &m.header.frame_id; }
+  static std::string const* pointer(const M& m) { return &m.header.frame_id; }
+  static std::string value(const M& m) { return m.header.frame_id; }
+};
+
+/**
  * \brief TimeStamp trait.  In the default implementation pointer()
  * returns &m.header.stamp if HasHeader<M>::value is true, otherwise returns NULL.  value()
  * does not exist, and causes a compile error


### PR DESCRIPTION
While retrieving `frame_id` from message, for example, TF frames, it's necessary. now tf2 message filter also depends on its support.