### PR TITLE
Correct package.xml and CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,6 @@ find_package(ament_cmake_python REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcutils REQUIRED)
-find_package(builtin_interfaces REQUIRED)
 
 add_library(${PROJECT_NAME} src/connection.cpp)
 if(WIN32)
@@ -29,8 +28,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 ament_target_dependencies(${PROJECT_NAME}
   "rclcpp"
   "rcutils"
-  "builtin_interfaces"
-  )
+)
 
 install(
   TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
@@ -44,19 +42,13 @@ install(
   DESTINATION include
 )
 
-find_package(python_cmake_module REQUIRED)
-_ament_cmake_python_register_environment_hook()
-install(
-  DIRECTORY "src/${PROJECT_NAME}/"
-  DESTINATION "${PYTHON_INSTALL_DIR}/${PROJECT_NAME}"
-  PATTERN "*.pyc" EXCLUDE
-  PATTERN "__pycache__" EXCLUDE
-)
+ament_python_install_package(${PROJECT_NAME}
+  PACKAGE_DIR src/${PROJECT_NAME})
 
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(${PROJECT_NAME})
-ament_export_dependencies(rclcpp rcutils builtin_interfaces)
+ament_export_dependencies(rclcpp rcutils)
 
 if(BUILD_TESTING)
   find_package(sensor_msgs REQUIRED)
@@ -120,6 +112,7 @@ if(BUILD_TESTING)
   endif()
 
   # Provides PYTHON_EXECUTABLE_DEBUG
+  find_package(python_cmake_module REQUIRED)
   find_package(PythonExtra REQUIRED)
   set(_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
   if(WIN32)

--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,8 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <buildtool_depend>python_cmake_module</buildtool_depend>
 
+  <build_depend>rclcpp</build_depend>
+  <build_depend>rcutils</build_depend>
   <build_export_depend>rclcpp</build_export_depend>
   <build_export_depend>rcutils</build_export_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -29,7 +29,6 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
-  <test_depend>rclcpp</test_depend>
   <test_depend>sensor_msgs</test_depend>
   <test_depend>std_msgs</test_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -14,17 +14,20 @@
   <author>Dirk Thomas</author>
   <author>Jing Wang</author>
 
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <buildtool_depend>python_cmake_module</buildtool_depend>
 
-  <build_depend>builtin_interfaces</build_depend>
-  <build_depend>rclcpp</build_depend>
-  <build_depend>rclpy</build_depend>
+  <build_export_depend>rclcpp</build_export_depend>
+  <build_export_depend>rcutils</build_export_depend>
+
+  <exec_depend>builtin_interfaces</exec_depend>
+  <exec_depend>rclpy</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>rclcpp</test_depend>
   <test_depend>sensor_msgs</test_depend>
   <test_depend>std_msgs</test_depend>
 


### PR DESCRIPTION
This patch revisits and corrects this package's metadata and build system. Namely,

- Use and export build and run time dependencies properly.
- Install Python code as a Python package.
