### PR TITLE
Fix Duration signature for Windows CI

### DIFF
--- a/test/test_subscriber.cpp
+++ b/test/test_subscriber.cpp
@@ -68,7 +68,7 @@ TEST(Subscriber, simple)
   auto pub = node->create_publisher<Msg>("test_topic");
   rclcpp::Clock ros_clock;
   auto start = ros_clock.now();
-  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1.0, 0))
+  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1, 0))
   {
     pub->publish(std::make_shared<Msg>());
     rclcpp::Rate(50).sleep();
@@ -87,7 +87,7 @@ TEST(Subscriber, simple_raw)
   auto pub = node->create_publisher<Msg>("test_topic");
   rclcpp::Clock ros_clock;
   auto start = ros_clock.now();
-  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1.0, 0))
+  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1, 0))
   {
     pub->publish(std::make_shared<Msg>());
     rclcpp::Rate(50).sleep();
@@ -110,7 +110,7 @@ TEST(Subscriber, subUnsubSub)
 
   rclcpp::Clock ros_clock;
   auto start = ros_clock.now();
-  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1.0, 0))
+  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1, 0))
   {
     pub->publish(std::make_shared<Msg>());
     rclcpp::Rate(50).sleep();
@@ -133,7 +133,7 @@ TEST(Subscriber, subUnsubSub_raw)
 
   rclcpp::Clock ros_clock;
   auto start = ros_clock.now();
-  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1.0, 0))
+  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1, 0))
   {
     pub->publish(std::make_shared<Msg>());
     rclcpp::Rate(50).sleep();
@@ -156,7 +156,7 @@ TEST(Subscriber, switchRawAndShared)
 
   rclcpp::Clock ros_clock;
   auto start = ros_clock.now();
-  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1.0, 0))
+  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1, 0))
   {
     pub->publish(std::make_shared<Msg>());
     rclcpp::Rate(50).sleep();
@@ -177,7 +177,7 @@ TEST(Subscriber, subInChain)
 
   rclcpp::Clock ros_clock;
   auto start = ros_clock.now();
-  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1.0, 0))
+  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1, 0))
   {
     pub->publish(std::make_shared<Msg>());
     rclcpp::Rate(50).sleep();


### PR DESCRIPTION
Duration call was incorrect, should be `Duration(int32_t seconds, uint32_t nanoseconds)`.