### PR TITLE
Suppress rclcpp deprecation warnings in unit tests

### DIFF
--- a/test/test_subscriber.cpp
+++ b/test/test_subscriber.cpp
@@ -34,6 +34,10 @@
 
 #include <gtest/gtest.h>
 
+// see ros2/rclcpp#1619,1713
+// TODO: remove this comment, and the `NonConstHelper` tests
+// once the deprecated signatures have been discontinued.
+#define RCLCPP_AVOID_DEPRECATIONS_FOR_UNIT_TESTS 1
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_lifecycle/lifecycle_node.hpp>
 #include "message_filters/subscriber.h"


### PR DESCRIPTION
ros2/rclcpp#1713 deprecates the `void shared_ptr<T>` subscription callback signatures, so this PR introduces the `RCLCPP_AVOID_DEPRECATIONS_FOR_UNIT_TESTS` macro to suppress warnings from the tests requiring these deprecated signatures.

Said tests (those with `NonConstHelper`) have to be removed once the deprecated signatures are removed from `rclcpp`.

Signed-off-by: Abrar Rahman Protyasha <abrar@openrobotics.org>