### PR TITLE
Migrate to C++11 variadic templates

### DIFF
--- a/include/message_filters/signal9.hpp
+++ b/include/message_filters/signal9.hpp
@@ -43,341 +43,100 @@
 namespace message_filters
 {
 
-template<typename M0, typename M1, typename M2, typename M3, typename M4, typename M5,
-  typename M6, typename M7, typename M8>
+template<typename ... Ms>
 class CallbackHelper9
 {
 public:
-  typedef MessageEvent<M0 const> M0Event;
-  typedef MessageEvent<M1 const> M1Event;
-  typedef MessageEvent<M2 const> M2Event;
-  typedef MessageEvent<M3 const> M3Event;
-  typedef MessageEvent<M4 const> M4Event;
-  typedef MessageEvent<M5 const> M5Event;
-  typedef MessageEvent<M6 const> M6Event;
-  typedef MessageEvent<M7 const> M7Event;
-  typedef MessageEvent<M8 const> M8Event;
-
   virtual ~CallbackHelper9() {}
 
-  virtual void call(
-    bool nonconst_force_copy, const M0Event & e0, const M1Event & e1,
-    const M2Event & e2, const M3Event & e3, const M4Event & e4, const M5Event & e5,
-    const M6Event & e6, const M7Event & e7, const M8Event & e8) = 0;
+  virtual void call(bool nonconst_force_copy, const MessageEvent<Ms const> & ... es) = 0;
 
   typedef std::shared_ptr<CallbackHelper9> Ptr;
 };
 
-template<typename P0, typename P1, typename P2, typename P3, typename P4, typename P5,
-  typename P6, typename P7, typename P8>
+template<typename ... Ps>
 class CallbackHelper9T
-  : public CallbackHelper9<typename ParameterAdapter<P0>::Message,
-    typename ParameterAdapter<P1>::Message,
-    typename ParameterAdapter<P2>::Message,
-    typename ParameterAdapter<P3>::Message,
-    typename ParameterAdapter<P4>::Message,
-    typename ParameterAdapter<P5>::Message,
-    typename ParameterAdapter<P6>::Message,
-    typename ParameterAdapter<P7>::Message,
-    typename ParameterAdapter<P8>::Message>
+  : public CallbackHelper9<typename ParameterAdapter<Ps>::Message...>
 {
-private:
-  typedef ParameterAdapter<P0> A0;
-  typedef ParameterAdapter<P1> A1;
-  typedef ParameterAdapter<P2> A2;
-  typedef ParameterAdapter<P3> A3;
-  typedef ParameterAdapter<P4> A4;
-  typedef ParameterAdapter<P5> A5;
-  typedef ParameterAdapter<P6> A6;
-  typedef ParameterAdapter<P7> A7;
-  typedef ParameterAdapter<P8> A8;
-  typedef typename A0::Event M0Event;
-  typedef typename A1::Event M1Event;
-  typedef typename A2::Event M2Event;
-  typedef typename A3::Event M3Event;
-  typedef typename A4::Event M4Event;
-  typedef typename A5::Event M5Event;
-  typedef typename A6::Event M6Event;
-  typedef typename A7::Event M7Event;
-  typedef typename A8::Event M8Event;
-
 public:
-  typedef std::function<void (typename A0::Parameter, typename A1::Parameter,
-      typename A2::Parameter, typename A3::Parameter, typename A4::Parameter,
-      typename A5::Parameter, typename A6::Parameter, typename A7::Parameter,
-      typename A8::Parameter)> Callback;
+  typedef std::function<void (typename ParameterAdapter<Ps>::Parameter...)> Callback;
 
   CallbackHelper9T(const Callback & cb)  // NOLINT(runtime/explicit)
   : callback_(cb)
   {
   }
 
-  virtual void call(
-    bool nonconst_force_copy, const M0Event & e0, const M1Event & e1,
-    const M2Event & e2, const M3Event & e3, const M4Event & e4, const M5Event & e5,
-    const M6Event & e6, const M7Event & e7, const M8Event & e8)
+  virtual void call(bool nonconst_force_copy, const typename ParameterAdapter<Ps>::Event &... es)
   {
-    M0Event my_e0(e0, nonconst_force_copy || e0.nonConstWillCopy());
-    M1Event my_e1(e1, nonconst_force_copy || e0.nonConstWillCopy());
-    M2Event my_e2(e2, nonconst_force_copy || e0.nonConstWillCopy());
-    M3Event my_e3(e3, nonconst_force_copy || e0.nonConstWillCopy());
-    M4Event my_e4(e4, nonconst_force_copy || e0.nonConstWillCopy());
-    M5Event my_e5(e5, nonconst_force_copy || e0.nonConstWillCopy());
-    M6Event my_e6(e6, nonconst_force_copy || e0.nonConstWillCopy());
-    M7Event my_e7(e7, nonconst_force_copy || e0.nonConstWillCopy());
-    M8Event my_e8(e8, nonconst_force_copy || e0.nonConstWillCopy());
-    callback_(
-      A0::getParameter(e0),
-      A1::getParameter(e1),
-      A2::getParameter(e2),
-      A3::getParameter(e3),
-      A4::getParameter(e4),
-      A5::getParameter(e5),
-      A6::getParameter(e6),
-      A7::getParameter(e7),
-      A8::getParameter(e8));
+    auto my_es{std::make_tuple(
+        typename ParameterAdapter<Ps>::Event(
+          es,
+          nonconst_force_copy || es.nonConstWillCopy())...)};
+    callback_(ParameterAdapter<Ps>::getParameter(es)...);
   }
 
 private:
   Callback callback_;
 };
 
-template<typename M0, typename M1, typename M2, typename M3, typename M4, typename M5,
-  typename M6, typename M7, typename M8>
+template<typename ... Ms>
 class Signal9
 {
-  typedef std::shared_ptr<CallbackHelper9<M0, M1, M2, M3, M4, M5, M6, M7, M8>> CallbackHelper9Ptr;
+  typedef std::shared_ptr<CallbackHelper9<Ms...>> CallbackHelper9Ptr;
   typedef std::vector<CallbackHelper9Ptr> V_CallbackHelper9;
 
 public:
-  typedef MessageEvent<M0 const> M0Event;
-  typedef MessageEvent<M1 const> M1Event;
-  typedef MessageEvent<M2 const> M2Event;
-  typedef MessageEvent<M3 const> M3Event;
-  typedef MessageEvent<M4 const> M4Event;
-  typedef MessageEvent<M5 const> M5Event;
-  typedef MessageEvent<M6 const> M6Event;
-  typedef MessageEvent<M7 const> M7Event;
-  typedef MessageEvent<M8 const> M8Event;
-  typedef std::shared_ptr<M0 const> M0ConstPtr;
-  typedef std::shared_ptr<M1 const> M1ConstPtr;
-  typedef std::shared_ptr<M2 const> M2ConstPtr;
-  typedef std::shared_ptr<M3 const> M3ConstPtr;
-  typedef std::shared_ptr<M4 const> M4ConstPtr;
-  typedef std::shared_ptr<M5 const> M5ConstPtr;
-  typedef std::shared_ptr<M6 const> M6ConstPtr;
-  typedef std::shared_ptr<M7 const> M7ConstPtr;
-  typedef std::shared_ptr<M8 const> M8ConstPtr;
   typedef const std::shared_ptr<NullType const> & NullP;
 
-
-  template<typename P0, typename P1, typename P2, typename P3, typename P4, typename P5,
-    typename P6, typename P7, typename P8>
-  Connection addCallback(const std::function<void(P0, P1, P2, P3, P4, P5, P6, P7, P8)> & callback)
+  template<typename ... Ps>
+  Connection addCallback(const std::function<void(Ps...)> & callback)
   {
-    CallbackHelper9T<P0, P1, P2, P3, P4, P5, P6, P7, P8> * helper =
-      new CallbackHelper9T<P0, P1, P2, P3, P4, P5, P6, P7, P8>(callback);
+    CallbackHelper9T<Ps...> * helper = new CallbackHelper9T<Ps...>(callback);
 
     std::lock_guard<std::mutex> lock(mutex_);
     callbacks_.push_back(CallbackHelper9Ptr(helper));
     return Connection(std::bind(&Signal9::removeCallback, this, callbacks_.back()));
   }
 
-  template<typename P0, typename P1>
-  Connection addCallback(void (* callback)(P0, P1))
+  template<typename ... Ps>
+  Connection addCallback(void (* callback)(Ps...))
   {
     return addCallback(
-      std::function<void(P0, P1, NullP, NullP, NullP, NullP, NullP, NullP,
-      NullP)>(
-        std::bind(
-          callback, std::placeholders::_1, std::placeholders::_2)));
+      std::function<void(Ps...)>(
+        [callback](auto &&... args) {
+          callback(args ...);
+        }));
   }
 
-  template<typename P0, typename P1, typename P2>
-  Connection addCallback(void (* callback)(P0, P1, P2))
+  template<typename T, typename ... Ps>
+  Connection addCallback(void (T::* callback)(Ps...), T * t)
   {
     return addCallback(
-      std::function<void(P0, P1, P2, NullP, NullP, NullP, NullP, NullP,
-      NullP)>(
-        std::bind(
-          callback, std::placeholders::_1, std::placeholders::_2,
-          std::placeholders::_3)));
-  }
-
-  template<typename P0, typename P1, typename P2, typename P3>
-  Connection addCallback(void (* callback)(P0, P1, P2, P3))
-  {
-    return addCallback(
-      std::function<void(P0, P1, P2, P3, NullP, NullP, NullP, NullP, NullP)>(
-        std::bind(
-          callback, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-          std::placeholders::_4)));
-  }
-
-  template<typename P0, typename P1, typename P2, typename P3, typename P4>
-  Connection addCallback(void (* callback)(P0, P1, P2, P3, P4))
-  {
-    return addCallback(
-      std::function<void(P0, P1, P2, P3, P4, NullP, NullP, NullP, NullP)>(
-        std::bind(
-          callback, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-          std::placeholders::_4, std::placeholders::_5)));
-  }
-
-  template<typename P0, typename P1, typename P2, typename P3, typename P4, typename P5>
-  Connection addCallback(void (* callback)(P0, P1, P2, P3, P4, P5))
-  {
-    return addCallback(
-      std::function<void(P0, P1, P2, P3, P4, P5, NullP, NullP, NullP)>(
-        std::bind(
-          callback, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-          std::placeholders::_4, std::placeholders::_5, std::placeholders::_6)));
-  }
-
-  template<typename P0, typename P1, typename P2, typename P3, typename P4, typename P5,
-    typename P6>
-  Connection addCallback(void (* callback)(P0, P1, P2, P3, P4, P5, P6))
-  {
-    return addCallback(
-      std::function<void(P0, P1, P2, P3, P4, P5, P6, NullP, NullP)>(
-        std::bind(
-          callback, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-          std::placeholders::_4, std::placeholders::_5, std::placeholders::_6,
-          std::placeholders::_7)));
-  }
-
-  template<typename P0, typename P1, typename P2, typename P3, typename P4, typename P5,
-    typename P6, typename P7>
-  Connection addCallback(void (* callback)(P0, P1, P2, P3, P4, P5, P6, P7))
-  {
-    return addCallback(
-      std::function<void(P0, P1, P2, P3, P4, P5, P6, P7, NullP)>(
-        std::bind(
-          callback, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-          std::placeholders::_4, std::placeholders::_5, std::placeholders::_6,
-          std::placeholders::_7, std::placeholders::_8)));
-  }
-
-  template<typename P0, typename P1, typename P2, typename P3, typename P4, typename P5,
-    typename P6, typename P7, typename P8>
-  Connection addCallback(void (* callback)(P0, P1, P2, P3, P4, P5, P6, P7, P8))
-  {
-    return addCallback(
-      std::function<void(P0, P1, P2, P3, P4, P5, P6, P7, P8)>(
-        std::bind(
-          callback, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-          std::placeholders::_4, std::placeholders::_5, std::placeholders::_6,
-          std::placeholders::_7, std::placeholders::_8, std::placeholders::_9)));
-  }
-
-  template<typename T, typename P0, typename P1>
-  Connection addCallback(void (T::* callback)(P0, P1), T * t)
-  {
-    return addCallback(
-      std::function<void(P0, P1, NullP, NullP, NullP, NullP, NullP, NullP, NullP)>(
-        std::bind(
-          callback, t, std::placeholders::_1, std::placeholders::_2)));
-  }
-
-  template<typename T, typename P0, typename P1, typename P2>
-  Connection addCallback(void (T::* callback)(P0, P1, P2), T * t)
-  {
-    return addCallback(
-      std::function<void(P0, P1, P2, NullP, NullP, NullP, NullP, NullP, NullP)>(
-        std::bind(
-          callback, t, std::placeholders::_1, std::placeholders::_2,
-          std::placeholders::_3)));
-  }
-
-  template<typename T, typename P0, typename P1, typename P2, typename P3>
-  Connection addCallback(void (T::* callback)(P0, P1, P2, P3), T * t)
-  {
-    return addCallback(
-      std::function<void(P0, P1, P2, P3, NullP, NullP, NullP, NullP, NullP)>(
-        std::bind(
-          callback, t, std::placeholders::_1, std::placeholders::_2,
-          std::placeholders::_3, std::placeholders::_4)));
-  }
-
-  template<typename T, typename P0, typename P1, typename P2, typename P3, typename P4>
-  Connection addCallback(void (T::* callback)(P0, P1, P2, P3, P4), T * t)
-  {
-    return addCallback(
-      std::function<void(P0, P1, P2, P3, P4, NullP, NullP, NullP, NullP)>(
-        std::bind(
-          callback, t, std::placeholders::_1, std::placeholders::_2,
-          std::placeholders::_3, std::placeholders::_4, std::placeholders::_5)));
-  }
-
-  template<typename T, typename P0, typename P1, typename P2, typename P3, typename P4,
-    typename P5>
-  Connection addCallback(void (T::* callback)(P0, P1, P2, P3, P4, P5), T * t)
-  {
-    return addCallback(
-      std::function<void(P0, P1, P2, P3, P4, P5, NullP, NullP, NullP)>(
-        std::bind(
-          callback, t, std::placeholders::_1, std::placeholders::_2,
-          std::placeholders::_3, std::placeholders::_4, std::placeholders::_5,
-          std::placeholders::_6)));
-  }
-
-  template<typename T, typename P0, typename P1, typename P2, typename P3, typename P4,
-    typename P5, typename P6>
-  Connection addCallback(void (T::* callback)(P0, P1, P2, P3, P4, P5, P6), T * t)
-  {
-    return addCallback(
-      std::function<void(P0, P1, P2, P3, P4, P5, P6, NullP, NullP)>(
-        std::bind(
-          callback, t, std::placeholders::_1, std::placeholders::_2,
-          std::placeholders::_3, std::placeholders::_4, std::placeholders::_5,
-          std::placeholders::_6, std::placeholders::_7)));
-  }
-
-  template<typename T, typename P0, typename P1, typename P2, typename P3, typename P4,
-    typename P5, typename P6, typename P7>
-  Connection addCallback(void (T::* callback)(P0, P1, P2, P3, P4, P5, P6, P7), T * t)
-  {
-    return addCallback(
-      std::function<void(P0, P1, P2, P3, P4, P5, P6, P7, NullP)>(
-        std::bind(
-          callback, t, std::placeholders::_1, std::placeholders::_2,
-          std::placeholders::_3, std::placeholders::_4, std::placeholders::_5,
-          std::placeholders::_6, std::placeholders::_7, std::placeholders::_8)));
+      std::function<void(Ps...)>(
+        [ = ](const Ps &... ps) {
+          (t->*callback)(ps ...);
+        }));
   }
 
   template<typename C>
   Connection addCallback(C & callback)
   {
-    return addCallback<const M0ConstPtr &,
-             const M1ConstPtr &,
-             const M2ConstPtr &,
-             const M3ConstPtr &,
-             const M4ConstPtr &,
-             const M5ConstPtr &,
-             const M6ConstPtr &,
-             const M7ConstPtr &,
-             const M8ConstPtr &>(
-      std::bind(
-        callback, std::placeholders::_1,
-        std::placeholders::_2, std::placeholders::_3, std::placeholders::_4,
-        std::placeholders::_5, std::placeholders::_6, std::placeholders::_7,
-        std::placeholders::_8, std::placeholders::_9));
+    return addCallback(
+      std::function<void(const std::shared_ptr<const Ms> & ...)>(
+        [callback](const std::shared_ptr<const Ms> & ... msgs) {callback(msgs ...);}));
   }
 
   void removeCallback(const CallbackHelper9Ptr & helper)
   {
     std::lock_guard<std::mutex> lock(mutex_);
-    typename V_CallbackHelper9::iterator it = std::find(
-      callbacks_.begin(), callbacks_.end(), helper);
+    typename V_CallbackHelper9::iterator it =
+      std::find(callbacks_.begin(), callbacks_.end(), helper);
     if (it != callbacks_.end()) {
       callbacks_.erase(it);
     }
   }
 
