### PR TITLE
Depend directly on python_cmake_module.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
+  <buildtool_depend>python_cmake_module</buildtool_depend>
 
   <build_depend>builtin_interfaces</build_depend>
   <build_depend>rclcpp</build_depend>


### PR DESCRIPTION
Since we use it directly, I think it ought to be added to the manifest.
As to why it's not strictly needed to build, I believe it's bubbling up
from an exported dependency chain starting with a
buildtool_export_depend in rosidl_generator_py.