### PR TITLE
Add a simpler aproximate time sync policy: ApproximateEpsilonTime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,11 @@ if(BUILD_TESTING)
   if(TARGET ${PROJECT_NAME}-test_approximate_time_policy)
     target_link_libraries(${PROJECT_NAME}-test_approximate_time_policy ${PROJECT_NAME})
   endif()
+
+  ament_add_gtest(${PROJECT_NAME}-test_approximate_epsilon_time_policy test/test_approximate_epsilon_time_policy.cpp)
+  if(TARGET ${PROJECT_NAME}-test_approximate_epsilon_time_policy)
+    target_link_libraries(${PROJECT_NAME}-test_approximate_epsilon_time_policy ${PROJECT_NAME})
+  endif()
   
   ament_add_gtest(${PROJECT_NAME}-test_latest_time_policy test/test_latest_time_policy.cpp)
   if(TARGET ${PROJECT_NAME}-test_latest_time_policy)

--- a/include/message_filters/sync_policies/approximate_epsilon_time.h
+++ b/include/message_filters/sync_policies/approximate_epsilon_time.h
@@ -203,12 +203,6 @@ private:
       older, std::make_index_sequence<9u>());
   }
 
-  // void erase_old_events()
-  // {
-  //   auto old = get_older_timestamp();
-  //   erase_old_events_within_ts(old);
-  // }
-
   template<size_t Is>
   void
   erase_begin_of_vector()

