### PR TITLE
Resolve ambiguity with boost/bind.hpp

### DIFF
--- a/include/message_filters/signal9.h
+++ b/include/message_filters/signal9.h
@@ -179,112 +179,96 @@ public:
   template<typename P0, typename P1>
   Connection addCallback(void(*callback)(P0, P1))
   {
-    using namespace std::placeholders;
-    return addCallback(std::function<void(P0, P1, NullP, NullP, NullP, NullP, NullP, NullP, NullP)>(std::bind(callback, _1, _2)));
+    return addCallback(std::function<void(P0, P1, NullP, NullP, NullP, NullP, NullP, NullP, NullP)>(std::bind(callback, std::placeholders::_1, std::placeholders::_2)));
   }
 
   template<typename P0, typename P1, typename P2>
   Connection addCallback(void(*callback)(P0, P1, P2))
   {
-    using namespace std::placeholders;
-    return addCallback(std::function<void(P0, P1, P2, NullP, NullP, NullP, NullP, NullP, NullP)>(std::bind(callback, _1, _2, _3)));
+    return addCallback(std::function<void(P0, P1, P2, NullP, NullP, NullP, NullP, NullP, NullP)>(std::bind(callback, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3)));
   }
 
   template<typename P0, typename P1, typename P2, typename P3>
   Connection addCallback(void(*callback)(P0, P1, P2, P3))
   {
-    using namespace std::placeholders;
-    return addCallback(std::function<void(P0, P1, P2, P3, NullP, NullP, NullP, NullP, NullP)>(std::bind(callback, _1, _2, _3, _4)));
+    return addCallback(std::function<void(P0, P1, P2, P3, NullP, NullP, NullP, NullP, NullP)>(std::bind(callback, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4)));
   }
 
   template<typename P0, typename P1, typename P2, typename P3, typename P4>
   Connection addCallback(void(*callback)(P0, P1, P2, P3, P4))
   {
-    using namespace std::placeholders;
-    return addCallback(std::function<void(P0, P1, P2, P3, P4, NullP, NullP, NullP, NullP)>(std::bind(callback, _1, _2, _3, _4, _5)));
+    return addCallback(std::function<void(P0, P1, P2, P3, P4, NullP, NullP, NullP, NullP)>(std::bind(callback, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5)));
   }
 
   template<typename P0, typename P1, typename P2, typename P3, typename P4, typename P5>
   Connection addCallback(void(*callback)(P0, P1, P2, P3, P4, P5))
   {
-    using namespace std::placeholders;
-    return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, NullP, NullP, NullP)>(std::bind(callback, _1, _2, _3, _4, _5, _6)));
+    return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, NullP, NullP, NullP)>(std::bind(callback, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5, std::placeholders::_6)));
   }
 
   template<typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6>
   Connection addCallback(void(*callback)(P0, P1, P2, P3, P4, P5, P6))
   {
-    using namespace std::placeholders;
-    return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, P6, NullP, NullP)>(std::bind(callback, _1, _2, _3, _4, _5, _6, _7)));
+    return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, P6, NullP, NullP)>(std::bind(callback, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5, std::placeholders::_6, std::placeholders::_7)));
   }
 
   template<typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6, typename P7>
   Connection addCallback(void(*callback)(P0, P1, P2, P3, P4, P5, P6, P7))
   {
-    using namespace std::placeholders;
-    return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, P6, P7, NullP)>(std::bind(callback, _1, _2, _3, _4, _5, _6, _7, _8)));
+    return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, P6, P7, NullP)>(std::bind(callback, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5, std::placeholders::_6, std::placeholders::_7, std::placeholders::_8)));
   }
 
   template<typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6, typename P7, typename P8>
   Connection addCallback(void(*callback)(P0, P1, P2, P3, P4, P5, P6, P7, P8))
   {
-    using namespace std::placeholders;
-    return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, P6, P7, P8)>(std::bind(callback, _1, _2, _3, _4, _5, _6, _7, _8, _9)));
+    return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, P6, P7, P8)>(std::bind(callback, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5, std::placeholders::_6, std::placeholders::_7, std::placeholders::_8, std::placeholders::_9)));
   }
 
   template<typename T, typename P0, typename P1>
   Connection addCallback(void(T::*callback)(P0, P1), T* t)
   {
-    using namespace std::placeholders;
-    return addCallback(std::function<void(P0, P1, NullP, NullP, NullP, NullP, NullP, NullP, NullP)>(std::bind(callback, t, _1, _2)));
+    return addCallback(std::function<void(P0, P1, NullP, NullP, NullP, NullP, NullP, NullP, NullP)>(std::bind(callback, t, std::placeholders::_1, std::placeholders::_2)));
   }
 
   template<typename T, typename P0, typename P1, typename P2>
   Connection addCallback(void(T::*callback)(P0, P1, P2), T* t)
   {
-    using namespace std::placeholders;
-    return addCallback(std::function<void(P0, P1, P2, NullP, NullP, NullP, NullP, NullP, NullP)>(std::bind(callback, t, _1, _2, _3)));
+    return addCallback(std::function<void(P0, P1, P2, NullP, NullP, NullP, NullP, NullP, NullP)>(std::bind(callback, t, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3)));
   }
 
   template<typename T, typename P0, typename P1, typename P2, typename P3>
   Connection addCallback(void(T::*callback)(P0, P1, P2, P3), T* t)
   {
-    using namespace std::placeholders;
-    return addCallback(std::function<void(P0, P1, P2, P3, NullP, NullP, NullP, NullP, NullP)>(std::bind(callback, t, _1, _2, _3, _4)));
+    return addCallback(std::function<void(P0, P1, P2, P3, NullP, NullP, NullP, NullP, NullP)>(std::bind(callback, t, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4)));
   }
 
   template<typename T, typename P0, typename P1, typename P2, typename P3, typename P4>
   Connection addCallback(void(T::*callback)(P0, P1, P2, P3, P4), T* t)
   {
-    using namespace std::placeholders;
-    return addCallback(std::function<void(P0, P1, P2, P3, P4, NullP, NullP, NullP, NullP)>(std::bind(callback, t, _1, _2, _3, _4, _5)));
+    return addCallback(std::function<void(P0, P1, P2, P3, P4, NullP, NullP, NullP, NullP)>(std::bind(callback, t, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5)));
   }
 
   template<typename T, typename P0, typename P1, typename P2, typename P3, typename P4, typename P5>
   Connection addCallback(void(T::*callback)(P0, P1, P2, P3, P4, P5), T* t)
   {
-    using namespace std::placeholders;
-    return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, NullP, NullP, NullP)>(std::bind(callback, t, _1, _2, _3, _4, _5, _6)));
+    return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, NullP, NullP, NullP)>(std::bind(callback, t, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5, std::placeholders::_6)));
   }
 
   template<typename T, typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6>
   Connection addCallback(void(T::*callback)(P0, P1, P2, P3, P4, P5, P6), T* t)
   {
-    using namespace std::placeholders;
-    return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, P6, NullP, NullP)>(std::bind(callback, t, _1, _2, _3, _4, _5, _6, _7)));
+    return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, P6, NullP, NullP)>(std::bind(callback, t, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5, std::placeholders::_6, std::placeholders::_7)));
   }
 
   template<typename T, typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6, typename P7>
   Connection addCallback(void(T::*callback)(P0, P1, P2, P3, P4, P5, P6, P7), T* t)
   {
-    using namespace std::placeholders;
-    return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, P6, P7, NullP)>(std::bind(callback, t, _1, _2, _3, _4, _5, _6, _7, _8)));
+    return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, P6, P7, NullP)>(std::bind(callback, t, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5, std::placeholders::_6, std::placeholders::_7, std::placeholders::_8)));
   }
 
   template<typename C>
   Connection addCallback( C& callback)
   {
-    using namespace std::placeholders;
     return addCallback<const M0ConstPtr&,
                      const M1ConstPtr&,
                      const M2ConstPtr&,
@@ -293,7 +277,7 @@ public:
                      const M5ConstPtr&,
                      const M6ConstPtr&,
                      const M7ConstPtr&,
-                     const M8ConstPtr&>(std::bind(callback, _1, _2, _3, _4, _5, _6, _7, _8, _9));
+                     const M8ConstPtr&>(std::bind(callback, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5, std::placeholders::_6, std::placeholders::_7, std::placeholders::_8, std::placeholders::_9));
   }
 
   void removeCallback(const CallbackHelper9Ptr& helper)