-  void call(
-    const M0Event & e0, const M1Event & e1, const M2Event & e2, const M3Event & e3,
-    const M4Event & e4, const M5Event & e5, const M6Event & e6, const M7Event & e7,
-    const M8Event & e8)
+  void call(const MessageEvent<Ms const> & ... es)
   {
     std::lock_guard<std::mutex> lock(mutex_);
     bool nonconst_force_copy = callbacks_.size() > 1;
@@ -385,7 +144,7 @@ public:
     typename V_CallbackHelper9::iterator end = callbacks_.end();
     for (; it != end; ++it) {
       const CallbackHelper9Ptr & helper = *it;
-      helper->call(nonconst_force_copy, e0, e1, e2, e3, e4, e5, e6, e7, e8);
+      helper->call(nonconst_force_copy, es ...);
     }
   }
 

--- a/include/message_filters/sync_policies/latest_time.hpp
+++ b/include/message_filters/sync_policies/latest_time.hpp
@@ -81,14 +81,11 @@ namespace message_filters
 namespace sync_policies
 {
 
-template<typename M0, typename M1,
-  typename M2 = NullType, typename M3 = NullType, typename M4 = NullType,
-  typename M5 = NullType, typename M6 = NullType, typename M7 = NullType,
-  typename M8 = NullType>
-struct LatestTime : public PolicyBase<M0, M1, M2, M3, M4, M5, M6, M7, M8>
+template<typename ... M>
+struct LatestTime : public PolicyBase<M...>
 {
   typedef Synchronizer<LatestTime> Sync;
-  typedef PolicyBase<M0, M1, M2, M3, M4, M5, M6, M7, M8> Super;
+  typedef PolicyBase<M...> Super;
   typedef typename Super::Messages Messages;
   typedef typename Super::Signal Signal;
   typedef typename Super::Events Events;
@@ -204,10 +201,7 @@ private:
   // assumed data_mutex_ is locked
   void publish()
   {
-    parent_->signal(
-      std::get<0>(events_), std::get<1>(events_), std::get<2>(events_),
-      std::get<3>(events_), std::get<4>(events_), std::get<5>(events_),
-      std::get<6>(events_), std::get<7>(events_), std::get<8>(events_));
+    std::apply([this](auto &&... args) {this->parent_->signal(args ...);}, events_);
   }
 
   struct Rate
@@ -307,23 +301,22 @@ private:
   template<int i>
   bool received_msg()
   {
-    return RealTypeCount::value > i ? static_cast<bool>(std::get<i>(events_).getMessage()) : true;
+    return static_cast<bool>(std::get<i>(events_).getMessage());
   }
 
   // assumed data_mutex_ is locked
   bool is_full()
   {
-    bool full = received_msg<0>();
-    full = full && received_msg<1>();
-    full = full && received_msg<2>();
-    full = full && received_msg<3>();
-    full = full && received_msg<4>();
-    full = full && received_msg<5>();
-    full = full && received_msg<6>();
-    full = full && received_msg<7>();
-    full = full && received_msg<8>();
+    return is_full_impl(std::make_index_sequence<std::tuple_size_v<Events>>{});
+  }
 
-    return full;
+  template<std::size_t... Is>
+  bool is_full_impl(std::index_sequence<Is...>)
+  {
+    /* *INDENT-OFF* */
+    // uncrustify messes with the brackets which are required (at least by GCC)
+    return (... && received_msg<Is>());
+    /* *INDENT-ON* */
   }
 
   // assumed data_mutex_ is locked

--- a/include/message_filters/synchronizer.hpp
+++ b/include/message_filters/synchronizer.hpp
@@ -53,82 +53,10 @@ public:
   typedef typename Policy::Events Events;
   typedef typename Policy::Signal Signal;
 
-  typedef typename std::tuple_element<0, Messages>::type M0;
-  typedef typename std::tuple_element<1, Messages>::type M1;
-  typedef typename std::tuple_element<2, Messages>::type M2;
-  typedef typename std::tuple_element<3, Messages>::type M3;
-  typedef typename std::tuple_element<4, Messages>::type M4;
-  typedef typename std::tuple_element<5, Messages>::type M5;
-  typedef typename std::tuple_element<6, Messages>::type M6;
-  typedef typename std::tuple_element<7, Messages>::type M7;
-  typedef typename std::tuple_element<8, Messages>::type M8;
-
-
-  typedef typename std::tuple_element<0, Events>::type M0Event;
-  typedef typename std::tuple_element<1, Events>::type M1Event;
-  typedef typename std::tuple_element<2, Events>::type M2Event;
-  typedef typename std::tuple_element<3, Events>::type M3Event;
-  typedef typename std::tuple_element<4, Events>::type M4Event;
-  typedef typename std::tuple_element<5, Events>::type M5Event;
-  typedef typename std::tuple_element<6, Events>::type M6Event;
-  typedef typename std::tuple_element<7, Events>::type M7Event;
-  typedef typename std::tuple_element<8, Events>::type M8Event;
-
-  static const uint8_t MAX_MESSAGES = 9;
-
-  template<class F0, class F1>
-  Synchronizer(F0 & f0, F1 & f1)
+  template<class F0, class F1, class ... Fs>
+  Synchronizer(F0 & f0, F1 & f1, Fs &... fs)
   {
-    connectInput(f0, f1);
-    init();
-  }
-
-  template<class F0, class F1, class F2>
-  Synchronizer(F0 & f0, F1 & f1, F2 & f2)
-  {
-    connectInput(f0, f1, f2);
-    init();
-  }
-
-  template<class F0, class F1, class F2, class F3>
-  Synchronizer(F0 & f0, F1 & f1, F2 & f2, F3 & f3)
-  {
-    connectInput(f0, f1, f2, f3);
-    init();
-  }
-
-  template<class F0, class F1, class F2, class F3, class F4>
-  Synchronizer(F0 & f0, F1 & f1, F2 & f2, F3 & f3, F4 & f4)
-  {
-    connectInput(f0, f1, f2, f3, f4);
-    init();
-  }
-
-  template<class F0, class F1, class F2, class F3, class F4, class F5>
-  Synchronizer(F0 & f0, F1 & f1, F2 & f2, F3 & f3, F4 & f4, F5 & f5)
-  {
-    connectInput(f0, f1, f2, f3, f4, f5);
-    init();
-  }
-
-  template<class F0, class F1, class F2, class F3, class F4, class F5, class F6>
-  Synchronizer(F0 & f0, F1 & f1, F2 & f2, F3 & f3, F4 & f4, F5 & f5, F6 & f6)
-  {
-    connectInput(f0, f1, f2, f3, f4, f5, f6);
-    init();
-  }
-
-  template<class F0, class F1, class F2, class F3, class F4, class F5, class F6, class F7>
-  Synchronizer(F0 & f0, F1 & f1, F2 & f2, F3 & f3, F4 & f4, F5 & f5, F6 & f6, F7 & f7)
-  {
-    connectInput(f0, f1, f2, f3, f4, f5, f6, f7);
-    init();
-  }
-
-  template<class F0, class F1, class F2, class F3, class F4, class F5, class F6, class F7, class F8>
-  Synchronizer(F0 & f0, F1 & f1, F2 & f2, F3 & f3, F4 & f4, F5 & f5, F6 & f6, F7 & f7, F8 & f8)
-  {
-    connectInput(f0, f1, f2, f3, f4, f5, f6, f7, f8);
+    connectInput(f0, f1, fs ...);
     init();
   }
 
@@ -137,70 +65,11 @@ public:
     init();
   }
 
-  template<class F0, class F1>
-  Synchronizer(const Policy & policy, F0 & f0, F1 & f1)
+  template<class ... Fs>
+  Synchronizer(const Policy & policy, Fs &... fs)
   : Policy(policy)
   {
-    connectInput(f0, f1);
-    init();
-  }
-
-  template<class F0, class F1, class F2>
-  Synchronizer(const Policy & policy, F0 & f0, F1 & f1, F2 & f2)
-  : Policy(policy)
-  {
-    connectInput(f0, f1, f2);
-    init();
-  }
-
-  template<class F0, class F1, class F2, class F3>
-  Synchronizer(const Policy & policy, F0 & f0, F1 & f1, F2 & f2, F3 & f3)
-  : Policy(policy)
-  {
-    connectInput(f0, f1, f2, f3);
-    init();
-  }
-
-  template<class F0, class F1, class F2, class F3, class F4>
-  Synchronizer(const Policy & policy, F0 & f0, F1 & f1, F2 & f2, F3 & f3, F4 & f4)
-  : Policy(policy)
-  {
-    connectInput(f0, f1, f2, f3, f4);
-    init();
-  }
-
-  template<class F0, class F1, class F2, class F3, class F4, class F5>
-  Synchronizer(const Policy & policy, F0 & f0, F1 & f1, F2 & f2, F3 & f3, F4 & f4, F5 & f5)
-  : Policy(policy)
-  {
-    connectInput(f0, f1, f2, f3, f4, f5);
-    init();
-  }
-
-  template<class F0, class F1, class F2, class F3, class F4, class F5, class F6>
-  Synchronizer(const Policy & policy, F0 & f0, F1 & f1, F2 & f2, F3 & f3, F4 & f4, F5 & f5, F6 & f6)
-  : Policy(policy)
-  {
-    connectInput(f0, f1, f2, f3, f4, f5, f6);
-    init();
-  }
-
-  template<class F0, class F1, class F2, class F3, class F4, class F5, class F6, class F7>
-  Synchronizer(
-    const Policy & policy, F0 & f0, F1 & f1, F2 & f2, F3 & f3, F4 & f4, F5 & f5, F6 & f6, F7 & f7)
-  : Policy(policy)
-  {
-    connectInput(f0, f1, f2, f3, f4, f5, f6, f7);
-    init();
-  }
-
-  template<class F0, class F1, class F2, class F3, class F4, class F5, class F6, class F7, class F8>
-  Synchronizer(
-    const Policy & policy, F0 & f0, F1 & f1, F2 & f2, F3 & f3, F4 & f4, F5 & f5, F6 & f6, F7 & f7,
-    F8 & f8)
-  : Policy(policy)
-  {
-    connectInput(f0, f1, f2, f3, f4, f5, f6, f7, f8);
+    connectInput(fs ...);
     init();
   }
 
@@ -220,87 +89,30 @@ public:
     Policy::initParent(this);
   }
 
