### PR TITLE
Adapt Subscriber class to be used with LifecycleNode instances

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 find_package(ament_cmake_python REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
 find_package(rcutils)
 find_package(builtin_interfaces REQUIRED)
 
@@ -26,6 +27,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC include)
 
 ament_target_dependencies(${PROJECT_NAME}
   "rclcpp"
+  "rclcpp_lifecycle"
   "rcutils"
   "builtin_interfaces"
   )
@@ -85,7 +87,7 @@ if(BUILD_TESTING)
   if(TARGET ${PROJECT_NAME}-test_subscriber)
     target_link_libraries(${PROJECT_NAME}-test_subscriber ${PROJECT_NAME})
     target_include_directories(${PROJECT_NAME}-test_subscriber PUBLIC include)
-    ament_target_dependencies(${PROJECT_NAME}-test_subscriber "rclcpp" "sensor_msgs")
+    ament_target_dependencies(${PROJECT_NAME}-test_subscriber "rclcpp" "rclcpp_lifecycle" "sensor_msgs")
   endif()
 
   ament_add_gtest(${PROJECT_NAME}-test_synchronizer test/test_synchronizer.cpp)

--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,7 @@
 
   <build_depend>builtin_interfaces</build_depend>
   <build_depend>rclcpp</build_depend>
+  <build_depend>rclcpp_lifecycle</build_depend>
   <build_depend>rclpy</build_depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
All message filters used to work only with rclcpp::Node instances. It is not possible to use them with rclcpp_lifecycle::LifecycleNode instances.