### PR TITLE
Fixes pointed out by clang

### DIFF
--- a/include/message_filters/subscriber.h
+++ b/include/message_filters/subscriber.h
@@ -102,16 +102,14 @@ public:
    *
    * \param node The rclcpp::Node to use to subscribe.
    * \param topic The topic to subscribe to.
-   * \param qos (optional) The rmw qos profile to use to subscribe
+   * \param qos The rmw qos profile to use to subscribe.
+   * \param options The subscription options to use to subscribe.
    */
   virtual void subscribe(
     NodeType * node,
     const std::string& topic,
     const rmw_qos_profile_t qos,
-    rclcpp::SubscriptionOptions options)
-  {
-    this->subscribe(node, topic, qos, options);
-  }
+    rclcpp::SubscriptionOptions options) = 0;
 
   /**
    * \brief Re-subscribe to a topic.  Only works if this subscriber has previously been subscribed to a topic.

--- a/test/test_message_traits.cpp
+++ b/test/test_message_traits.cpp
@@ -33,7 +33,9 @@
 *********************************************************************/
 
 #include <gtest/gtest.h>
+
 #include "message_filters/message_traits.h"
+#include "rclcpp/time.hpp"
 #include "std_msgs/msg/header.hpp"
 
 struct Msg
@@ -50,5 +52,7 @@ TEST(MessageTraits, timeSource)
   EXPECT_EQ(time.get_clock_type(), RCL_ROS_TIME);
 
   // Ensure an exception isn't thrown when compared with a RCL_ROS_TIME time.
-  EXPECT_NO_THROW((time == rclcpp::Time{msg.header.stamp, RCL_ROS_TIME}));
+  bool unused;
+  EXPECT_NO_THROW(unused = (time == rclcpp::Time{msg.header.stamp, RCL_ROS_TIME}));
+  (void)unused;
 }


### PR DESCRIPTION
1.  Make one of the SubscriptionBase::subscribe methods pure virtual.  That's because it only ever called itself, which is nonsensical.  That just means that all classes that derive from it must implement it.
2.  Make clang aware that one of the tests here just wants to test that equality doesn't throw, so we don't care about the result.