--- a/include/message_filters/sync_policies/approximate_epsilon_time.h
+++ b/include/message_filters/sync_policies/approximate_epsilon_time.h
@@ -1,7 +1,7 @@
 /*********************************************************************
 * Software License Agreement (BSD License)
 *
-*  Copyright (c) 2009, Willow Garage, Inc.
+*  Copyright (c) 2022, Open Source Robotics Foundation, Inc.
 *  All rights reserved.
 *
 *  Redistribution and use in source and binary forms, with or without

--- a/include/message_filters/sync_policies/approximate_epsilon_time.h
+++ b/include/message_filters/sync_policies/approximate_epsilon_time.h
@@ -1,0 +1,357 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2009, Willow Garage, Inc.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#ifndef MESSAGE_FILTERS__SYNC_POLICIES__APPROXIMATE_EPSILON_TIME_H_
+#define MESSAGE_FILTERS__SYNC_POLICIES__APPROXIMATE_EPSILON_TIME_H_
+
+#include <deque>
+#include <string>
+#include <tuple>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "message_filters/connection.h"
+#include "message_filters/message_traits.h"
+#include "message_filters/null_types.h"
+#include "message_filters/signal9.h"
+#include "message_filters/synchronizer.h"
+
+namespace message_filters
+{
+namespace sync_policies
+{
+
+template<typename M0, typename M1, typename M2 = NullType, typename M3 = NullType, typename M4 = NullType,
+         typename M5 = NullType, typename M6 = NullType, typename M7 = NullType, typename M8 = NullType>
+class ApproximateEpsilonTime : public PolicyBase<M0, M1, M2, M3, M4, M5, M6, M7, M8>
+{
+public:
+  typedef Synchronizer<ApproximateEpsilonTime> Sync;
+  typedef PolicyBase<M0, M1, M2, M3, M4, M5, M6, M7, M8> Super;
+  typedef typename Super::Messages Messages;
+  typedef typename Super::Signal Signal;
+  typedef typename Super::Events Events;
+  typedef typename Super::RealTypeCount RealTypeCount;
+  typedef typename Super::M0Event M0Event;
+  typedef typename Super::M1Event M1Event;
+  typedef typename Super::M2Event M2Event;
+  typedef typename Super::M3Event M3Event;
+  typedef typename Super::M4Event M4Event;
+  typedef typename Super::M5Event M5Event;
+  typedef typename Super::M6Event M6Event;
+  typedef typename Super::M7Event M7Event;
+  typedef typename Super::M8Event M8Event;
+  typedef Events Tuple;
+
+  ApproximateEpsilonTime(uint32_t queue_size, rclcpp::Duration epsilon)
+  : parent_(nullptr)
+  , queue_size_(queue_size)
+  , epsilon_{epsilon}
+  {
+  }
+
+  ApproximateEpsilonTime(const ApproximateEpsilonTime& e)
+  : epsilon_{e.epsilon_}
+  {
+    *this = e;
+  }
+
+  ApproximateEpsilonTime& operator=(const ApproximateEpsilonTime& rhs)
+  {
+    parent_ = rhs.parent_;
+    queue_size_ = rhs.queue_size_;
+    events_ = rhs.events_;
+    epsilon_ = rhs.epsilon_;
+
+    return *this;
+  }
+
+  void initParent(Sync* parent)
+  {
+    parent_ = parent;
+  }
+
+  template<size_t i>
+  void add(const typename std::tuple_element<i, Events>::type& evt)
+  {
+    RCUTILS_ASSERT(parent_);
+
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    // Tuple& t = tuples_[mt::TimeStamp<typename std::tuple_element<i, Messages>::type>::value(*evt.getMessage())];
+    auto & events_of_this_type = std::get<i>(events_);
+    if (0u == events_of_this_type.size()) {
+      ++number_of_non_empty_events_;
+    }
+    events_of_this_type.push_back(evt);
+    if (number_of_non_empty_events_ == RealTypeCount::value) {
+      process();
+    } else if (events_of_this_type.size() > queue_size_) {
+      // erase_old_events();
+      erase_begin_of_vector<i>();
+    }
+  }
+
+private:
+  // using mt = message_filters::message_traits;
+  using TimeIndexPair = std::pair<rclcpp::Time, size_t>;
+
+  template <size_t Is>
+  TimeIndexPair
+  get_older_timestamp_between(const TimeIndexPair & current)
+  {
+    namespace mt = message_filters::message_traits;
+    using ThisEventType = typename std::tuple_element<Is, Events>::type;
+    if constexpr (Is >= RealTypeCount::value) {
+      return current;
+    }
+    const auto & events_of_this_type = std::get<Is>(events_);
+    if (0u == events_of_this_type.size()) {
+      // this condition should not happen
+      return current;
+    }
+    auto candidate = mt::TimeStamp<typename ThisEventType::Message>::value(*events_of_this_type.at(0).getMessage());
+    if (current.first > candidate) {
+      return std::make_pair(candidate, Is);
+    }
+    return current;
+  }
+
+  template <size_t ... Is>
+  TimeIndexPair
+  get_older_timestamp_helper(std::index_sequence<Is...> const &)
+  {
+    TimeIndexPair older{
+      rclcpp::Time(std::numeric_limits<int64_t>::max(), RCL_ROS_TIME), std::numeric_limits<size_t>::max()};
+    ((older = get_older_timestamp_between<Is>(older)), ...);
+    return older;
+  }
+
+  TimeIndexPair
+  get_older_timestamp()
+  {
+    return get_older_timestamp_helper(std::make_index_sequence<9u>());
+  }
+
+  template <size_t Is>
+  bool
+  check_timestamp_within_epsilon(const TimeIndexPair & older)
+  {
+    namespace mt = message_filters::message_traits;
+    using ThisEventType = typename std::tuple_element<Is, Events>::type;
+    if constexpr (Is >= RealTypeCount::value) {
+      return true;
+    }
+    if (Is == older.second) {
+      return true;
+    }
+    const auto & events_of_this_type = std::get<Is>(events_);
+    if (0u == events_of_this_type.size()) {
+      // this condition should not happen
+      return false;
+    }
+    auto ts = mt::TimeStamp<typename ThisEventType::Message>::value(*events_of_this_type.at(0).getMessage());
+    if (older.first + epsilon_ >= ts) {
+      return true;
+    }
+    return false;
+  }
+
+  template <size_t ... Is>
+  bool
+  check_all_timestamp_within_epsilon_helper(
+    const TimeIndexPair & older, std::index_sequence<Is...> const &)
+  {
+    bool valid = true;
+    ((valid &= check_timestamp_within_epsilon<Is>(older)), ...);
+    return valid;
+  }
+
+  bool
+  check_all_timestamp_within_epsilon(const TimeIndexPair & older)
+  {
+    return check_all_timestamp_within_epsilon_helper(
+      older, std::make_index_sequence<9u>());
+  }
+
+  // void erase_old_events()
+  // {
+  //   auto old = get_older_timestamp();
+  //   erase_old_events_within_ts(old);
+  // }
+
+  template<size_t Is>
+  void
+  erase_begin_of_vector()
+  {
+    if constexpr (Is >= RealTypeCount::value) {
+      return;
+    }
+    auto & this_vector = std::get<Is>(events_);
+    if (this_vector.begin() != this_vector.end()) {
+      this_vector.erase(this_vector.begin());
+      if (this_vector.empty()) {
+        --number_of_non_empty_events_;
+      }
+    }
+  }
+
+  template <size_t ... Is>
+  void
+  erase_begin_of_vectors_helper(std::index_sequence<Is...> const &)
+  {
+    ((erase_begin_of_vector<Is>()), ...);
+  }
+
+  void erase_begin_of_vectors()
+  {
+    return erase_begin_of_vectors_helper(std::make_index_sequence<9u>());
+  }
+
+  template<size_t Is>
+  void
+  erase_begin_of_vector_if_within_ts(rclcpp::Time timestamp)
+  {
+    namespace mt = message_filters::message_traits;
+    using ThisEventType = typename std::tuple_element<Is, Events>::type;
+    if constexpr (Is >= RealTypeCount::value) {
+      return;
+    }
+    auto & this_vector = std::get<Is>(events_);
+    if (this_vector.begin() == this_vector.end()) {
+      return;
+    }
+    auto event_ts = mt::TimeStamp<typename ThisEventType::Message>::value(
+      *this_vector.at(0).getMessage());
+    if (timestamp + epsilon_ < event_ts) {
+      return;
+    }
+    this_vector.erase(this_vector.begin());
+    if (this_vector.empty()) {
+      --number_of_non_empty_events_;
+    }
+  }
+
+  template <size_t ... Is>
+  void
+  erase_old_events_within_ts_helper(rclcpp::Time timestamp, std::index_sequence<Is...> const &)
+  {
+    ((erase_begin_of_vector_if_within_ts<Is>(timestamp)), ...);
+  }
+
+  void erase_old_events_within_ts(rclcpp::Time timestamp)
+  {
+    return erase_old_events_within_ts_helper(timestamp, std::make_index_sequence<9u>());
+  }
+
+  void signal()
+  {
+    if constexpr (RealTypeCount::value == 2) {
+      parent_->signal(
+        std::get<0>(events_).at(0), std::get<1>(events_).at(0),
+        M2Event{}, M3Event{}, M4Event{}, M5Event{}, M6Event{}, M7Event{}, M8Event{});
+    } else if constexpr (RealTypeCount::value == 3) {
+      parent_->signal(
+        std::get<0>(events_).at(0), std::get<1>(events_).at(0), std::get<2>(events_).at(0),
+        M3Event{}, M4Event{}, M5Event{}, M6Event{}, M7Event{}, M8Event{});
+    } else if constexpr (RealTypeCount::value == 4) {
+      parent_->signal(
+        std::get<0>(events_).at(0), std::get<1>(events_).at(0), std::get<2>(events_).at(0),
+        std::get<3>(events_).at(0),
+        M4Event{}, M5Event{}, M6Event{}, M7Event{}, M8Event{});
+    } else if constexpr (RealTypeCount::value == 5) {
+      parent_->signal(
+        std::get<0>(events_).at(0), std::get<1>(events_).at(0), std::get<2>(events_).at(0),
+        std::get<3>(events_).at(0), std::get<4>(events_).at(0),
+        M5Event{}, M6Event{}, M7Event{}, M8Event{});
+    } else if constexpr (RealTypeCount::value == 6) {
+      parent_->signal(
+        std::get<0>(events_).at(0), std::get<1>(events_).at(0), std::get<2>(events_).at(0),
+        std::get<3>(events_).at(0), std::get<4>(events_).at(0), std::get<5>(events_).at(0),
+        M6Event{}, M7Event{}, M8Event{});
+    } else if constexpr (RealTypeCount::value == 7) {
+      parent_->signal(
+        std::get<0>(events_).at(0), std::get<1>(events_).at(0), std::get<2>(events_).at(0),
+        std::get<3>(events_).at(0), std::get<4>(events_).at(0), std::get<5>(events_).at(0),
+        std::get<6>(events_).at(0),
+        M7Event{}, M8Event{});
+    } else if constexpr (RealTypeCount::value == 8) {
+      parent_->signal(
+        std::get<0>(events_).at(0), std::get<1>(events_).at(0), std::get<2>(events_).at(0),
+        std::get<3>(events_).at(0), std::get<4>(events_).at(0), std::get<5>(events_).at(0),
+        std::get<6>(events_).at(0), std::get<7>(events_).at(0),
+        M8Event{});
+    } else if constexpr (RealTypeCount::value == 9) {
+      parent_->signal(
+        std::get<0>(events_).at(0), std::get<1>(events_).at(0), std::get<2>(events_).at(0),
+        std::get<3>(events_).at(0), std::get<4>(events_).at(0), std::get<5>(events_).at(0),
+        std::get<6>(events_).at(0), std::get<7>(events_).at(0), std::get<8>(events_).at(0));
+    } else {
+      static_assert("RealTypeCount::value should be >=2 and <=9");
+    }
+  }
+
+  // assumes mutex_ is already locked
+  void process()
+  {
+    while (number_of_non_empty_events_ == RealTypeCount::value) {
+      auto old_ts = get_older_timestamp();
+      if (check_all_timestamp_within_epsilon(old_ts)) {
+        signal();
+        erase_begin_of_vectors();
+      } else {
+        erase_old_events_within_ts(old_ts.first);
+      }
+    }
+  }
+
+  Sync* parent_;
+
+  uint32_t queue_size_;
+  rclcpp::Duration epsilon_;
+  size_t number_of_non_empty_events_{0};
+  using TupleOfVecOfEvents = std::tuple<
+    std::vector<M0Event>, std::vector<M1Event>, std::vector<M2Event>,
+    std::vector<M3Event>, std::vector<M4Event>, std::vector<M5Event>,
+    std::vector<M6Event>, std::vector<M7Event>, std::vector<M8Event>>;
+  TupleOfVecOfEvents events_;
+
+  std::mutex mutex_;
+};
+
+}  // namespace sync_policies
+}  // namespace message_filters
+
+#endif  // MESSAGE_FILTERS__SYNC_POLICIES__APPROXIMATE_EPSILON_TIME_H_
+

--- a/include/message_filters/sync_policies/approximate_epsilon_time.h
+++ b/include/message_filters/sync_policies/approximate_epsilon_time.h
@@ -123,7 +123,6 @@ public:
   }
 
 private:
-  // using mt = message_filters::message_traits;
   using TimeIndexPair = std::pair<rclcpp::Time, size_t>;
 
   template <size_t Is>

--- a/include/message_filters/sync_policies/approximate_epsilon_time.h
+++ b/include/message_filters/sync_policies/approximate_epsilon_time.h
@@ -109,7 +109,6 @@ public:
 
     std::lock_guard<std::mutex> lock(mutex_);
 
-    // Tuple& t = tuples_[mt::TimeStamp<typename std::tuple_element<i, Messages>::type>::value(*evt.getMessage())];
     auto & events_of_this_type = std::get<i>(events_);
     if (0u == events_of_this_type.size()) {
       ++number_of_non_empty_events_;

--- a/include/message_filters/sync_policies/approximate_epsilon_time.h
+++ b/include/message_filters/sync_policies/approximate_epsilon_time.h
@@ -118,7 +118,7 @@ public:
       process();
     } else if (events_of_this_type.size() > queue_size_) {
       // erase_old_events();
-      erase_begin_of_vector<i>();
+      erase_beginning_of_vector<i>();
     }
   }
 
@@ -205,7 +205,7 @@ private:
 
   template<size_t Is>
   void
-  erase_begin_of_vector()
+  erase_beginning_of_vector()
   {
     if constexpr (Is >= RealTypeCount::value) {
       return;
@@ -221,19 +221,19 @@ private:
 
   template <size_t ... Is>
   void
-  erase_begin_of_vectors_helper(std::index_sequence<Is...> const &)
+  erase_beginning_of_vectors_helper(std::index_sequence<Is...> const &)
   {
-    ((erase_begin_of_vector<Is>()), ...);
+    ((erase_beginning_of_vector<Is>()), ...);
   }
 
-  void erase_begin_of_vectors()
+  void erase_beginning_of_vectors()
   {
-    return erase_begin_of_vectors_helper(std::make_index_sequence<9u>());
+    return erase_beginning_of_vectors_helper(std::make_index_sequence<9u>());
   }
 
   template<size_t Is>
   void
-  erase_begin_of_vector_if_within_ts(rclcpp::Time timestamp)
+  erase_beginning_of_vector_if_within_ts(rclcpp::Time timestamp)
   {
     namespace mt = message_filters::message_traits;
     using ThisEventType = typename std::tuple_element<Is, Events>::type;
@@ -259,7 +259,7 @@ private:
   void
   erase_old_events_within_ts_helper(rclcpp::Time timestamp, std::index_sequence<Is...> const &)
   {
-    ((erase_begin_of_vector_if_within_ts<Is>(timestamp)), ...);
+    ((erase_beginning_of_vector_if_within_ts<Is>(timestamp)), ...);
   }
 
   void erase_old_events_within_ts(rclcpp::Time timestamp)
@@ -321,7 +321,7 @@ private:
       auto old_ts = get_older_timestamp();
       if (check_all_timestamp_within_epsilon(old_ts)) {
         signal();
-        erase_begin_of_vectors();
+        erase_beginning_of_vectors();
       } else {
         erase_old_events_within_ts(old_ts.first);
       }

--- a/include/message_filters/sync_policies/approximate_epsilon_time.h
+++ b/include/message_filters/sync_policies/approximate_epsilon_time.h
@@ -117,7 +117,6 @@ public:
     if (number_of_non_empty_events_ == RealTypeCount::value) {
       process();
     } else if (events_of_this_type.size() > queue_size_) {
-      // erase_old_events();
       erase_beginning_of_vector<i>();
     }
   }

--- a/include/message_filters/sync_policies/approximate_epsilon_time.h
+++ b/include/message_filters/sync_policies/approximate_epsilon_time.h
@@ -232,7 +232,7 @@ private:
 
   template<size_t Is>
   void
-  erase_beginning_of_vector_if_within_ts(rclcpp::Time timestamp)
+  erase_beginning_of_vector_if_on_sync_with_ts(rclcpp::Time timestamp)
   {
     namespace mt = message_filters::message_traits;
     using ThisEventType = typename std::tuple_element<Is, Events>::type;
@@ -256,14 +256,14 @@ private:
 
   template <size_t ... Is>
   void
-  erase_old_events_within_ts_helper(rclcpp::Time timestamp, std::index_sequence<Is...> const &)
+  erase_old_events_if_on_sync_with_ts_helper(rclcpp::Time timestamp, std::index_sequence<Is...> const &)
   {
-    ((erase_beginning_of_vector_if_within_ts<Is>(timestamp)), ...);
+    ((erase_beginning_of_vector_if_on_sync_with_ts<Is>(timestamp)), ...);
   }
 
-  void erase_old_events_within_ts(rclcpp::Time timestamp)
+  void erase_old_events_if_on_sync_with_ts(rclcpp::Time timestamp)
   {
-    return erase_old_events_within_ts_helper(timestamp, std::make_index_sequence<9u>());
+    return erase_old_events_if_on_sync_with_ts_helper(timestamp, std::make_index_sequence<9u>());
   }
 
   void signal()
@@ -322,7 +322,7 @@ private:
         signal();
         erase_beginning_of_vectors();
       } else {
-        erase_old_events_within_ts(old_ts.first);
+        erase_old_events_if_on_sync_with_ts(old_ts.first);
       }
     }
   }

--- a/include/message_filters/sync_policies/approximate_time.h
+++ b/include/message_filters/sync_policies/approximate_time.h
@@ -32,8 +32,8 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-#ifndef MESSAGE_FILTERS__SYNC_APPROXIMATE_TIME_H_
-#define MESSAGE_FILTERS__SYNC_APPROXIMATE_TIME_H_
+#ifndef MESSAGE_FILTERS__SYNC_POLICIES__APPROXIMATE_TIME_H_
+#define MESSAGE_FILTERS__SYNC_POLICIES__APPROXIMATE_TIME_H_
 
 #include <cassert>
 #include <deque>
@@ -860,4 +860,4 @@ private:
 }  // namespace sync
 }  // namespace message_filters
 
-#endif // MESSAGE_FILTERS__SYNC_APPROXIMATE_TIME_H_
+#endif // MESSAGE_FILTERS__SYNC_POLICIES__APPROXIMATE_TIME_H_

--- a/include/message_filters/sync_policies/exact_time.h
+++ b/include/message_filters/sync_policies/exact_time.h
@@ -32,8 +32,8 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-#ifndef MESSAGE_FILTERS__SYNC_EXACT_TIME_H_
-#define MESSAGE_FILTERS__SYNC_EXACT_TIME_H_
+#ifndef MESSAGE_FILTERS__SYNC_POLICIES__EXACT_TIME_H_
+#define MESSAGE_FILTERS__SYNC_POLICIES__EXACT_TIME_H_
 
 #include <deque>
 #include <string>
@@ -224,5 +224,5 @@ private:
 }  // namespace sync_policies
 }  // namespace message_filters
 
-#endif  // MESSAGE_FILTERS__SYNC_EXACT_TIME_H_
+#endif  // MESSAGE_FILTERS__SYNC_POLICIES__EXACT_TIME_H_
 

--- a/include/message_filters/sync_policies/latest_time.h
+++ b/include/message_filters/sync_policies/latest_time.h
@@ -64,8 +64,8 @@ void callback(const sensor_msgs::CameraInfo::ConstPtr&, const sensor_msgs::Image
  *
  */
 
