### PR TITLE
Add the ability to use raw pointers in Subscriber

### DIFF
--- a/include/message_filters/subscriber.h
+++ b/include/message_filters/subscriber.h
@@ -46,17 +46,28 @@ namespace message_filters
 class SubscriberBase
 {
 public:
-  virtual ~SubscriberBase() {}
+  virtual ~SubscriberBase() = default;
   /**
    * \brief Subscribe to a topic.
    *
    * If this Subscriber is already subscribed to a topic, this function will first unsubscribe.
    *
-   * \param node The rclcpp::Node::ShardPtr to use to subscribe.
+   * \param node The rclcpp::Node::SharedPtr to use to subscribe.
    * \param topic The topic to subscribe to.
    * \param qos (optional) The rmw qos profile to use to subscribe
    */
   virtual void subscribe(rclcpp::Node::SharedPtr node, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default) = 0;
+
+  /**
+   * \brief Subscribe to a topic.
+   *
+   * If this Subscriber is already subscribed to a topic, this function will first unsubscribe.
+   *
+   * \param node The rclcpp::Node to use to subscribe.
+   * \param topic The topic to subscribe to.
+   * \param qos (optional) The rmw qos profile to use to subscribe
+   */
+  virtual void subscribe(rclcpp::Node * node, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default) = 0;
   /**
    * \brief Re-subscribe to a topic.  Only works if this subscriber has previously been subscribed to a topic.
    */
@@ -107,12 +118,15 @@ public:
     subscribe(node, topic, qos);
   }
 
+  Subscriber(rclcpp::Node* node, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default)
+  {
+    subscribe(node, topic, qos);
+  }
+
   /**
    * \brief Empty constructor, use subscribe() to subscribe to a topic
    */
-  Subscriber()
-  {
-  }
+  Subscriber() = default;
 
   ~Subscriber()
   {
@@ -140,7 +154,43 @@ public:
                [this](std::shared_ptr<M const> msg) {
                  this->cb(EventType(msg));
                }, qos);
-      node_ = node;
+
+      // The subscriber is switching to using a shared pointer, so relase the raw.
+      if (node_raw_ != nullptr) {
+        node_raw_ = nullptr;
+      }
+      node_shared_ = node;
+    }
+  }
+
+  /**
+   * \brief Subscribe to a topic.
+   *
+   * If this Subscriber is already subscribed to a topic, this function will first unsubscribe.
+   *
+   * \param node The rclcpp::Node to use to subscribe.
+   * \param topic The topic to subscribe to.
+   * \param qos (optional) The rmw qos profile to use to subscribe
+   */
+  void subscribe(rclcpp::Node * node, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default)
+  {
+    unsubscribe();
+
+    if (!topic.empty())
+    {
+      topic_ = topic;
+      qos_ = qos;
+      sub_ = node->create_subscription<M>(topic,
+               [this](std::shared_ptr<M const> msg) {
+                 this->cb(EventType(msg));
+               }, qos);
+
+      // The subscriber is switching to using a raw pointer, so release the shared.
+      if (node_shared_ != nullptr) {
+        node_shared_.reset();
+      }
+
+      node_raw_ = node;
     }
   }
 
@@ -153,7 +203,11 @@ public:
 
     if (!topic_.empty())
     {
-      subscribe(node_, topic_, qos_);
+      if (node_raw_ != nullptr) {
+        subscribe(node_raw_, topic_, qos_);
+      } else if (node_shared_ != nullptr) {
+        subscribe(node_shared_, topic_, qos_);
+      }
     }
   }
 
@@ -200,7 +254,10 @@ private:
   }
 
   typename rclcpp::Subscription<M>::SharedPtr sub_;
-  rclcpp::Node::SharedPtr node_;
+
+  rclcpp::Node::SharedPtr node_shared_;
+  rclcpp::Node * node_raw_ {nullptr};
+
   std::string topic_;
   rmw_qos_profile_t qos_;
 };

--- a/include/message_filters/subscriber.h
+++ b/include/message_filters/subscriber.h
@@ -144,23 +144,9 @@ public:
    */
   void subscribe(rclcpp::Node::SharedPtr node, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default)
   {
-    unsubscribe();
-
-    if (!topic.empty())
-    {
-      topic_ = topic;
-      qos_ = qos;
-      sub_ = node->create_subscription<M>(topic,
-               [this](std::shared_ptr<M const> msg) {
-                 this->cb(EventType(msg));
-               }, qos);
-
-      // The subscriber is switching to using a shared pointer, so relase the raw.
-      if (node_raw_ != nullptr) {
-        node_raw_ = nullptr;
-      }
-      node_shared_ = node;
-    }
+    subscribe(node.get(), topic, qos);
+    node_raw_ = nullptr;
+    node_shared_ = node;
   }
 
   /**
@@ -185,11 +171,6 @@ public:
                  this->cb(EventType(msg));
                }, qos);
 
-      // The subscriber is switching to using a raw pointer, so release the shared.
-      if (node_shared_ != nullptr) {
-        node_shared_.reset();
-      }
-
       node_raw_ = node;
     }
   }
@@ -199,8 +180,6 @@ public:
    */
   void subscribe()
   {
-    unsubscribe();
-
     if (!topic_.empty())
     {
       if (node_raw_ != nullptr) {

--- a/test/test_subscriber.cpp
+++ b/test/test_subscriber.cpp
@@ -166,7 +166,6 @@ TEST(Subscriber, switchRawAndShared)
   ASSERT_GT(h.count_, 0);
 }
 
-
 TEST(Subscriber, subInChain)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");


### PR DESCRIPTION
Using only SharedPtr was causing an issue in objects that are subclassed from Node.

If you want to create a `message_filter::Subscriber` as part of the subclass constructor, there was no way to get a shared pointer to the node instance itself to pass in. `shared_from_this` is not allowed in constructors for reasons listed here: https://en.cppreference.com/w/cpp/memory/enable_shared_from_this

As a workaround, I added an additional API where users can create a Subscriber using a raw pointer. The only downside to this is that the user is fully responsible for mananging the lifetime of the `message_filter::Subscriber` to ensure that it doesn't outlive the `Node`.  In the case where it is a member of a `Node` subclass, this is not an issue.