-  template<class F0, class F1>
-  void connectInput(F0 & f0, F1 & f1)
+  template<std::size_t I, class FTuple>
+  void connect(FTuple & ftuple)
   {
-    NullFilter<M2> f2;
-    connectInput(f0, f1, f2);
+    using MEvent = typename std::tuple_element<I, Events>::type;
+    input_connections_[I] =
+      std::get<I>(ftuple).registerCallback(
+      std::function<void(const MEvent &)>(
+        std::bind(
+          &Synchronizer::template cb<I>, this, std::placeholders::_1)));
   }
 
-  template<class F0, class F1, class F2>
-  void connectInput(F0 & f0, F1 & f1, F2 & f2)
+  template<class FTuple, std::size_t... Is>
+  void connectInputImpl(FTuple & ftuple, std::index_sequence<Is...>)
   {
-    NullFilter<M3> f3;
-    connectInput(f0, f1, f2, f3);
+    (connect<Is>(ftuple), ...);
   }
 
-  template<class F0, class F1, class F2, class F3>
-  void connectInput(F0 & f0, F1 & f1, F2 & f2, F3 & f3)
-  {
-    NullFilter<M4> f4;
-    connectInput(f0, f1, f2, f3, f4);
-  }
-
-  template<class F0, class F1, class F2, class F3, class F4>
-  void connectInput(F0 & f0, F1 & f1, F2 & f2, F3 & f3, F4 & f4)
-  {
-    NullFilter<M5> f5;
-    connectInput(f0, f1, f2, f3, f4, f5);
-  }
-
-  template<class F0, class F1, class F2, class F3, class F4, class F5>
-  void connectInput(F0 & f0, F1 & f1, F2 & f2, F3 & f3, F4 & f4, F5 & f5)
-  {
-    NullFilter<M6> f6;
-    connectInput(f0, f1, f2, f3, f4, f5, f6);
-  }
-
-  template<class F0, class F1, class F2, class F3, class F4, class F5, class F6>
-  void connectInput(F0 & f0, F1 & f1, F2 & f2, F3 & f3, F4 & f4, F5 & f5, F6 & f6)
-  {
-    NullFilter<M7> f7;
-    connectInput(f0, f1, f2, f3, f4, f5, f6, f7);
-  }
-
-  template<class F0, class F1, class F2, class F3, class F4, class F5, class F6, class F7>
-  void connectInput(F0 & f0, F1 & f1, F2 & f2, F3 & f3, F4 & f4, F5 & f5, F6 & f6, F7 & f7)
-  {
-    NullFilter<M8> f8;
-    connectInput(f0, f1, f2, f3, f4, f5, f6, f7, f8);
-  }
-
-  template<class F0, class F1, class F2, class F3, class F4, class F5, class F6, class F7, class F8>
-  void connectInput(F0 & f0, F1 & f1, F2 & f2, F3 & f3, F4 & f4, F5 & f5, F6 & f6, F7 & f7, F8 & f8)
+  template<class ... Fs>
+  void connectInput(Fs &... fs)
   {
     disconnectAll();
 
-    input_connections_[0] = f0.registerCallback(
-      std::function<void(const M0Event &)>(
-        std::bind(&Synchronizer::template cb<0>, this, std::placeholders::_1)));
-    input_connections_[1] = f1.registerCallback(
-      std::function<void(const M1Event &)>(
-        std::bind(&Synchronizer::template cb<1>, this, std::placeholders::_1)));
-    input_connections_[2] = f2.registerCallback(
-      std::function<void(const M2Event &)>(
-        std::bind(&Synchronizer::template cb<2>, this, std::placeholders::_1)));
-    input_connections_[3] = f3.registerCallback(
-      std::function<void(const M3Event &)>(
-        std::bind(&Synchronizer::template cb<3>, this, std::placeholders::_1)));
-    input_connections_[4] = f4.registerCallback(
-      std::function<void(const M4Event &)>(
-        std::bind(&Synchronizer::template cb<4>, this, std::placeholders::_1)));
-    input_connections_[5] = f5.registerCallback(
-      std::function<void(const M5Event &)>(
-        std::bind(&Synchronizer::template cb<5>, this, std::placeholders::_1)));
-    input_connections_[6] = f6.registerCallback(
-      std::function<void(const M6Event &)>(
-        std::bind(&Synchronizer::template cb<6>, this, std::placeholders::_1)));
-    input_connections_[7] = f7.registerCallback(
-      std::function<void(const M7Event &)>(
-        std::bind(&Synchronizer::template cb<7>, this, std::placeholders::_1)));
-    input_connections_[8] = f8.registerCallback(
-      std::function<void(const M8Event &)>(
-        std::bind(&Synchronizer::template cb<8>, this, std::placeholders::_1)));
+    std::tuple<Fs &...> tuple{fs ...};
+    connectInputImpl(tuple, std::make_index_sequence<sizeof...(Fs)>{});
   }
 
   template<class C>
