### PR TITLE
Move sensor_msgs to be a test dependency.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,8 +83,9 @@ if(BUILD_TESTING)
 
   ament_add_gtest(${PROJECT_NAME}-test_subscriber test/test_subscriber.cpp)
   if(TARGET ${PROJECT_NAME}-test_subscriber)
-    target_link_libraries(${PROJECT_NAME}-test_subscriber ${PROJECT_NAME} sensor_msgs_LIBRARIES)
-    target_include_directories(${PROJECT_NAME}-test_subscriber PUBLIC sensor_msgs_INCLUDE_DIRS)
+    target_link_libraries(${PROJECT_NAME}-test_subscriber ${PROJECT_NAME})
+    target_include_directories(${PROJECT_NAME}-test_subscriber PUBLIC include)
+    ament_target_dependencies(${PROJECT_NAME}-test_subscriber "rclcpp" "sensor_msgs")
   endif()
 
   ament_add_gtest(${PROJECT_NAME}-test_synchronizer test/test_synchronizer.cpp)
@@ -109,9 +110,9 @@ if(BUILD_TESTING)
 
   ament_add_gtest(${PROJECT_NAME}-test_fuzz test/test_fuzz.cpp SKIP_TEST)
   if(TARGET ${PROJECT_NAME}-test_fuzz)
-    target_link_libraries(${PROJECT_NAME}-test_fuzz ${PROJECT_NAME} sensor_msgs_LIBRARIES)
-    target_include_directories(${PROJECT_NAME}-test_fuzz PUBLIC sensor_msgs_INCLUDE_DIRS)
-
+    target_link_libraries(${PROJECT_NAME}-test_fuzz ${PROJECT_NAME})
+    target_include_directories(${PROJECT_NAME}-test_fuzz PUBLIC include)
+    ament_target_dependencies(${PROJECT_NAME}-test_fuzz "rclcpp" "sensor_msgs")
   endif()
 
   # python tests with python interfaces of message filters

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ find_package(ament_cmake_ros REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcutils)
 find_package(builtin_interfaces REQUIRED)
-find_package(sensor_msgs REQUIRED)
 
 add_library(${PROJECT_NAME} src/connection.cpp)
 if(WIN32)
@@ -29,7 +28,7 @@ ament_target_dependencies(${PROJECT_NAME}
   "rclcpp"
   "rcutils"
   "builtin_interfaces"
-  "sensor_msgs")
+  )
 
 install(
   TARGETS ${PROJECT_NAME}
@@ -56,8 +55,8 @@ ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
 
 if(BUILD_TESTING)
+  find_package(sensor_msgs REQUIRED)
   find_package(ament_lint_auto REQUIRED)
-  find_package(std_msgs REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gtest)
@@ -84,7 +83,8 @@ if(BUILD_TESTING)
 
   ament_add_gtest(${PROJECT_NAME}-test_subscriber test/test_subscriber.cpp)
   if(TARGET ${PROJECT_NAME}-test_subscriber)
-    target_link_libraries(${PROJECT_NAME}-test_subscriber ${PROJECT_NAME})
+    target_link_libraries(${PROJECT_NAME}-test_subscriber ${PROJECT_NAME} sensor_msgs_LIBRARIES)
+    target_include_directories(${PROJECT_NAME}-test_subscriber PUBLIC sensor_msgs_INCLUDE_DIRS)
   endif()
 
   ament_add_gtest(${PROJECT_NAME}-test_synchronizer test/test_synchronizer.cpp)
@@ -109,7 +109,9 @@ if(BUILD_TESTING)
 
   ament_add_gtest(${PROJECT_NAME}-test_fuzz test/test_fuzz.cpp SKIP_TEST)
   if(TARGET ${PROJECT_NAME}-test_fuzz)
-    target_link_libraries(${PROJECT_NAME}-test_fuzz ${PROJECT_NAME})
+    target_link_libraries(${PROJECT_NAME}-test_fuzz ${PROJECT_NAME} sensor_msgs_LIBRARIES)
+    target_include_directories(${PROJECT_NAME}-test_fuzz PUBLIC sensor_msgs_INCLUDE_DIRS)
+
   endif()
 
   # python tests with python interfaces of message filters

--- a/package.xml
+++ b/package.xml
@@ -20,11 +20,11 @@
   <build_depend>builtin_interfaces</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>rclpy</build_depend>
-  <build_depend>sensor_msgs</build_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>sensor_msgs</test_depend>
   <test_depend>std_msgs</test_depend>
 
   <export>


### PR DESCRIPTION
It's only used in the tests. Otherwise it would need to be exported for osx linking.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5624)](http://ci.ros2.org/job/ci_linux/5624/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2247)](http://ci.ros2.org/job/ci_linux-aarch64/2247/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4637)](http://ci.ros2.org/job/ci_osx/4637/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5502)](http://ci.ros2.org/job/ci_windows/5502/)