### PR DESCRIPTION
This resolves an issue where `std::bind` placeholders are ambiguous when including both `boost/bind.hpp` and `message_filters/signal9.h`. `boost/bind.hpp` includes the line `using namespace boost::placeholders;`. Message filters also uses `using namespace std::placeholders` (in a smaller scope). That causes a compile error about the unqualified placeholders (`_1`, `_2`, ...) in `signal9.h` being ambiguous. This PR works around it by using the fully qualified namespace.

My motivation is porting `pcl_ros` to ROS 2. `pcl` 1.8 includes `boost/bind.hpp` in public headers, and `pcl_ros` uses `message_filters`.

<details><summary>pcl 1.8 files using boost bind</summary>

```
/usr/include/pcl-1.8/pcl/registration/boost.h:#include <boost/bind.hpp>
/usr/include/pcl-1.8/pcl/visualization/boost.h:#include <boost/bind.hpp>
/usr/include/pcl-1.8/pcl/filters/boost.h:#include <boost/bind.hpp>
/usr/include/pcl-1.8/pcl/keypoints/keypoint.h:#include <boost/bind.hpp>
/usr/include/pcl-1.8/pcl/io/boost.h:#include <boost/bind.hpp>
/usr/include/pcl-1.8/pcl/io/openni2/openni2_device.h:#include <boost/bind.hpp>
/usr/include/pcl-1.8/pcl/features/feature.h:#include <boost/bind.hpp>
/usr/include/pcl-1.8/pcl/features/boost.h:#include <boost/bind.hpp>
/usr/include/pcl-1.8/pcl/surface/boost.h:#include <boost/bind.hpp>
```
</details>