@@ -331,12 +143,10 @@ public:
   const std::string & getName() {return name_;}
 
 
-  void signal(
-    const M0Event & e0, const M1Event & e1, const M2Event & e2, const M3Event & e3,
-    const M4Event & e4, const M5Event & e5, const M6Event & e6, const M7Event & e7,
-    const M8Event & e8)
+  template<class ... MEvent>
+  void signal(const MEvent &... es)
   {
-    signal_.call(e0, e1, e2, e3, e4, e5, e6, e7, e8);
+    signal_.call(es ...);
   }
 
   Policy * getPolicy() {return static_cast<Policy *>(this);}
@@ -352,8 +162,8 @@ public:
 private:
   void disconnectAll()
   {
-    for (int i = 0; i < MAX_MESSAGES; ++i) {
-      input_connections_[i].disconnect();
+    for (auto & input_connection : input_connections_) {
+      input_connection.disconnect();
     }
   }
 
@@ -367,55 +177,19 @@ private:
 
   Signal signal_;
 
-  Connection input_connections_[MAX_MESSAGES];
+  Connection input_connections_[Policy::N_MESSAGES];
 
   std::string name_;
 };
 
-template<class ... T>
-struct mp_plus;
-template<>
-struct mp_plus<>
-{
-  using type = std::integral_constant<int, 0>;
-};
-template<class T1, class ... T>
-struct mp_plus<T1, T...>
-{
-  static constexpr auto _v = !T1::value + mp_plus<T...>::type::value;
-  using type = std::integral_constant<
-    typename std::remove_const<decltype(_v)>::type, _v>;
-};
-
-template<class L, class V>
-struct mp_count;
-template<template<class ...> class L, class ... T, class V>
-struct mp_count<L<T ...>, V>
-{
-  using type = typename mp_plus<std::is_same<T, V>...>::type;
-};
-
-template<typename M0, typename M1, typename M2, typename M3, typename M4,
-  typename M5, typename M6, typename M7, typename M8>
+template<typename ... Ms>
 struct PolicyBase
 {
-  typedef typename mp_count<std::tuple<M0, M1, M2, M3, M4, M5, M6, M7, M8>, NullType>::type
-    RealTypeCount;
-  typedef std::tuple<M0, M1, M2, M3, M4, M5, M6, M7, M8> Messages;
-  typedef Signal9<M0, M1, M2, M3, M4, M5, M6, M7, M8> Signal;
-  typedef std::tuple<MessageEvent<M0 const>, MessageEvent<M1 const>, MessageEvent<M2 const>,
-      MessageEvent<M3 const>, MessageEvent<M4 const>, MessageEvent<M5 const>,
-      MessageEvent<M6 const>, MessageEvent<M7 const>, MessageEvent<M8 const>> Events;
-
-  typedef typename std::tuple_element<0, Events>::type M0Event;
-  typedef typename std::tuple_element<1, Events>::type M1Event;
-  typedef typename std::tuple_element<2, Events>::type M2Event;
-  typedef typename std::tuple_element<3, Events>::type M3Event;
-  typedef typename std::tuple_element<4, Events>::type M4Event;
-  typedef typename std::tuple_element<5, Events>::type M5Event;
-  typedef typename std::tuple_element<6, Events>::type M6Event;
-  typedef typename std::tuple_element<7, Events>::type M7Event;
-  typedef typename std::tuple_element<8, Events>::type M8Event;
+  static constexpr std::size_t N_MESSAGES = sizeof...(Ms);
+  typedef std::integral_constant<int, N_MESSAGES> RealTypeCount;
+  typedef std::tuple<Ms...> Messages;
+  typedef Signal9<Ms...> Signal;
+  typedef std::tuple<MessageEvent<Ms const>...> Events;
 };
 
 }  // namespace message_filters

