### PR TITLE
Expose Subscription Options - V2

### DIFF
--- a/include/message_filters/subscriber.h
+++ b/include/message_filters/subscriber.h
@@ -107,7 +107,9 @@ public:
     rclcpp::SubscriptionOptions options)
   {
     (void) options;
-    RCLCPP_WARN(node->get_logger(), "SubscriberBase::subscribe with four arguments has not been overridden");
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "SubscriberBase::subscribe with four arguments has not been overridden");
     this->subscribe(node, topic, qos);
   }
 

--- a/include/message_filters/subscriber.h
+++ b/include/message_filters/subscriber.h
@@ -107,7 +107,7 @@ public:
     rclcpp::SubscriptionOptions options)
   {
     (void) options;
-    throw std::runtime_error("SubscriberBase::subscribe with four arguments has not been overridden");
+    RCLCPP_WARN(node->get_logger(), "SubscriberBase::subscribe with four arguments has not been overridden");
     this->subscribe(node, topic, qos);
   }
 


### PR DESCRIPTION
This PR is needed for QoS overrides in subscriptions, as in https://github.com/ros-perception/image_pipeline/pull/651.

This is the approach suggested in https://github.com/ros2/message_filters/pull/53#discussion_r626682459.