### PR TITLE
Update the HasHeader check to be more specific.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(ament_cmake_python REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcutils REQUIRED)
+find_package(std_msgs REQUIRED)
 
 add_library(${PROJECT_NAME} src/connection.cpp)
 if(WIN32)
@@ -29,6 +30,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 ament_target_dependencies(${PROJECT_NAME}
   "rclcpp"
   "rcutils"
+  "std_msgs"
 )
 
 install(
@@ -53,12 +55,12 @@ ament_export_libraries(${PROJECT_NAME})
 # Export modern CMake targets
 ament_export_targets(${PROJECT_NAME})
 
-ament_export_dependencies(rclcpp rcutils)
+ament_export_dependencies(rclcpp rcutils std_msgs)
 
 if(BUILD_TESTING)
-  find_package(sensor_msgs REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   find_package(rclcpp_lifecycle REQUIRED)
+  find_package(sensor_msgs REQUIRED)
 
   ament_lint_auto_find_test_dependencies()
 
@@ -114,7 +116,7 @@ if(BUILD_TESTING)
   if(TARGET ${PROJECT_NAME}-test_approximate_epsilon_time_policy)
     target_link_libraries(${PROJECT_NAME}-test_approximate_epsilon_time_policy ${PROJECT_NAME})
   endif()
-  
+
   ament_add_gtest(${PROJECT_NAME}-test_latest_time_policy test/test_latest_time_policy.cpp)
   if(TARGET ${PROJECT_NAME}-test_latest_time_policy)
     target_link_libraries(${PROJECT_NAME}-test_latest_time_policy ${PROJECT_NAME})

--- a/include/message_filters/message_traits.h
+++ b/include/message_filters/message_traits.h
@@ -34,6 +34,7 @@
 #include <type_traits>
 
 #include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/header.hpp>
 
 namespace message_filters
 {
@@ -41,12 +42,19 @@ namespace message_traits
 {
 
 /**
- * \brief HasHeader informs whether or not there is a header that gets serialized as the first thing in the message
+ * False if the message does not have a header
+ * @tparam M
  */
-template<typename M, typename = void> struct HasHeader : public std::false_type {};
+template<typename M, typename = void>
+struct HasHeader : public std::false_type {};
 
+/**
+ * True if the message has a field named 'header' with a type of std_msgs::msg::Header
+ * @tparam M
+ */
 template <typename M>
-struct HasHeader<M, decltype((void) M::header)> : std::true_type {};
+struct HasHeader<M, typename std::enable_if<std::is_same<std_msgs::msg::Header,
+  decltype(M().header)>::value>::type>: public std::true_type {};
 
 /**
  * \brief FrameId trait.  In the default implementation pointer()
@@ -59,7 +67,7 @@ struct FrameId
   static std::string* pointer(M& m) { (void)m; return nullptr; }
   static std::string const* pointer(const M& m) { (void)m; return nullptr; }
 };
- template<typename M>
+template<typename M>
 struct FrameId<M, typename std::enable_if<HasHeader<M>::value>::type >
 {
   static std::string* pointer(M& m) { return &m.header.frame_id; }

--- a/package.xml
+++ b/package.xml
@@ -22,10 +22,9 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <buildtool_depend>python_cmake_module</buildtool_depend>
 
-  <build_depend>rclcpp</build_depend>
-  <build_depend>rcutils</build_depend>
-  <build_export_depend>rclcpp</build_export_depend>
-  <build_export_depend>rcutils</build_export_depend>
+  <depend>rclcpp</depend>
+  <depend>rcutils</depend>
+  <depend>std_msgs</depend>
 
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rclpy</exec_depend>
@@ -34,7 +33,6 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>sensor_msgs</test_depend>
-  <test_depend>std_msgs</test_depend>
   <test_depend>rclcpp_lifecycle</test_depend>
 
   <export>


### PR DESCRIPTION
That is, make sure that not only does the message have a field called 'header', but that it also is of type std_msgs/msg/Header.  Otherwise we won't be able to compile the bits below.