--- a/include/message_filters/time_synchronizer.hpp
+++ b/include/message_filters/time_synchronizer.hpp
@@ -73,23 +73,12 @@ void callback(const sensor_msgs::msg::CameraInfo::SharedPtr, const sensor_msgs::
 \endverbatim
  *
  */
-template<class M0, class M1, class M2 = NullType, class M3 = NullType, class M4 = NullType,
-  class M5 = NullType, class M6 = NullType, class M7 = NullType, class M8 = NullType>
-class TimeSynchronizer : public Synchronizer<sync_policies::ExactTime<M0, M1, M2, M3, M4, M5, M6,
-    M7, M8>>
+template<class ... Ms>
+class TimeSynchronizer : public Synchronizer<sync_policies::ExactTime<Ms...>>
 {
 public:
-  typedef sync_policies::ExactTime<M0, M1, M2, M3, M4, M5, M6, M7, M8> Policy;
+  typedef sync_policies::ExactTime<Ms...> Policy;
   typedef Synchronizer<Policy> Base;
-  typedef std::shared_ptr<M0 const> M0ConstPtr;
-  typedef std::shared_ptr<M1 const> M1ConstPtr;
-  typedef std::shared_ptr<M2 const> M2ConstPtr;
-  typedef std::shared_ptr<M3 const> M3ConstPtr;
-  typedef std::shared_ptr<M4 const> M4ConstPtr;
-  typedef std::shared_ptr<M5 const> M5ConstPtr;
-  typedef std::shared_ptr<M6 const> M6ConstPtr;
-  typedef std::shared_ptr<M7 const> M7ConstPtr;
-  typedef std::shared_ptr<M8 const> M8ConstPtr;
 
   using Base::add;
   using Base::connectInput;
@@ -97,132 +86,60 @@ public:
   using Base::setName;
   using Base::getName;
   using Policy::registerDropCallback;
-  typedef typename Base::M0Event M0Event;
-  typedef typename Base::M1Event M1Event;
-  typedef typename Base::M2Event M2Event;
-  typedef typename Base::M3Event M3Event;
-  typedef typename Base::M4Event M4Event;
-  typedef typename Base::M5Event M5Event;
-  typedef typename Base::M6Event M6Event;
-  typedef typename Base::M7Event M7Event;
-  typedef typename Base::M8Event M8Event;
+
+  template<class ... Fs>
+  TimeSynchronizer(uint32_t queue_size, Fs &... fs)
+  : Base(Policy(queue_size))
+  {
+    connectInput(fs ...);
+  }
 
   template<class F0, class F1>
+  [[deprecated("Use variade constructor instead")]]
   TimeSynchronizer(F0 & f0, F1 & f1, uint32_t queue_size)
-  : Base(Policy(queue_size))
-  {
-    connectInput(f0, f1);
-  }
+  : TimeSynchronizer(queue_size, f0, f1) {}
 
   template<class F0, class F1, class F2>
+  [[deprecated("Use variade constructor instead")]]
   TimeSynchronizer(F0 & f0, F1 & f1, F2 & f2, uint32_t queue_size)
-  : Base(Policy(queue_size))
-  {
-    connectInput(f0, f1, f2);
-  }
+  : TimeSynchronizer(queue_size, f0, f1, f2) {}
 
   template<class F0, class F1, class F2, class F3>
+  [[deprecated("Use variade constructor instead")]]
   TimeSynchronizer(F0 & f0, F1 & f1, F2 & f2, F3 & f3, uint32_t queue_size)
-  : Base(Policy(queue_size))
-  {
-    connectInput(f0, f1, f2, f3);
-  }
+  : TimeSynchronizer(queue_size, f0, f1, f2, f3) {}
 
   template<class F0, class F1, class F2, class F3, class F4>
+  [[deprecated("Use variade constructor instead")]]
   TimeSynchronizer(F0 & f0, F1 & f1, F2 & f2, F3 & f3, F4 & f4, uint32_t queue_size)
-  : Base(Policy(queue_size))
-  {
-    connectInput(f0, f1, f2, f3, f4);
-  }
+  : TimeSynchronizer(queue_size, f0, f1, f2, f3, f4) {}
 
   template<class F0, class F1, class F2, class F3, class F4, class F5>
+  [[deprecated("Use variade constructor instead")]]
   TimeSynchronizer(F0 & f0, F1 & f1, F2 & f2, F3 & f3, F4 & f4, F5 & f5, uint32_t queue_size)
-  : Base(Policy(queue_size))
-  {
-    connectInput(f0, f1, f2, f3, f4, f5);
-  }
+  : TimeSynchronizer(queue_size, f0, f1, f2, f3, f4, f5) {}
 
   template<class F0, class F1, class F2, class F3, class F4, class F5, class F6>
+  [[deprecated("Use variade constructor instead")]]
   TimeSynchronizer(
     F0 & f0, F1 & f1, F2 & f2, F3 & f3, F4 & f4, F5 & f5, F6 & f6,
     uint32_t queue_size)
-  : Base(Policy(queue_size))
-  {
-    connectInput(f0, f1, f2, f3, f4, f5, f6);
-  }
+  : TimeSynchronizer(queue_size, f0, f1, f2, f3, f4, f5, f6) {}
 
   template<class F0, class F1, class F2, class F3, class F4, class F5, class F6, class F7>
+  [[deprecated("Use variade constructor instead")]]
   TimeSynchronizer(
     F0 & f0, F1 & f1, F2 & f2, F3 & f3, F4 & f4, F5 & f5, F6 & f6, F7 & f7,
     uint32_t queue_size)
-  : Base(Policy(queue_size))
-  {
-    connectInput(f0, f1, f2, f3, f4, f5, f6, f7);
-  }
+  : TimeSynchronizer(queue_size, f0, f1, f2, f3, f4, f5, f6, f7) {}
 
   template<class F0, class F1, class F2, class F3, class F4, class F5, class F6, class F7, class F8>
+  [[deprecated("Use variade constructor instead")]]
   TimeSynchronizer(
     F0 & f0, F1 & f1, F2 & f2, F3 & f3, F4 & f4, F5 & f5, F6 & f6, F7 & f7, F8 & f8,
     uint32_t queue_size)
-  : Base(Policy(queue_size))
-  {
-    connectInput(f0, f1, f2, f3, f4, f5, f6, f7, f8);
-  }
-
-  TimeSynchronizer(uint32_t queue_size)  // NOLINT(runtime/explicit)
-  : Base(Policy(queue_size))
-  {
-  }
-
-  ////////////////////////////////////////////////////////////////
-  // For backwards compatibility
-  ////////////////////////////////////////////////////////////////
-  void add0(const M0ConstPtr & msg)
-  {
-    this->template add<0>(M0Event(msg));
-  }
-
-  void add1(const M1ConstPtr & msg)
-  {
-    this->template add<1>(M1Event(msg));
-  }
-
-  void add2(const M2ConstPtr & msg)
-  {
-    this->template add<2>(M2Event(msg));
-  }
-
-  void add3(const M3ConstPtr & msg)
-  {
-    this->template add<3>(M3Event(msg));
-  }
-
-  void add4(const M4ConstPtr & msg)
-  {
-    this->template add<4>(M4Event(msg));
-  }
-
-  void add5(const M5ConstPtr & msg)
-  {
-    this->template add<5>(M5Event(msg));
-  }
-
-  void add6(const M6ConstPtr & msg)
-  {
-    this->template add<6>(M6Event(msg));
-  }
-
-  void add7(const M7ConstPtr & msg)
-  {
-    this->template add<7>(M7Event(msg));
-  }
-
-  void add8(const M8ConstPtr & msg)
-  {
-    this->template add<8>(M8Event(msg));
-  }
+  : TimeSynchronizer(queue_size, f0, f1, f2, f3, f4, f5, f6, f7, f8) {}
 };
-
 }  // namespace message_filters
 
 #endif  // MESSAGE_FILTERS__TIME_SYNCHRONIZER_HPP_

