### PR TITLE
Fix TypeError: unhashable type: 'Time' error

### DIFF
--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -224,7 +224,8 @@ class TimeSynchronizer(SimpleFilter):
 
     def add(self, msg, my_queue, my_queue_index=None):
         self.lock.acquire()
-        my_queue[msg.header.stamp] = msg
+        stamp = Time.from_msg(msg.header.stamp)
+        my_queue[stamp.nanoseconds] = msg
         while len(my_queue) > self.queue_size:
             del my_queue[min(my_queue)]
         # common is the set of timestamps that occur in all queues

--- a/test/directed.py
+++ b/test/directed.py
@@ -17,6 +17,7 @@ import rclpy
 import random
 import unittest
 
+from builtin_interfaces.msg import Time as TimeMsg
 from message_filters import SimpleFilter, Subscriber, Cache, TimeSynchronizer
 
 
@@ -26,7 +27,7 @@ class MockHeader:
 class MockMessage:
     def __init__(self, stamp, data):
         self.header = MockHeader()
-        self.header.stamp = stamp
+        self.header.stamp = TimeMsg(sec=stamp)
         self.data = data
 
 class MockFilter(SimpleFilter):


### PR DESCRIPTION
Fixes #34 

In the TimeSynchronizer class the following error is thrown because msg.header.stamp (builtin_interfaces/Time) is not hashable (perhaps it was in ROS 1), see below:

```bash
  File "/home/jamie/my_ros2_ws/install/message_filters/lib/python3.6/site-packages/message_filters/__init__.py", line 227, in add
    my_queue[msg.header.stamp] = msg
TypeError: unhashable type: 'Time'
```
This occurs at [message_filters/\_\_init\_\_.py#L227](https://github.com/ros2/message_filters/blob/master/src/message_filters/__init__.py#L227).

I've just taken the approach used in ApproximateTimeSynchronizer to hash the timestamp, creating a rclpy Time object and using the nanoseconds field as the hash:

```python
stamp = Time.from_msg(msg.header.stamp)
my_queue[stamp.nanoseconds] = msg
```
There is also a lot of code that was added to ApproximateTimeSynchronizer but not to TimeSynchronizer, perhaps these checks should be in TimeSynchronizer too, in case someone doesn't set a header?
```python
        if not hasattr(msg, 'header') or not hasattr(msg.header, 'stamp'):
            if not self.allow_headerless:
                msg_filters_logger = rclpy.logging.get_logger('message_filters_approx')
                msg_filters_logger.set_level(LoggingSeverity.INFO)
                msg_filters_logger.warn("can not use message filters for "
                              "messages without timestamp infomation when "
                              "'allow_headerless' is disabled. auto assign "
                              "ROSTIME to headerless messages once enabling "
                              "constructor option of 'allow_headerless'.")
                return

            stamp = ROSClock().now()
```