-#ifndef MESSAGE_FILTERS__SYNC_LATEST_TIME_H_
-#define MESSAGE_FILTERS__SYNC_LATEST_TIME_H_
+#ifndef MESSAGE_FILTERS__SYNC_POLICIES__LATEST_TIME_H_
+#define MESSAGE_FILTERS__SYNC_POLICIES__LATEST_TIME_H_
 
 #include <algorithm>
 #include <memory>
@@ -386,4 +386,4 @@ private:
 }  // namespace sync
 }  // namespace message_filters
 
-#endif // MESSAGE_FILTERS__SYNC_LATEST_TIME_H_
+#endif // MESSAGE_FILTERS__SYNC_POLICIES__LATEST_TIME_H_

--- a/test/test_approximate_epsilon_time_policy.cpp
+++ b/test/test_approximate_epsilon_time_policy.cpp
@@ -2,7 +2,7 @@
 /*********************************************************************
 * Software License Agreement (BSD License)
 *
-*  Copyright (c) 2010, Willow Garage, Inc.
+*  Copyright (c) 2022, Open Source Robotics Foundation, Inc.
 *  All rights reserved.
 *
 *  Redistribution and use in source and binary forms, with or without

--- a/test/test_approximate_epsilon_time_policy.cpp
+++ b/test/test_approximate_epsilon_time_policy.cpp
@@ -131,7 +131,6 @@ public:
         sync_.add<1>(q);
       }
     }
-    //printf("Done running test\n");
     EXPECT_EQ(output_.size(), output_position_);
   }
 

--- a/test/test_approximate_epsilon_time_policy.cpp
+++ b/test/test_approximate_epsilon_time_policy.cpp
@@ -35,7 +35,6 @@
 
 #include <vector>
 
-
 #include <gtest/gtest.h>
 #include <rclcpp/rclcpp.hpp>
 

--- a/test/test_approximate_epsilon_time_policy.cpp
+++ b/test/test_approximate_epsilon_time_policy.cpp
@@ -1,0 +1,233 @@
+
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2010, Willow Garage, Inc.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#include <vector>
+
+
+#include <gtest/gtest.h>
+#include <rclcpp/rclcpp.hpp>
+
+#include "message_filters/synchronizer.h"
+#include "message_filters/sync_policies/approximate_epsilon_time.h"
+#include "message_filters/message_traits.h"
+
+using namespace std::placeholders;
+using namespace message_filters;
+using namespace message_filters::sync_policies;
+
+struct Header
+{
+  rclcpp::Time stamp;
+};
+
+
+struct Msg
+{
+  Header header;
+  int data;
+};
+using MsgPtr = std::shared_ptr<Msg>;
+using MsgConstPtr = std::shared_ptr<const Msg>;
+
+namespace message_filters
+{
+namespace message_traits
+{
+template<>
+struct TimeStamp<Msg>
+{
+  static rclcpp::Time value(const Msg& m)
+  {
+    return m.header.stamp;
+  }
+};
+}
+}
+
+typedef std::pair<rclcpp::Time, rclcpp::Time> TimePair;
+typedef std::pair<rclcpp::Time, unsigned int> TimeAndTopic;
+struct TimeQuad
+{
+  TimeQuad(rclcpp::Time p, rclcpp::Time q, rclcpp::Time r, rclcpp::Time s)
+  {
+    time[0] = p;
+    time[1] = q;
+    time[2] = r;
+    time[3] = s;
+  }
+  rclcpp::Time time[4];
+};
+
+
+class ApproximateEpsilonTimeSynchronizerTest
+{
+public:
+
+  ApproximateEpsilonTimeSynchronizerTest(const std::vector<TimeAndTopic> &input,
+				  const std::vector<TimePair> &output,
+				  uint32_t queue_size, rclcpp::Duration epsilon) :
+    input_(input), output_(output), output_position_(0), sync_(
+      ApproximateEpsilonTime<Msg, Msg>{queue_size, epsilon})
+  {
+    sync_.registerCallback(std::bind(&ApproximateEpsilonTimeSynchronizerTest::callback, this, _1, _2));
+  }
+
+  void callback(const MsgConstPtr& p, const MsgConstPtr& q)
+  {
+    ASSERT_TRUE(p);
+    ASSERT_TRUE(q);
+    ASSERT_LT(output_position_, output_.size());
+    EXPECT_EQ(output_[output_position_].first, p->header.stamp);
+    EXPECT_EQ(output_[output_position_].second, q->header.stamp);
+    ++output_position_;
+  }
+
+  void run()
+  {
+    for (unsigned int i = 0; i < input_.size(); i++)
+    {
+      if (input_[i].second == 0)
+      {
+        MsgPtr p(std::make_shared<Msg>());
+        p->header.stamp = input_[i].first;
+        sync_.add<0>(p);
+      }
+      else
+      {
+        MsgPtr q(std::make_shared<Msg>());
+        q->header.stamp = input_[i].first;
+        sync_.add<1>(q);
+      }
+    }
+    //printf("Done running test\n");
+    EXPECT_EQ(output_.size(), output_position_);
+  }
+
+private:
+  const std::vector<TimeAndTopic> &input_;
+  const std::vector<TimePair> &output_;
+  unsigned int output_position_;
+  typedef Synchronizer<ApproximateEpsilonTime<Msg, Msg> > Sync2;
+public:
+  Sync2 sync_;
+};
+
+TEST(ApproxTimeSync, ExactMatch) {
+  // Input A:  a..b..c
+  // Input B:  A..B..C
+  // Output:   a..b..c
+  //           A..B..C
+  std::vector<TimeAndTopic> input;
+  std::vector<TimePair> output;
+
+  rclcpp::Time t(0, 0, RCL_ROS_TIME);
+  rclcpp::Duration s(1, 0);
+
+  input.push_back(TimeAndTopic(t,0));     // a
+  input.push_back(TimeAndTopic(t,1));   // A
+  input.push_back(TimeAndTopic(t+s*3,0)); // b
+  input.push_back(TimeAndTopic(t+s*3,1)); // B
+  input.push_back(TimeAndTopic(t+s*6,0)); // c
+  input.push_back(TimeAndTopic(t+s*6,1)); // C
+  output.push_back(TimePair(t, t));
+  output.push_back(TimePair(t+s*3, t+s*3));
+  output.push_back(TimePair(t+s*6, t+s*6));
+
+  ApproximateEpsilonTimeSynchronizerTest sync_test(
+    input, output, 10, rclcpp::Duration::from_seconds(0.5));
+  sync_test.run();
+}
+
+
+TEST(ApproxTimeSync, PerfectMatch) {
+  // Input A:  a..b..c.
+  // Input B:  .A..B..C
+  // Output:   ...a..b.c
+  //           ...A..B.C
+  std::vector<TimeAndTopic> input;
+  std::vector<TimePair> output;
+
+  rclcpp::Time t(0, 0, RCL_ROS_TIME);
+  rclcpp::Duration s(1, 0);
+
+  input.push_back(TimeAndTopic(t,0));     // a
+  input.push_back(TimeAndTopic(t+s,1));   // A
+  input.push_back(TimeAndTopic(t+s*3,0)); // b
+  input.push_back(TimeAndTopic(t+s*4,1)); // B
+  input.push_back(TimeAndTopic(t+s*6,0)); // c
+  input.push_back(TimeAndTopic(t+s*7,1)); // C
+  output.push_back(TimePair(t, t+s));
+  output.push_back(TimePair(t+s*3, t+s*4));
+  output.push_back(TimePair(t+s*6, t+s*7));
+
+  ApproximateEpsilonTimeSynchronizerTest sync_test(
+    input, output, 10, rclcpp::Duration::from_seconds(1.5));
+  sync_test.run();
+}
+
+
+TEST(ApproxTimeSync, ImperfectMatch) {
+  // Input A:  a.xb..c.
+  // Input B:  .A...B.C
+  // Output:   ..a...b.c
+  //           ..A...B.C
+  std::vector<TimeAndTopic> input;
+  std::vector<TimePair> output;
+
+  rclcpp::Time t(0, 0, RCL_ROS_TIME);
+  rclcpp::Duration s(1, 0);
+
+  input.push_back(TimeAndTopic(t,0));     // a
+  input.push_back(TimeAndTopic(t+s,1));   // A
+  input.push_back(TimeAndTopic(t+s*2,0)); // x
+  input.push_back(TimeAndTopic(t+s*3,0)); // b
+  input.push_back(TimeAndTopic(t+s*4,1)); // B
+  input.push_back(TimeAndTopic(t+s*6,0)); // c
+  input.push_back(TimeAndTopic(t+s*7,1)); // C
+  output.push_back(TimePair(t, t+s));
+  output.push_back(TimePair(t+s*3, t+s*4));
+  output.push_back(TimePair(t+s*6, t+s*7));
+
+  ApproximateEpsilonTimeSynchronizerTest sync_test(
+    input, output, 10, rclcpp::Duration::from_seconds(1.5));
+  sync_test.run();
+}
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+
+  return RUN_ALL_TESTS();
+}

--- a/test/test_approximate_epsilon_time_policy.cpp
+++ b/test/test_approximate_epsilon_time_policy.cpp
@@ -115,18 +115,20 @@ public:
 
   void run()
   {
-    for (unsigned int i = 0; i < input_.size(); i++)
+    for (const auto & time_topic: input_)
     {
-      if (input_[i].second == 0)
+      const rclcpp::Time & time = time_topic.first;
+      const unsigned int & topic = time_topic.second;
+      if (topic == 0)
       {
         MsgPtr p(std::make_shared<Msg>());
-        p->header.stamp = input_[i].first;
+        p->header.stamp = time;
         sync_.add<0>(p);
       }
       else
       {
         MsgPtr q(std::make_shared<Msg>());
-        q->header.stamp = input_[i].first;
+        q->header.stamp = time;
         sync_.add<1>(q);
       }
     }


### PR DESCRIPTION
This adds another approximate time policy.
The difference is that it doesn't use a relatively complex algorithm to check if the topics are in sync.

It works like ExactTime, but accepts timestamps being within an "epsilon" tolerance.

Todo:
- [x] Add test cases.

(I have done some manual testing using this in stereo image proc, it seems to work fine)