--- a/test/test_fuzz.cpp
+++ b/test/test_fuzz.cpp
@@ -117,9 +117,9 @@ TEST(TimeSynchronizer, fuzz_synchronizer)
     msg1->header.stamp = rclcpp::Clock().now();
     fuzz_msg(msg2);
     msg2->header.stamp = msg1->header.stamp;
-    sync.add0(msg1);
+    sync.add<0>(msg1);
     ASSERT_EQ(h.count_, 0);
-    sync.add1(msg2);
+    sync.add<1>(msg2);
     ASSERT_EQ(h.count_, 1);
     rclcpp::Rate(50).sleep();
   }

--- a/test/test_synchronizer.cpp
+++ b/test/test_synchronizer.cpp
@@ -49,14 +49,11 @@ typedef std::shared_ptr<Msg> MsgPtr;
 typedef std::shared_ptr<Msg const> MsgConstPtr;
 
 
-template<typename M0, typename M1, typename M2 = message_filters::NullType,
-  typename M3 = message_filters::NullType, typename M4 = message_filters::NullType,
-  typename M5 = message_filters::NullType, typename M6 = message_filters::NullType,
-  typename M7 = message_filters::NullType, typename M8 = message_filters::NullType>
-struct NullPolicy : public message_filters::PolicyBase<M0, M1, M2, M3, M4, M5, M6, M7, M8>
+template<typename ... Ms>
+struct NullPolicy : public message_filters::PolicyBase<Ms...>
 {
   typedef message_filters::Synchronizer<NullPolicy> Sync;
-  typedef message_filters::PolicyBase<M0, M1, M2, M3, M4, M5, M6, M7, M8> Super;
+  typedef message_filters::PolicyBase<Ms...> Super;
   typedef typename Super::Messages Messages;
   typedef typename Super::Signal Signal;
   typedef typename Super::Events Events;

--- a/test/time_synchronizer_unittest.cpp
+++ b/test/time_synchronizer_unittest.cpp
@@ -88,52 +88,52 @@ public:
 TEST(TimeSynchronizer, compile2)
 {
   message_filters::NullFilter<Msg> f0, f1;
-  message_filters::TimeSynchronizer<Msg, Msg> sync(f0, f1, 1);
+  message_filters::TimeSynchronizer<Msg, Msg> sync(1, f0, f1);
 }
 
 TEST(TimeSynchronizer, compile3)
 {
   message_filters::NullFilter<Msg> f0, f1, f2;
-  message_filters::TimeSynchronizer<Msg, Msg, Msg> sync(f0, f1, f2, 1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg> sync(1, f0, f1, f2);
 }
 
 TEST(TimeSynchronizer, compile4)
 {
   message_filters::NullFilter<Msg> f0, f1, f2, f3;
-  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg> sync(f0, f1, f2, f3, 1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg> sync(1, f0, f1, f2, f3);
 }
 
 TEST(TimeSynchronizer, compile5)
 {
   message_filters::NullFilter<Msg> f0, f1, f2, f3, f4;
-  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg> sync(f0, f1, f2, f3, f4, 1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg> sync(1, f0, f1, f2, f3, f4);
 }
 
 TEST(TimeSynchronizer, compile6)
 {
   message_filters::NullFilter<Msg> f0, f1, f2, f3, f4, f5;
-  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg> sync(f0, f1, f2, f3, f4, f5, 1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg> sync(1, f0, f1, f2, f3, f4, f5);
 }
 
 TEST(TimeSynchronizer, compile7)
 {
   message_filters::NullFilter<Msg> f0, f1, f2, f3, f4, f5, f6;
-  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(f0, f1, f2, f3, f4, f5,
-    f6, 1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(1, f0, f1, f2, f3, f4,
+    f5, f6);
 }
 
 TEST(TimeSynchronizer, compile8)
 {
   message_filters::NullFilter<Msg> f0, f1, f2, f3, f4, f5, f6, f7;
-  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(f0, f1, f2, f3, f4,
-    f5, f6, f7, 1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(1, f0, f1, f2, f3,
+    f4, f5, f6, f7);
 }
 
 TEST(TimeSynchronizer, compile9)
 {
   message_filters::NullFilter<Msg> f0, f1, f2, f3, f4, f5, f6, f7, f8;
-  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(f0, f1,
-    f2, f3, f4, f5, f6, f7, f8, 1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(1, f0, f1, f2,
+    f3, f4, f5, f6, f7, f8);
 }
 
 void function2(const MsgConstPtr &, const MsgConstPtr &) {}
@@ -286,9 +286,9 @@ TEST(TimeSynchronizer, immediate2)
   MsgPtr m(std::make_shared<Msg>());
   m->header.stamp = rclcpp::Clock().now();
 
-  sync.add0(m);
+  sync.add<0>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add1(m);
+  sync.add<1>(m);
   ASSERT_EQ(h.count_, 1);
 }
 
@@ -300,11 +300,11 @@ TEST(TimeSynchronizer, immediate3)
   MsgPtr m(std::make_shared<Msg>());
   m->header.stamp = rclcpp::Clock().now();
 
-  sync.add0(m);
+  sync.add<0>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add1(m);
+  sync.add<1>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add2(m);
+  sync.add<2>(m);
   ASSERT_EQ(h.count_, 1);
 }
 
@@ -316,13 +316,13 @@ TEST(TimeSynchronizer, immediate4)
   MsgPtr m(std::make_shared<Msg>());
   m->header.stamp = rclcpp::Clock().now();
 
-  sync.add0(m);
+  sync.add<0>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add1(m);
+  sync.add<1>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add2(m);
+  sync.add<2>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add3(m);
+  sync.add<3>(m);
   ASSERT_EQ(h.count_, 1);
 }
 
@@ -334,15 +334,15 @@ TEST(TimeSynchronizer, immediate5)
   MsgPtr m(std::make_shared<Msg>());
   m->header.stamp = rclcpp::Clock().now();
 
-  sync.add0(m);
+  sync.add<0>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add1(m);
+  sync.add<1>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add2(m);
+  sync.add<2>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add3(m);
+  sync.add<3>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add4(m);
+  sync.add<4>(m);
   ASSERT_EQ(h.count_, 1);
 }
 
@@ -354,17 +354,17 @@ TEST(TimeSynchronizer, immediate6)
   MsgPtr m(std::make_shared<Msg>());
   m->header.stamp = rclcpp::Clock().now();
 
-  sync.add0(m);
+  sync.add<0>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add1(m);
+  sync.add<1>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add2(m);
+  sync.add<2>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add3(m);
+  sync.add<3>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add4(m);
+  sync.add<4>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add5(m);
+  sync.add<5>(m);
   ASSERT_EQ(h.count_, 1);
 }
 
@@ -376,19 +376,19 @@ TEST(TimeSynchronizer, immediate7)
   MsgPtr m(std::make_shared<Msg>());
   m->header.stamp = rclcpp::Clock().now();
 
-  sync.add0(m);
+  sync.add<0>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add1(m);
+  sync.add<1>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add2(m);
+  sync.add<2>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add3(m);
+  sync.add<3>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add4(m);
+  sync.add<4>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add5(m);
+  sync.add<5>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add6(m);
+  sync.add<6>(m);
   ASSERT_EQ(h.count_, 1);
 }
 
@@ -400,21 +400,21 @@ TEST(TimeSynchronizer, immediate8)
   MsgPtr m(std::make_shared<Msg>());
   m->header.stamp = rclcpp::Clock().now();
 
-  sync.add0(m);
+  sync.add<0>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add1(m);
+  sync.add<1>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add2(m);
+  sync.add<2>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add3(m);
+  sync.add<3>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add4(m);
+  sync.add<4>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add5(m);
+  sync.add<5>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add6(m);
+  sync.add<6>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add7(m);
+  sync.add<7>(m);
   ASSERT_EQ(h.count_, 1);
 }
 
@@ -426,23 +426,23 @@ TEST(TimeSynchronizer, immediate9)
   MsgPtr m(std::make_shared<Msg>());
   m->header.stamp = rclcpp::Clock().now();
 
-  sync.add0(m);
+  sync.add<0>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add1(m);
+  sync.add<1>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add2(m);
+  sync.add<2>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add3(m);
+  sync.add<3>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add4(m);
+  sync.add<4>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add5(m);
+  sync.add<5>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add6(m);
+  sync.add<6>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add7(m);
+  sync.add<7>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add8(m);
+  sync.add<8>(m);
   ASSERT_EQ(h.count_, 1);
 }
 
