### PR TITLE
Get topic name from base class to propagate remaps

### DIFF
--- a/include/message_filters/subscriber.h
+++ b/include/message_filters/subscriber.h
@@ -321,7 +321,7 @@ public:
 
   std::string getTopic() const
   {
-    return this->topic_;
+    return std::string(this->sub_->get_topic_name());
   }
 
   /**


### PR DESCRIPTION
When remapping a topic `foo` to `bar`, it appears that `Subscriber::getTopic` returns the name of the topic as initialized when instantiating the subscriber `foo`.
In the base class, get topic returns the remapped topic `bar`, which is in my opinion the correct behavior to go to.

If I were to retrieve the topic I'm subscribing to, I expect to retrieve the remapped name (aka the true name) rather than something that is not used.