### PR TITLE
feat: add signal time functions to ExactTime policy

### DIFF
--- a/include/message_filters/sync_policies/exact_time.h
+++ b/include/message_filters/sync_policies/exact_time.h
@@ -138,6 +138,11 @@ struct ExactTime : public PolicyBase<M0, M1, M2, M3, M4, M5, M6, M7, M8>
     return drop_signal_.addCallback(callback, t);
   }
 
+  rclcpp::Time getLastSignalTime() const
+  {
+    return last_signal_time_;
+  }
+
 private:
 
   // assumes mutex_ is already locked


### PR DESCRIPTION
There was no easy way to obtain the last 'signal' time of the sync policy in order to determine the last successful sync time. This exposes the underlying time objects.