### PR TITLE
Add lifecycle node support (#59)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,8 @@ ament_export_targets(${PROJECT_NAME})
 if(BUILD_TESTING)
   find_package(sensor_msgs REQUIRED)
   find_package(ament_lint_auto REQUIRED)
+  find_package(rclcpp_lifecycle REQUIRED)
+
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gtest)
@@ -88,7 +90,7 @@ if(BUILD_TESTING)
   if(TARGET ${PROJECT_NAME}-test_subscriber)
     target_link_libraries(${PROJECT_NAME}-test_subscriber ${PROJECT_NAME})
     target_include_directories(${PROJECT_NAME}-test_subscriber PUBLIC include)
-    ament_target_dependencies(${PROJECT_NAME}-test_subscriber "rclcpp" "sensor_msgs")
+    ament_target_dependencies(${PROJECT_NAME}-test_subscriber "rclcpp" "rclcpp_lifecycle" "sensor_msgs")
   endif()
 
   ament_add_gtest(${PROJECT_NAME}-test_synchronizer test/test_synchronizer.cpp)

--- a/include/message_filters/subscriber.h
+++ b/include/message_filters/subscriber.h
@@ -43,9 +43,12 @@
 namespace message_filters
 {
 
+template<class NodeType = rclcpp::Node>
 class SubscriberBase
 {
 public:
+  typedef std::shared_ptr<NodeType> NodePtr;
+
   virtual ~SubscriberBase() = default;
   /**
    * \brief Subscribe to a topic.
@@ -56,7 +59,7 @@ public:
    * \param topic The topic to subscribe to.
    * \param qos (optional) The rmw qos profile to use to subscribe
    */
-  virtual void subscribe(rclcpp::Node::SharedPtr node, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default) = 0;
+  virtual void subscribe(NodePtr node, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default) = 0;
 
   /**
    * \brief Subscribe to a topic.
@@ -67,7 +70,50 @@ public:
    * \param topic The topic to subscribe to.
    * \param qos (optional) The rmw qos profile to use to subscribe
    */
-  virtual void subscribe(rclcpp::Node * node, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default) = 0;
+  virtual void subscribe(NodeType * node, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default) = 0;
+
+  /**
+   * \brief Subscribe to a topic.
+   *
+   * If this Subscriber is already subscribed to a topic, this function will first unsubscribe.
+   * This override allows SubscriptionOptions to be passed into the class without changing API.
+   *
+   * \param node The rclcpp::Node::SharedPtr to use to subscribe.
+   * \param topic The topic to subscribe to.
+   * \param qos (optional) The rmw qos profile to use to subscribe.
+   * \param options The subscription options to use to subscribe.
+   */
+  virtual void subscribe(
+    NodePtr node,
+    const std::string& topic,
+    const rmw_qos_profile_t qos,
+    rclcpp::SubscriptionOptions options)
+  {
+    this->subscribe(node.get(), topic, qos, options);
+  };
+
+  /**
+   * \brief Subscribe to a topic.
+   *
+   * If this Subscriber is already subscribed to a topic, this function will first unsubscribe.
+   *
+   * \param node The rclcpp::Node to use to subscribe.
+   * \param topic The topic to subscribe to.
+   * \param qos (optional) The rmw qos profile to use to subscribe
+   */
+  virtual void subscribe(
+    NodeType * node,
+    const std::string& topic,
+    const rmw_qos_profile_t qos,
+    rclcpp::SubscriptionOptions options)
+  {
+    (void) options;
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "SubscriberBase::subscribe with four arguments has not been overridden");
+    this->subscribe(node, topic, qos);
+  }
+
   /**
    * \brief Re-subscribe to a topic.  Only works if this subscriber has previously been subscribed to a topic.
    */
@@ -77,7 +123,8 @@ public:
    */
   virtual void unsubscribe() = 0;
 };
-typedef std::shared_ptr<SubscriberBase> SubscriberBasePtr;
+template <typename T>
+using SubscriberBasePtr = std::shared_ptr<SubscriberBase<T>>;
 
 /**
  * \brief ROS subscription filter.
@@ -98,10 +145,11 @@ typedef std::shared_ptr<SubscriberBase> SubscriberBasePtr;
 void callback(const std::shared_ptr<M const>&);
 \endverbatim
  */