@@ -458,16 +458,16 @@ TEST(TimeSynchronizer, multipleTimes)
   MsgPtr m(std::make_shared<Msg>());
   m->header.stamp = rclcpp::Time();
 
-  sync.add0(m);
+  sync.add<0>(m);
   ASSERT_EQ(h.count_, 0);
 
   m = std::make_shared<Msg>();
   m->header.stamp = rclcpp::Time(100000000);
-  sync.add1(m);
+  sync.add<1>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add0(m);
+  sync.add<0>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add2(m);
+  sync.add<2>(m);
   ASSERT_EQ(h.count_, 1);
 }
 
@@ -479,21 +479,21 @@ TEST(TimeSynchronizer, queueSize)
   MsgPtr m(std::make_shared<Msg>());
   m->header.stamp = rclcpp::Time();
 
-  sync.add0(m);
+  sync.add<0>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add1(m);
+  sync.add<1>(m);
   ASSERT_EQ(h.count_, 0);
 
   m = std::make_shared<Msg>();
   m->header.stamp = rclcpp::Time(100000000);
-  sync.add1(m);
+  sync.add<1>(m);
   ASSERT_EQ(h.count_, 0);
 
   m = std::make_shared<Msg>();
   m->header.stamp = rclcpp::Time();
-  sync.add1(m);
+  sync.add<1>(m);
   ASSERT_EQ(h.count_, 0);
