### PR TITLE
Fix cache.h std::placeholder namespace

### DIFF
--- a/include/message_filters/cache.h
+++ b/include/message_filters/cache.h
@@ -47,7 +47,6 @@
 
 namespace message_filters
 {
-using namespace std::placeholders;
 /**
  * \brief Stores a time history of messages
  *
@@ -90,7 +89,7 @@ public:
   template<class F>
   void connectInput(F& f)
   {
-    incoming_connection_ = f.registerCallback(typename SimpleFilter<M>::EventCallback(std::bind(&Cache::callback, this, _1)));
+    incoming_connection_ = f.registerCallback(typename SimpleFilter<M>::EventCallback(std::bind(&Cache::callback, this, std::placeholders::_1)));
   }
 
   ~Cache()

--- a/include/message_filters/cache.h
+++ b/include/message_filters/cache.h
@@ -89,7 +89,8 @@ public:
   template<class F>
   void connectInput(F& f)
   {
-    incoming_connection_ = f.registerCallback(typename SimpleFilter<M>::EventCallback(std::bind(&Cache::callback, this, std::placeholders::_1)));
+    incoming_connection_ = f.registerCallback(typename SimpleFilter<M>::EventCallback(
+      std::bind(&Cache::callback, this, std::placeholders::_1)));
   }
 
   ~Cache()


### PR DESCRIPTION
Same as in #22 which was resolved by #40, boost users would have problems due to ambiguous namespace issue with `message_filters::Cache`. The same change as in #40 should be applied to it. 