### PR TITLE
TypeAdapters support (#95)

### DIFF
--- a/include/message_filters/subscriber.h
+++ b/include/message_filters/subscriber.h
@@ -306,17 +306,10 @@ public:
       rclcpp_qos.get_rmw_qos_profile() = qos;
       qos_ = qos;
       options_ = options;
-      if constexpr(!rclcpp::is_type_adapter<M>::value){
-		    sub_ = node->template create_subscription<M>(topic, rclcpp_qos,
-           [this](std::shared_ptr<M const> msg) {
-             this->cb(EventType(msg));
-           }, options);
-      } else {
-        sub_ = node->template create_subscription<M>(topic, rclcpp_qos,
-           [this](std::shared_ptr<typename M::custom_type const> msg) {
-             this->cb(EventType(msg));
-           }, options);
-      }
+      sub_ = node->template create_subscription<M>(topic, rclcpp_qos,
+          [this](std::shared_ptr<MessageType const> msg) {
+            this->cb(EventType(msg));
+          }, options);
 
       node_raw_ = node;
     }

--- a/include/message_filters/subscriber.h
+++ b/include/message_filters/subscriber.h
@@ -145,10 +145,10 @@ void callback(const std::shared_ptr<M const>&);
 \endverbatim
  */
 
-template <typename M, bool is_adapter>
+template <typename M, bool is_adapter = rclcpp::is_type_adapter<M>::value>
 struct message_type;
 
-template <typename M> 
+template <typename M>
 struct message_type <M, true>
 {
   using type = typename M::custom_type;
@@ -160,18 +160,18 @@ struct message_type <M, false>
   using type = M;
 };
 
+template <typename M>
+using message_type_t = typename message_type<M>::type;
 
 template<class M, class NodeType = rclcpp::Node>
 class Subscriber 
 : public SubscriberBase<NodeType>
-, public SimpleFilter<typename message_type<M, rclcpp::is_type_adapter<M>::value>::type>
+, public SimpleFilter<message_type_t<M>>
 {
 public:
   typedef std::shared_ptr<NodeType> NodePtr;
-
-  using MessageType = typename message_type<M, rclcpp::is_type_adapter<M>::value>::type;
-  using EventType = MessageEvent<MessageType const>;
-
+  typedef message_type_t<M> MessageType;
+  typedef MessageEvent<MessageType const> EventType;
 
   /**
    * \brief Constructor


### PR DESCRIPTION
See #95.

This patch allows to use Type Adaptation within message_filters. 
A requirement for the adapted native structure is to feature an header attribute like ROS messages usually do. 