-  sync.add2(m);
+  sync.add<2>(m);
   ASSERT_EQ(h.count_, 0);
 }
 
@@ -506,10 +506,10 @@ TEST(TimeSynchronizer, dropCallback)
   MsgPtr m(std::make_shared<Msg>());
   m->header.stamp = rclcpp::Time(0, 0);
 
-  sync.add0(m);
+  sync.add<0>(m);
   ASSERT_EQ(h.drop_count_, 0);
   m->header.stamp = rclcpp::Time(100000000);
-  sync.add0(m);
+  sync.add<0>(m);
 
   ASSERT_EQ(h.drop_count_, 1);
 }
@@ -547,7 +547,7 @@ TEST(TimeSynchronizer, eventInEventOut)
 TEST(TimeSynchronizer, connectConstructor)
 {
   message_filters::PassThrough<Msg> pt1, pt2;
-  message_filters::TimeSynchronizer<Msg, Msg> sync(pt1, pt2, 1);
+  message_filters::TimeSynchronizer<Msg, Msg> sync(1, pt1, pt2);
   Helper h;
   sync.registerCallback(std::bind(&Helper::cb, &h));
   MsgPtr m(std::make_shared<Msg>());


### PR DESCRIPTION
This PR mirgates message_synchronisers to variadic templates and allows for arbitrary numbers of topics.

Please note, that TimeSynchronizer had to be shruken down significantly for two reasons:

1. Implementing add0 .. add8 is now quiet hard. It has been dropped, because there is a generic alternative with add<I>
2. Variadic parameters are required to be at the end of a function signature. Therefore the queue_size parameter had to be moved to the front.

Given these changes, it might make sense to make TimeSynchronizer a template alias rather than a template class.