<details><summary>Compile errors in pcl_ros</summary>

```
/opt/ros/dashing/include/message_filters/signal9.h:281:126: error: reference to ‘_6’ is ambiguous
     return addCallback(std::function<void(P0, P1, P2, P3, P4, P5, P6, P7, NullP)>(std::bind(callback, t, _1, _2, _3, _4, _5, _6, _7, _8)));
                                                                                                                              ^~
In file included from /usr/include/boost/function.hpp:13:0,
                 from /usr/include/pcl-1.8/pcl/features/feature.h:48,
                 from /usr/include/pcl-1.8/pcl/features/normal_3d.h:44,
                 from /home/sloretz/ws/mf_ws2/src/perception_pcl/pcl_ros/include/pcl_ros/features/normal_3d.h:41,
                 from /home/sloretz/ws/mf_ws2/src/perception_pcl/pcl_ros/src/pcl_ros/features/normal_3d.cpp:38:
/usr/include/c++/7/functional:280:34: note: candidates are: const std::_Placeholder<6> std::placeholders::_6
     extern const _Placeholder<6> _6;
                                  ^~
In file included from /usr/include/boost/bind/bind.hpp:2319:0,
                 from /usr/include/boost/bind.hpp:22,
                 from /usr/include/pcl-1.8/pcl/features/feature.h:49,
                 from /usr/include/pcl-1.8/pcl/features/normal_3d.h:44,
                 from /home/sloretz/ws/mf_ws2/src/perception_pcl/pcl_ros/include/pcl_ros/features/normal_3d.h:41,
                 from /home/sloretz/ws/mf_ws2/src/perception_pcl/pcl_ros/src/pcl_ros/features/normal_3d.cpp:38:
/usr/include/boost/bind/placeholders.hpp:51:38: note:                 constexpr const boost::arg<6> boost::placeholders::_6
 BOOST_STATIC_CONSTEXPR boost::arg<6> _6;
                                      ^~
In file included from /opt/ros/dashing/include/message_filters/synchronizer.h:47:0,
                 from /home/sloretz/ws/mf_ws2/src/perception_pcl/pcl_ros/include/pcl_ros/pcl_node.h:60,
                 from /home/sloretz/ws/mf_ws2/src/perception_pcl/pcl_ros/include/pcl_ros/features/feature.h:45,
                 from /home/sloretz/ws/mf_ws2/src/perception_pcl/pcl_ros/include/pcl_ros/features/normal_3d.h:42,
                 from /home/sloretz/ws/mf_ws2/src/perception_pcl/pcl_ros/src/pcl_ros/features/normal_3d.cpp:38:
```
</details>

I thought I could work around this by moving `message_filters` imports above `pcl` imports, but that does not work. I think the placeholder names are being resolved when the `Signal9<>` class is instantiated.