-template<class M>
-class Subscriber : public SubscriberBase, public SimpleFilter<M>
+template<class M, class NodeType = rclcpp::Node>
+class Subscriber : public SubscriberBase<NodeType>, public SimpleFilter<M>
 {
 public:
+  typedef std::shared_ptr<NodeType> NodePtr;
   typedef MessageEvent<M const> EventType;
 
   /**
@@ -113,14 +161,42 @@ public:
    * \param topic The topic to subscribe to.
    * \param qos (optional) The rmw qos profile to use to subscribe
    */
-  Subscriber(rclcpp::Node::SharedPtr node, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default)
+  Subscriber(NodePtr node, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default)
   {
     subscribe(node, topic, qos);
   }
 
-  Subscriber(rclcpp::Node* node, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default)
+  Subscriber(NodeType * node, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default)
   {
     subscribe(node, topic, qos);
+  }
+
+  /**
+   * \brief Constructor
+   *
+   * See the rclcpp::Node::subscribe() variants for more information on the parameters
+   *
+   * \param node The rclcpp::Node::SharedPtr to use to subscribe.
+   * \param topic The topic to subscribe to.
+   * \param qos The rmw qos profile to use to subscribe.
+   * \param options The subscription options to use to subscribe.
+   */
+  Subscriber(
+    NodePtr node,
+    const std::string& topic,
+    const rmw_qos_profile_t qos,
+    rclcpp::SubscriptionOptions options)
+  {
+      subscribe(node.get(), topic, qos, options);
+  }
+
+  Subscriber(
+    NodeType * node,
+    const std::string& topic,
+    const rmw_qos_profile_t qos,
+    rclcpp::SubscriptionOptions options)
+  {
+    subscribe(node, topic, qos, options);
   }
 
   /**
@@ -142,9 +218,43 @@ public:
    * \param topic The topic to subscribe to.
    * \param qos (optional) The rmw qos profile to use to subscribe
    */
-  void subscribe(rclcpp::Node::SharedPtr node, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default)
+  void subscribe(NodePtr node, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default) override
   {
-    subscribe(node.get(), topic, qos);
+    subscribe(node.get(), topic, qos, rclcpp::SubscriptionOptions());
+  }
+
+  /**
+   * \brief Subscribe to a topic.
+   *
+   * If this Subscriber is already subscribed to a topic, this function will first unsubscribe.
+   *
+   * \param node The rclcpp::Node to use to subscribe.
+   * \param topic The topic to subscribe to.
+   * \param qos (optional) The rmw qos profile to use to subscribe
+   */
+  // TODO(wjwwood): deprecate in favor of API's that use `rclcpp::QoS` instead.
+  void subscribe(NodeType * node, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default) override
+  {
+    subscribe(node, topic, qos, rclcpp::SubscriptionOptions());
+  }
+
+  /**
+   * \brief Subscribe to a topic.
+   *
+   * If this Subscriber is already subscribed to a topic, this function will first unsubscribe.
+   *
+   * \param node The rclcpp::Node::SharedPtr to use to subscribe.
+   * \param topic The topic to subscribe to.
+   * \param qos The rmw qos profile to use to subscribe.
+   * \param options The subscription options to use to subscribe.
+   */
+  void subscribe(
+    NodePtr node,
+    const std::string& topic,
+    const rmw_qos_profile_t qos,
+    rclcpp::SubscriptionOptions options)
+  {
+    subscribe(node.get(), topic, qos, options);
     node_raw_ = nullptr;
     node_shared_ = node;
   }
@@ -159,7 +269,11 @@ public:
    * \param qos (optional) The rmw qos profile to use to subscribe
    */
   // TODO(wjwwood): deprecate in favor of API's that use `rclcpp::QoS` instead.
-  void subscribe(rclcpp::Node * node, const std::string& topic, const rmw_qos_profile_t qos = rmw_qos_profile_default)
+  void subscribe(
+    NodeType * node,
+    const std::string& topic,
+    const rmw_qos_profile_t qos,
+    rclcpp::SubscriptionOptions options)
   {
     unsubscribe();
 
@@ -169,7 +283,8 @@ public:
       rclcpp::QoS rclcpp_qos(rclcpp::QoSInitialization::from_rmw(qos));
       rclcpp_qos.get_rmw_qos_profile() = qos;
       qos_ = qos;
-      sub_ = node->create_subscription<M>(topic, rclcpp_qos,
+      options_ = options;
+      sub_ = node->template create_subscription<M>(topic, rclcpp_qos,
                [this](std::shared_ptr<M const> msg) {
                  this->cb(EventType(msg));
                });
@@ -181,7 +296,7 @@ public:
   /**
    * \brief Re-subscribe to a topic.  Only works if this subscriber has previously been subscribed to a topic.
    */
-  void subscribe()
+  void subscribe() override
   {
     if (!topic_.empty())
     {
@@ -196,7 +311,7 @@ public:
   /**
    * \brief Force immediate unsubscription of this subscriber from its topic
    */
-  void unsubscribe()
+  void unsubscribe() override
   {
     sub_.reset();
   }
@@ -237,11 +352,12 @@ private:
 
   typename rclcpp::Subscription<M>::SharedPtr sub_;
 
-  rclcpp::Node::SharedPtr node_shared_;
-  rclcpp::Node * node_raw_ {nullptr};
+  NodePtr node_shared_;
+  NodeType * node_raw_ {nullptr};
 
   std::string topic_;
   rmw_qos_profile_t qos_;
+  rclcpp::SubscriptionOptions options_;
 };
 
 }  // namespace message_filters

--- a/package.xml
+++ b/package.xml
@@ -27,6 +27,7 @@
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>sensor_msgs</test_depend>
   <test_depend>std_msgs</test_depend>
+  <test_depend>rclcpp_lifecycle</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
* adapt Subscriber class to be used with LifecycleNode instances
* Update to new subscriber calls
* Change rclcpp_lifecycle to a test dependency

Taken from rolling release branch
Signed-off-by: Hunter L. Allen <hunter.allen@ghostrobotics.io>
Co-authored-by: Joao C. Monteiro <jcmonteiro92@gmail.com>