### PR TITLE
Remove 'using' keyword in message_filters

### DIFF
--- a/test/msg_cache_unittest.cpp
+++ b/test/msg_cache_unittest.cpp
@@ -42,8 +42,6 @@
 #include "message_filters/cache.h"
 #include "message_filters/message_traits.h"
 
-using namespace message_filters ;
-
 struct Header
 {
   rclcpp::Time stamp ;
@@ -71,25 +69,22 @@ struct TimeStamp<Msg>
 }
 }
 
-
-void fillCacheEasy(Cache<Msg>& cache, unsigned int start, unsigned int end)
-
+void fillCacheEasy(message_filters::Cache<Msg>& cache, unsigned int start, unsigned int end)
 {
-  for (unsigned int i=start; i < end; i++)
-  {
-    Msg* msg = new Msg ;
-    msg->data = i ;
-    msg->header.stamp= rclcpp::Time(i*10, 0) ;
+  for (unsigned int i = start; i < end; i++) {
+    Msg * msg = new Msg;
+    msg->data = i;
+    msg->header.stamp = rclcpp::Time(i * 10, 0);
 
-    std::shared_ptr<Msg const> msg_ptr(msg) ;
-    cache.add(msg_ptr) ;
+    std::shared_ptr<Msg const> msg_ptr(msg);
+    cache.add(msg_ptr);
   }
 }
 
 TEST(Cache, easyInterval)
 {
-  Cache<Msg> cache(10) ;
-  fillCacheEasy(cache, 0, 5) ;
+  message_filters::Cache<Msg> cache(10);
+  fillCacheEasy(cache, 0, 5);
 
   std::vector<std::shared_ptr<Msg const> > interval_data = cache.getInterval(rclcpp::Time(5, 0), rclcpp::Time(35, 0)) ;
 
@@ -110,7 +105,7 @@ TEST(Cache, easyInterval)
 
 TEST(Cache, easySurroundingInterval)
 {
-  Cache<Msg> cache(10);
+  message_filters::Cache<Msg> cache(10);
   fillCacheEasy(cache, 1, 6);
 
   std::vector<std::shared_ptr<Msg const> > interval_data;
@@ -148,7 +143,7 @@ std::shared_ptr<Msg const> buildMsg(int32_t seconds, int data)
 
 TEST(Cache, easyUnsorted)
 {
-  Cache<Msg> cache(10) ;
+  message_filters::Cache<Msg> cache(10);
 
   cache.add(buildMsg(10, 1)) ;
   cache.add(buildMsg(30, 3)) ;
@@ -175,8 +170,8 @@ TEST(Cache, easyUnsorted)
 
 TEST(Cache, easyElemBeforeAfter)
 {
-  Cache<Msg> cache(10) ;
-  std::shared_ptr<Msg const> elem_ptr ;
+  message_filters::Cache<Msg> cache(10);
+  std::shared_ptr<Msg const> elem_ptr;
 
   fillCacheEasy(cache, 5, 10) ;
 
@@ -196,29 +191,30 @@ TEST(Cache, easyElemBeforeAfter)
 struct EventHelper
 {
 public:
-  void cb(const MessageEvent<Msg const>& evt)
+  void cb(const message_filters::MessageEvent<Msg const> & evt)
   {
     event_ = evt;
   }
 
-  MessageEvent<Msg const> event_;
+  message_filters::MessageEvent<Msg const> event_;
 };
 
 TEST(Cache, eventInEventOut)
 {
-  Cache<Msg> c0(10);
-  Cache<Msg> c1(c0, 10);
+  message_filters::Cache<Msg> c0(10);
+  message_filters::Cache<Msg> c1(c0, 10);
   EventHelper h;
   c1.registerCallback(&EventHelper::cb, &h);
 
-  MessageEvent<Msg const> evt(std::make_shared<Msg const>(), rclcpp::Time(4, 0));
+  message_filters::MessageEvent<Msg const> evt(std::make_shared<Msg const>(), rclcpp::Time(4, 0));
   c0.add(evt);
 
   EXPECT_EQ(h.event_.getReceiptTime(), evt.getReceiptTime());
   EXPECT_EQ(h.event_.getMessage(), evt.getMessage());
 }
 
-int main(int argc, char **argv){
+int main(int argc, char **argv)
+{
   testing::InitGoogleTest(&argc, argv);
   rclcpp::init(argc, argv);
   return RUN_ALL_TESTS();

--- a/test/msg_cache_unittest.cpp
+++ b/test/msg_cache_unittest.cpp
@@ -34,13 +34,14 @@
 
 #include <gtest/gtest.h>
 
-#include <rclcpp/rclcpp.hpp>
-#include <memory>
 #include <functional>
+#include <memory>
+#include <vector>
+
+#include <rclcpp/rclcpp.hpp>
 #include "message_filters/cache.h"
 #include "message_filters/message_traits.h"
 
-using namespace std ;
 using namespace message_filters ;
 
 struct Header
@@ -90,7 +91,7 @@ TEST(Cache, easyInterval)
   Cache<Msg> cache(10) ;
   fillCacheEasy(cache, 0, 5) ;
 
-  vector<std::shared_ptr<Msg const> > interval_data = cache.getInterval(rclcpp::Time(5, 0), rclcpp::Time(35, 0)) ;
+  std::vector<std::shared_ptr<Msg const> > interval_data = cache.getInterval(rclcpp::Time(5, 0), rclcpp::Time(35, 0)) ;
 
   ASSERT_EQ(interval_data.size(), (unsigned int) 3) ;
   EXPECT_EQ(interval_data[0]->data, 1) ;
@@ -112,7 +113,7 @@ TEST(Cache, easySurroundingInterval)
   Cache<Msg> cache(10);
   fillCacheEasy(cache, 1, 6);
 
-  vector<std::shared_ptr<Msg const> > interval_data;
+  std::vector<std::shared_ptr<Msg const> > interval_data;
   interval_data = cache.getSurroundingInterval(rclcpp::Time(15,0), rclcpp::Time(35,0)) ;
   ASSERT_EQ(interval_data.size(), (unsigned int) 4);
   EXPECT_EQ(interval_data[0]->data, 1);
@@ -155,7 +156,7 @@ TEST(Cache, easyUnsorted)
   cache.add(buildMsg( 5, 0)) ;
   cache.add(buildMsg(20, 2)) ;
 
-  vector<std::shared_ptr<Msg const> > interval_data = cache.getInterval(rclcpp::Time(3, 0), rclcpp::Time(15, 0)) ;
+  std::vector<std::shared_ptr<Msg const> > interval_data = cache.getInterval(rclcpp::Time(3, 0), rclcpp::Time(15, 0)) ;
 
   ASSERT_EQ(interval_data.size(), (unsigned int) 2) ;
   EXPECT_EQ(interval_data[0]->data, 0) ;

--- a/test/msg_cache_unittest.cpp
+++ b/test/msg_cache_unittest.cpp
@@ -86,7 +86,7 @@ TEST(Cache, easyInterval)
   message_filters::Cache<Msg> cache(10);
   fillCacheEasy(cache, 0, 5);
 
-  std::vector<std::shared_ptr<Msg const> > interval_data = cache.getInterval(rclcpp::Time(5, 0), rclcpp::Time(35, 0)) ;
+  std::vector<std::shared_ptr<Msg const> > interval_data = cache.getInterval(rclcpp::Time(5, 0), rclcpp::Time(35, 0));
 
   ASSERT_EQ(interval_data.size(), (unsigned int) 3) ;
   EXPECT_EQ(interval_data[0]->data, 1) ;
@@ -151,7 +151,7 @@ TEST(Cache, easyUnsorted)
   cache.add(buildMsg( 5, 0)) ;
   cache.add(buildMsg(20, 2)) ;
 
-  std::vector<std::shared_ptr<Msg const> > interval_data = cache.getInterval(rclcpp::Time(3, 0), rclcpp::Time(15, 0)) ;
+  std::vector<std::shared_ptr<Msg const> > interval_data = cache.getInterval(rclcpp::Time(3, 0), rclcpp::Time(15, 0));
 
   ASSERT_EQ(interval_data.size(), (unsigned int) 2) ;
   EXPECT_EQ(interval_data[0]->data, 0) ;

--- a/test/test_approximate_epsilon_time_policy.cpp
+++ b/test/test_approximate_epsilon_time_policy.cpp
@@ -33,6 +33,9 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
+#include <functional>
+#include <memory>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -42,15 +45,10 @@
 #include "message_filters/sync_policies/approximate_epsilon_time.h"
 #include "message_filters/message_traits.h"
 
-using namespace std::placeholders;
-using namespace message_filters;
-using namespace message_filters::sync_policies;
-
 struct Header
 {
   rclcpp::Time stamp;
 };
-
 
 struct Msg
 {
@@ -98,9 +96,9 @@ public:
 				  const std::vector<TimePair> &output,
 				  uint32_t queue_size, rclcpp::Duration epsilon) :
     input_(input), output_(output), output_position_(0), sync_(
-      ApproximateEpsilonTime<Msg, Msg>{queue_size, epsilon})
+      message_filters::sync_policies::ApproximateEpsilonTime<Msg, Msg>{queue_size, epsilon})
   {
-    sync_.registerCallback(std::bind(&ApproximateEpsilonTimeSynchronizerTest::callback, this, _1, _2));
+    sync_.registerCallback(std::bind(&ApproximateEpsilonTimeSynchronizerTest::callback, this, std::placeholders::_1, std::placeholders::_2));
   }
 
   void callback(const MsgConstPtr& p, const MsgConstPtr& q)
@@ -136,10 +134,10 @@ public:
   }
 
 private:
-  const std::vector<TimeAndTopic> &input_;
-  const std::vector<TimePair> &output_;
+  const std::vector<TimeAndTopic> & input_;
+  const std::vector<TimePair> & output_;
   unsigned int output_position_;
-  typedef Synchronizer<ApproximateEpsilonTime<Msg, Msg> > Sync2;
+  typedef message_filters::Synchronizer<message_filters::sync_policies::ApproximateEpsilonTime<Msg, Msg>> Sync2;
 public:
   Sync2 sync_;
 };
@@ -157,10 +155,10 @@ TEST(ApproxTimeSync, ExactMatch) {
 
   input.push_back(TimeAndTopic(t,0));     // a
   input.push_back(TimeAndTopic(t,1));   // A
-  input.push_back(TimeAndTopic(t+s*3,0)); // b
-  input.push_back(TimeAndTopic(t+s*3,1)); // B
-  input.push_back(TimeAndTopic(t+s*6,0)); // c
-  input.push_back(TimeAndTopic(t+s*6,1)); // C
+  input.push_back(TimeAndTopic(t+s*3,0));  // b
+  input.push_back(TimeAndTopic(t+s*3,1));  // B
+  input.push_back(TimeAndTopic(t+s*6,0));  // c
+  input.push_back(TimeAndTopic(t+s*6,1));  // C
   output.push_back(TimePair(t, t));
   output.push_back(TimePair(t+s*3, t+s*3));
   output.push_back(TimePair(t+s*6, t+s*6));
@@ -225,7 +223,8 @@ TEST(ApproxTimeSync, ImperfectMatch) {
   sync_test.run();
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
   testing::InitGoogleTest(&argc, argv);
   rclcpp::init(argc, argv);
 

--- a/test/test_chain.cpp
+++ b/test/test_chain.cpp
@@ -32,12 +32,12 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include <rclcpp/rclcpp.hpp>
 #include "message_filters/chain.h"
-
-using namespace message_filters;
 
 struct Msg
 {
@@ -60,13 +60,13 @@ public:
   int32_t count_;
 };
 
-typedef std::shared_ptr<PassThrough<Msg> > PassThroughPtr;
+typedef std::shared_ptr<message_filters::PassThrough<Msg> > PassThroughPtr;
 
 TEST(Chain, simple)
 {
   Helper h;
-  Chain<Msg> c;
-  c.addFilter(std::make_shared<PassThrough<Msg> >());
+  message_filters::Chain<Msg> c;
+  c.addFilter(std::make_shared<message_filters::PassThrough<Msg> >());
   c.registerCallback(std::bind(&Helper::cb, &h));
 
   c.add(std::make_shared<Msg>());
@@ -78,11 +78,11 @@ TEST(Chain, simple)
 TEST(Chain, multipleFilters)
 {
   Helper h;
-  Chain<Msg> c;
-  c.addFilter(std::make_shared<PassThrough<Msg> >());
-  c.addFilter(std::make_shared<PassThrough<Msg> >());
-  c.addFilter(std::make_shared<PassThrough<Msg> >());
-  c.addFilter(std::make_shared<PassThrough<Msg> >());
+  message_filters::Chain<Msg> c;
+  c.addFilter(std::make_shared<message_filters::PassThrough<Msg> >());
+  c.addFilter(std::make_shared<message_filters::PassThrough<Msg> >());
+  c.addFilter(std::make_shared<message_filters::PassThrough<Msg> >());
+  c.addFilter(std::make_shared<message_filters::PassThrough<Msg> >());
   c.registerCallback(std::bind(&Helper::cb, &h));
 
   c.add(std::make_shared<Msg>());
@@ -94,16 +94,16 @@ TEST(Chain, multipleFilters)
 TEST(Chain, addingFilters)
 {
   Helper h;
-  Chain<Msg> c;
-  c.addFilter(std::make_shared<PassThrough<Msg> >());
-  c.addFilter(std::make_shared<PassThrough<Msg> >());
+  message_filters::Chain<Msg> c;
+  c.addFilter(std::make_shared<message_filters::PassThrough<Msg> >());
+  c.addFilter(std::make_shared<message_filters::PassThrough<Msg> >());
   c.registerCallback(std::bind(&Helper::cb, &h));
 
   c.add(std::make_shared<Msg>());
   EXPECT_EQ(h.count_, 1);
 
-  c.addFilter(std::make_shared<PassThrough<Msg> >());
-  c.addFilter(std::make_shared<PassThrough<Msg> >());
+  c.addFilter(std::make_shared<message_filters::PassThrough<Msg> >());
+  c.addFilter(std::make_shared<message_filters::PassThrough<Msg> >());
 
   c.add(std::make_shared<Msg>());
   EXPECT_EQ(h.count_, 2);
@@ -112,11 +112,11 @@ TEST(Chain, addingFilters)
 TEST(Chain, inputFilter)
 {
   Helper h;
-  Chain<Msg> c;
-  c.addFilter(std::make_shared<PassThrough<Msg> >());
+  message_filters::Chain<Msg> c;
+  c.addFilter(std::make_shared<message_filters::PassThrough<Msg> >());
   c.registerCallback(std::bind(&Helper::cb, &h));
 
-  PassThrough<Msg> p;
+  message_filters::PassThrough<Msg> p;
   c.connectInput(p);
   p.add(std::make_shared<Msg>());
   EXPECT_EQ(h.count_, 1);
@@ -128,8 +128,8 @@ TEST(Chain, inputFilter)
 TEST(Chain, nonSharedPtrFilter)
 {
   Helper h;
-  Chain<Msg> c;
-  PassThrough<Msg> p;
+  message_filters::Chain<Msg> c;
+  message_filters::PassThrough<Msg> p;
   c.addFilter(&p);
   c.registerCallback(std::bind(&Helper::cb, &h));
 
@@ -141,43 +141,44 @@ TEST(Chain, nonSharedPtrFilter)
 
 TEST(Chain, retrieveFilter)
 {
-  Chain<Msg> c;
+  message_filters::Chain<Msg> c;
 
-  ASSERT_FALSE(c.getFilter<PassThrough<Msg> >(0));
+  ASSERT_FALSE(c.getFilter<message_filters::PassThrough<Msg> >(0));
 
-  c.addFilter(std::make_shared<PassThrough<Msg> >());
+  c.addFilter(std::make_shared<message_filters::PassThrough<Msg> >());
 
-  ASSERT_TRUE(c.getFilter<PassThrough<Msg> >(0));
-  ASSERT_FALSE(c.getFilter<PassThrough<Msg> >(1));
+  ASSERT_TRUE(c.getFilter<message_filters::PassThrough<Msg> >(0));
+  ASSERT_FALSE(c.getFilter<message_filters::PassThrough<Msg> >(1));
 }
 
 TEST(Chain, retrieveFilterThroughBaseClass)
 {
-  Chain<Msg> c;
-  ChainBase* cb = &c;
+  message_filters::Chain<Msg> c;
+  message_filters::ChainBase * cb = &c;
 
-  ASSERT_FALSE(cb->getFilter<PassThrough<Msg> >(0));
+  ASSERT_FALSE(cb->getFilter<message_filters::PassThrough<Msg> >(0));
 
-  c.addFilter(std::make_shared<PassThrough<Msg> >());
+  c.addFilter(std::make_shared<message_filters::PassThrough<Msg> >());
 
-  ASSERT_TRUE(cb->getFilter<PassThrough<Msg> >(0));
-  ASSERT_FALSE(cb->getFilter<PassThrough<Msg> >(1));
+  ASSERT_TRUE(cb->getFilter<message_filters::PassThrough<Msg> >(0));
+  ASSERT_FALSE(cb->getFilter<message_filters::PassThrough<Msg> >(1));
 }
 
-struct PTDerived : public PassThrough<Msg>
+struct PTDerived : public message_filters::PassThrough<Msg>
 {
 
 };
 
 TEST(Chain, retrieveBaseClass)
 {
-  Chain<Msg> c;
+  message_filters::Chain<Msg> c;
   c.addFilter(std::make_shared<PTDerived>());
-  ASSERT_TRUE(c.getFilter<PassThrough<Msg> >(0));
+  ASSERT_TRUE(c.getFilter<message_filters::PassThrough<Msg> >(0));
   ASSERT_TRUE(c.getFilter<PTDerived>(0));
 }
 
-int main(int argc, char **argv){
+int main(int argc, char **argv)
+{
   testing::InitGoogleTest(&argc, argv);
   rclcpp::init(argc, argv);
   return RUN_ALL_TESTS();

--- a/test/test_exact_time_policy.cpp
+++ b/test/test_exact_time_policy.cpp
@@ -32,20 +32,19 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
+#include <functional>
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include <rclcpp/rclcpp.hpp>
 #include "message_filters/synchronizer.h"
 #include "message_filters/sync_policies/exact_time.h"
 
-using namespace message_filters;
-using namespace message_filters::sync_policies;
-
 struct Header
 {
   rclcpp::Time stamp;
 };
-
 
 struct Msg
 {
@@ -92,10 +91,10 @@ public:
   int32_t drop_count_;
 };
 
-typedef ExactTime<Msg, Msg> Policy2;
-typedef ExactTime<Msg, Msg, Msg> Policy3;
-typedef Synchronizer<Policy2> Sync2;
-typedef Synchronizer<Policy3> Sync3;
+typedef message_filters::sync_policies::ExactTime<Msg, Msg> Policy2;
+typedef message_filters::sync_policies::ExactTime<Msg, Msg, Msg> Policy3;
+typedef message_filters::Synchronizer<Policy2> Sync2;
+typedef message_filters::Synchronizer<Policy3> Sync3;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 // From here on we assume that testing the 3-message version is sufficient, so as not to duplicate
@@ -167,14 +166,14 @@ TEST(ExactTime, dropCallback)
 
 struct EventHelper
 {
-  void callback(const MessageEvent<Msg const>& e1, const MessageEvent<Msg const>& e2)
+  void callback(const message_filters::MessageEvent<Msg const> & e1, const message_filters::MessageEvent<Msg const> & e2)
   {
     e1_ = e1;
     e2_ = e2;
   }
 
-  MessageEvent<Msg const> e1_;
-  MessageEvent<Msg const> e2_;
+  message_filters::MessageEvent<Msg const> e1_;
+  message_filters::MessageEvent<Msg const> e2_;
 };
 
 TEST(ExactTime, eventInEventOut)
@@ -182,7 +181,7 @@ TEST(ExactTime, eventInEventOut)
   Sync2 sync(2);
   EventHelper h;
   sync.registerCallback(&EventHelper::callback, &h);
-  MessageEvent<Msg const> evt(std::make_shared<Msg>(), rclcpp::Time(4, 0));
+  message_filters::MessageEvent<Msg const> evt(std::make_shared<Msg>(), rclcpp::Time(4, 0));
 
   sync.add<0>(evt);
   sync.add<1>(evt);
@@ -193,7 +192,8 @@ TEST(ExactTime, eventInEventOut)
   ASSERT_EQ(h.e2_.getReceiptTime(), evt.getReceiptTime());
 }
 
-int main(int argc, char **argv){
+int main(int argc, char **argv)
+{
   testing::InitGoogleTest(&argc, argv);
   rclcpp::init(argc, argv);
   return RUN_ALL_TESTS();

--- a/test/test_simple.cpp
+++ b/test/test_simple.cpp
@@ -34,14 +34,13 @@
 
 #include <gtest/gtest.h>
 
-#include <rclcpp/rclcpp.hpp>
+#include <array>
 #include <functional>
 #include <memory>
-#include <array>
-#include "message_filters/simple_filter.h"
 
-using namespace message_filters;
-using namespace std::placeholders;
+#include <rclcpp/rclcpp.hpp>
+
+#include "message_filters/simple_filter.h"
 
 struct Msg
 {
@@ -49,11 +48,11 @@ struct Msg
 typedef std::shared_ptr<Msg> MsgPtr;
 typedef std::shared_ptr<Msg const> MsgConstPtr;
 
-struct Filter : public SimpleFilter<Msg>
+struct Filter : public message_filters::SimpleFilter<Msg>
 {
-  typedef MessageEvent<Msg const> EventType;
+  typedef message_filters::MessageEvent<Msg const> EventType;
 
-  void add(const EventType& evt)
+  void add(const EventType & evt)
   {
     signalMessage(evt);
   }
@@ -67,7 +66,7 @@ public:
     counts_.fill(0);
   }
 
-  void cb0(const MsgConstPtr&)
+  void cb0(const MsgConstPtr &)
   {
     ++counts_[0];
   }
@@ -82,7 +81,7 @@ public:
     ++counts_[2];
   }
 
-  void cb3(const MessageEvent<Msg const>&)
+  void cb3(const message_filters::MessageEvent<Msg const> &)
   {
     ++counts_[3];
   }
@@ -92,7 +91,7 @@ public:
     ++counts_[4];
   }
 
-  void cb5(const MsgPtr&)
+  void cb5(const MsgPtr &)
   {
     ++counts_[5];
   }
@@ -102,7 +101,7 @@ public:
     ++counts_[6];
   }
 
-  void cb7(const MessageEvent<Msg>&)
+  void cb7(const message_filters::MessageEvent<Msg> &)
   {
     ++counts_[7];
   }
@@ -114,14 +113,14 @@ TEST(SimpleFilter, callbackTypes)
 {
   Helper h;
   Filter f;
-  f.registerCallback(std::bind(&Helper::cb0, &h, _1));
-  f.registerCallback<const Msg&>(std::bind(&Helper::cb1, &h, _1));
-  f.registerCallback<MsgConstPtr>(std::bind(&Helper::cb2, &h, _1));
-  f.registerCallback<const MessageEvent<Msg const>&>(std::bind(&Helper::cb3, &h, _1));
-  f.registerCallback<Msg>(std::bind(&Helper::cb4, &h, _1));
-  f.registerCallback<const MsgPtr&>(std::bind(&Helper::cb5, &h, _1));
-  f.registerCallback<MsgPtr>(std::bind(&Helper::cb6, &h, _1));
-  f.registerCallback<const MessageEvent<Msg>&>(std::bind(&Helper::cb7, &h, _1));
+  f.registerCallback(std::bind(&Helper::cb0, &h, std::placeholders::_1));
+  f.registerCallback<const Msg&>(std::bind(&Helper::cb1, &h, std::placeholders::_1));
+  f.registerCallback<MsgConstPtr>(std::bind(&Helper::cb2, &h, std::placeholders::_1));
+  f.registerCallback<const message_filters::MessageEvent<Msg const>&>(std::bind(&Helper::cb3, &h, std::placeholders::_1));
+  f.registerCallback<Msg>(std::bind(&Helper::cb4, &h, std::placeholders::_1));
+  f.registerCallback<const MsgPtr&>(std::bind(&Helper::cb5, &h, std::placeholders::_1));
+  f.registerCallback<MsgPtr>(std::bind(&Helper::cb6, &h, std::placeholders::_1));
+  f.registerCallback<const message_filters::MessageEvent<Msg>&>(std::bind(&Helper::cb7, &h, std::placeholders::_1));
 
   f.add(Filter::EventType(std::make_shared<Msg>()));
   EXPECT_EQ(h.counts_[0], 1);
@@ -136,9 +135,9 @@ TEST(SimpleFilter, callbackTypes)
 
 struct OldFilter
 {
-  Connection registerCallback(const std::function<void(const MsgConstPtr&)>&)
+  message_filters::Connection registerCallback(const std::function<void(const MsgConstPtr&)>&)
   {
-    return Connection();
+    return message_filters::Connection();
   }
 };
 
@@ -146,7 +145,7 @@ TEST(SimpleFilter, oldRegisterWithNewFilter)
 {
   OldFilter f;
   Helper h;
-  f.registerCallback(std::bind(&Helper::cb3, &h, _1));
+  f.registerCallback(std::bind(&Helper::cb3, &h, std::placeholders::_1));
 }
 
 int main(int argc, char **argv){

--- a/test/test_subscriber.cpp
+++ b/test/test_subscriber.cpp
@@ -34,17 +34,16 @@
 
 #include <gtest/gtest.h>
 
-// see ros2/rclcpp#1619,1713
-// TODO: remove this comment, and the `NonConstHelper` tests
-// once the deprecated signatures have been discontinued.
-#define RCLCPP_AVOID_DEPRECATIONS_FOR_UNIT_TESTS 1
+#include <functional>
+#include <memory>
+#include <utility>
+
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_lifecycle/lifecycle_node.hpp>
 #include "message_filters/subscriber.h"
 #include "message_filters/chain.h"
 #include "sensor_msgs/msg/imu.hpp"
 
-using namespace message_filters;
 typedef sensor_msgs::msg::Imu Msg;
 typedef std::shared_ptr<sensor_msgs::msg::Imu const> MsgConstPtr;
 typedef std::shared_ptr<sensor_msgs::msg::Imu> MsgPtr;
@@ -68,13 +67,12 @@ TEST(Subscriber, simple)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
   Helper h;
-  Subscriber<Msg> sub(node, "test_topic");
+  message_filters::Subscriber<Msg> sub(node, "test_topic");
   sub.registerCallback(std::bind(&Helper::cb, &h, std::placeholders::_1));
   auto pub = node->create_publisher<Msg>("test_topic", 10);
   rclcpp::Clock ros_clock;
   auto start = ros_clock.now();
-  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1, 0))
-  {
+  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1, 0)) {
     pub->publish(Msg());
     rclcpp::Rate(50).sleep();
     rclcpp::spin_some(node);
@@ -87,13 +85,12 @@ TEST(Subscriber, simple_raw)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
   Helper h;
-  Subscriber<Msg> sub(node.get(), "test_topic");
+  message_filters::Subscriber<Msg> sub(node.get(), "test_topic");
   sub.registerCallback(std::bind(&Helper::cb, &h, std::placeholders::_1));
   auto pub = node->create_publisher<Msg>("test_topic", 10);
   rclcpp::Clock ros_clock;
   auto start = ros_clock.now();
-  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1, 0))
-  {
+  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1, 0)) {
     pub->publish(Msg());
     rclcpp::Rate(50).sleep();
     rclcpp::spin_some(node);
@@ -106,7 +103,7 @@ TEST(Subscriber, subUnsubSub)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
   Helper h;
-  Subscriber<Msg> sub(node, "test_topic");
+  message_filters::Subscriber<Msg> sub(node, "test_topic");
   sub.registerCallback(std::bind(&Helper::cb, &h,  std::placeholders::_1));
   auto pub = node->create_publisher<Msg>("test_topic", 10);
 
@@ -115,8 +112,7 @@ TEST(Subscriber, subUnsubSub)
 
   rclcpp::Clock ros_clock;
   auto start = ros_clock.now();
-  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1, 0))
-  {
+  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1, 0)) {
     pub->publish(Msg());
     rclcpp::Rate(50).sleep();
     rclcpp::spin_some(node);
@@ -129,7 +125,7 @@ TEST(Subscriber, subUnsubSub_raw)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
   Helper h;
-  Subscriber<Msg> sub(node.get(), "test_topic");
+  message_filters::Subscriber<Msg> sub(node.get(), "test_topic");
   sub.registerCallback(std::bind(&Helper::cb, &h,  std::placeholders::_1));
   auto pub = node->create_publisher<Msg>("test_topic", 10);
 
@@ -138,8 +134,7 @@ TEST(Subscriber, subUnsubSub_raw)
 
   rclcpp::Clock ros_clock;
   auto start = ros_clock.now();
-  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1, 0))
-  {
+  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1, 0)) {
     pub->publish(Msg());
     rclcpp::Rate(50).sleep();
     rclcpp::spin_some(node);
@@ -152,7 +147,7 @@ TEST(Subscriber, switchRawAndShared)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
   Helper h;
-  Subscriber<Msg> sub(node, "test_topic");
+  message_filters::Subscriber<Msg> sub(node, "test_topic");
   sub.registerCallback(std::bind(&Helper::cb, &h,  std::placeholders::_1));
   auto pub = node->create_publisher<Msg>("test_topic2", 10);
 
@@ -161,8 +156,7 @@ TEST(Subscriber, switchRawAndShared)
 
   rclcpp::Clock ros_clock;
   auto start = ros_clock.now();
-  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1, 0))
-  {
+  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1, 0)) {
     pub->publish(Msg());
     rclcpp::Rate(50).sleep();
     rclcpp::spin_some(node);
@@ -175,15 +169,14 @@ TEST(Subscriber, subInChain)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
   Helper h;
-  Chain<Msg> c;
-  c.addFilter(std::make_shared<Subscriber<Msg> >(node, "test_topic"));
+  message_filters::Chain<Msg> c;
+  c.addFilter(std::make_shared<message_filters::Subscriber<Msg> >(node, "test_topic"));
   c.registerCallback(std::bind(&Helper::cb, &h,  std::placeholders::_1));
   auto pub = node->create_publisher<Msg>("test_topic", 10);
 
   rclcpp::Clock ros_clock;
   auto start = ros_clock.now();
-  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1, 0))
-  {
+  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1, 0)) {
     pub->publish(Msg());
     rclcpp::Rate(50).sleep();
     rclcpp::spin_some(node);
@@ -216,7 +209,7 @@ TEST(Subscriber, singleNonConstCallback)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
   NonConstHelper h;
-  Subscriber<Msg> sub(node, "test_topic");
+  message_filters::Subscriber<Msg> sub(node, "test_topic");
   sub.registerCallback(&NonConstHelper::cb, &h);
   auto pub = node->create_publisher<Msg>("test_topic", 10);
   Msg msg;
@@ -233,7 +226,7 @@ TEST(Subscriber, multipleNonConstCallbacksFilterSubscriber)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
   NonConstHelper h, h2;
-  Subscriber<Msg> sub(node, "test_topic");
+  message_filters::Subscriber<Msg> sub(node, "test_topic");
   sub.registerCallback(&NonConstHelper::cb, &h);
   sub.registerCallback(&NonConstHelper::cb, &h2);
   auto pub = node->create_publisher<Msg>("test_topic", 10);
@@ -254,7 +247,7 @@ TEST(Subscriber, multipleCallbacksSomeFilterSomeDirect)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
   NonConstHelper h, h2;
-  Subscriber<Msg> sub(node, "test_topic");
+  message_filters::Subscriber<Msg> sub(node, "test_topic");
   sub.registerCallback(&NonConstHelper::cb, &h);
   auto sub2 = node->create_subscription<Msg>(
     "test_topic", 10, std::bind(&NonConstHelper::cb, &h2, std::placeholders::_1));
@@ -279,14 +272,13 @@ TEST(Subscriber, lifecycle)
 {
   auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test_node");
   Helper h;
-  Subscriber<Msg, rclcpp_lifecycle::LifecycleNode> sub(node, "test_topic");
+  message_filters::Subscriber<Msg, rclcpp_lifecycle::LifecycleNode> sub(node, "test_topic");
   sub.registerCallback(std::bind(&Helper::cb, &h, std::placeholders::_1));
   auto pub = node->create_publisher<Msg>("test_topic", 10);
   pub->on_activate();
   rclcpp::Clock ros_clock;
   auto start = ros_clock.now();
-  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1, 0))
-  {
+  while (h.count_ == 0 && (ros_clock.now() - start) < rclcpp::Duration(1, 0)) {
     pub->publish(Msg());
     rclcpp::Rate(50).sleep();
     rclcpp::spin_some(node->get_node_base_interface());
@@ -296,7 +288,8 @@ TEST(Subscriber, lifecycle)
 }
 
 
-int main(int argc, char **argv){
+int main(int argc, char **argv)
+{
   testing::InitGoogleTest(&argc, argv);
 
   rclcpp::init(argc, argv);

--- a/test/test_synchronizer.cpp
+++ b/test/test_synchronizer.cpp
@@ -34,12 +34,11 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+#include <memory>
+
 #include <rclcpp/rclcpp.hpp>
 #include "message_filters/synchronizer.h"
-#include <array>
-
-using namespace message_filters;
-using namespace std::placeholders;
 
 struct Header
 {
@@ -56,12 +55,12 @@ typedef std::shared_ptr<Msg> MsgPtr;
 typedef std::shared_ptr<Msg const> MsgConstPtr;
 
 
-template<typename M0, typename M1, typename M2 = NullType, typename M3 = NullType, typename M4 = NullType,
-         typename M5 = NullType, typename M6 = NullType, typename M7 = NullType, typename M8 = NullType>
-struct NullPolicy : public PolicyBase<M0, M1, M2, M3, M4, M5, M6, M7, M8>
+template<typename M0, typename M1, typename M2 = message_filters::NullType, typename M3 = message_filters::NullType, typename M4 = message_filters::NullType,
+         typename M5 = message_filters::NullType, typename M6 = message_filters::NullType, typename M7 = message_filters::NullType, typename M8 = message_filters::NullType>
+struct NullPolicy : public message_filters::PolicyBase<M0, M1, M2, M3, M4, M5, M6, M7, M8>
 {
-  typedef Synchronizer<NullPolicy> Sync;
-  typedef PolicyBase<M0, M1, M2, M3, M4, M5, M6, M7, M8> Super;
+  typedef message_filters::Synchronizer<NullPolicy> Sync;
+  typedef message_filters::PolicyBase<M0, M1, M2, M3, M4, M5, M6, M7, M8> Super;
   typedef typename Super::Messages Messages;
   typedef typename Super::Signal Signal;
   typedef typename Super::Events Events;
@@ -69,8 +68,7 @@ struct NullPolicy : public PolicyBase<M0, M1, M2, M3, M4, M5, M6, M7, M8>
 
   NullPolicy()
   {
-    for (int i = 0; i < RealTypeCount::value; ++i)
-    {
+    for (int i = 0; i < RealTypeCount::value; ++i) {
       added_[i] = 0;
     }
   }
@@ -80,7 +78,7 @@ struct NullPolicy : public PolicyBase<M0, M1, M2, M3, M4, M5, M6, M7, M8>
   }
 
   template<int i>
-  void add(const typename std::tuple_element<i, Events>::type&)
+  void add(const typename std::tuple_element<i, Events>::type &)
   {
     ++added_.at(i);
   }
@@ -98,50 +96,50 @@ typedef NullPolicy<Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg> Policy9;
 
 TEST(Synchronizer, compile2)
 {
-  NullFilter<Msg> f0, f1;
-  Synchronizer<Policy2> sync(f0, f1);
+  message_filters::NullFilter<Msg> f0, f1;
+  message_filters::Synchronizer<Policy2> sync(f0, f1);
 }
 
 TEST(Synchronizer, compile3)
 {
-  NullFilter<Msg> f0, f1, f2;
-  Synchronizer<Policy3> sync(f0, f1, f2);
+  message_filters::NullFilter<Msg> f0, f1, f2;
+  message_filters::Synchronizer<Policy3> sync(f0, f1, f2);
 }
 
 TEST(Synchronizer, compile4)
 {
-  NullFilter<Msg> f0, f1, f2, f3;
-  Synchronizer<Policy4> sync(f0, f1, f2, f3);
+  message_filters::NullFilter<Msg> f0, f1, f2, f3;
+  message_filters::Synchronizer<Policy4> sync(f0, f1, f2, f3);
 }
 
 TEST(Synchronizer, compile5)
 {
-  NullFilter<Msg> f0, f1, f2, f3, f4;
-  Synchronizer<Policy5> sync(f0, f1, f2, f3, f4);
+  message_filters::NullFilter<Msg> f0, f1, f2, f3, f4;
+  message_filters::Synchronizer<Policy5> sync(f0, f1, f2, f3, f4);
 }
 
 TEST(Synchronizer, compile6)
 {
-  NullFilter<Msg> f0, f1, f2, f3, f4, f5;
-  Synchronizer<Policy6> sync(f0, f1, f2, f3, f4, f5);
+  message_filters::NullFilter<Msg> f0, f1, f2, f3, f4, f5;
+  message_filters::Synchronizer<Policy6> sync(f0, f1, f2, f3, f4, f5);
 }
 
 TEST(Synchronizer, compile7)
 {
-  NullFilter<Msg> f0, f1, f2, f3, f4, f5, f6;
-  Synchronizer<Policy7> sync(f0, f1, f2, f3, f4, f5, f6);
+  message_filters::NullFilter<Msg> f0, f1, f2, f3, f4, f5, f6;
+  message_filters::Synchronizer<Policy7> sync(f0, f1, f2, f3, f4, f5, f6);
 }
 
 TEST(Synchronizer, compile8)
 {
-  NullFilter<Msg> f0, f1, f2, f3, f4, f5, f6, f7;
-  Synchronizer<Policy8> sync(f0, f1, f2, f3, f4, f5, f6, f7);
+  message_filters::NullFilter<Msg> f0, f1, f2, f3, f4, f5, f6, f7;
+  message_filters::Synchronizer<Policy8> sync(f0, f1, f2, f3, f4, f5, f6, f7);
 }
 
 TEST(Synchronizer, compile9)
 {
-  NullFilter<Msg> f0, f1, f2, f3, f4, f5, f6, f7, f8;
-  Synchronizer<Policy9> sync(f0, f1, f2, f3, f4, f5, f6, f7, f8);
+  message_filters::NullFilter<Msg> f0, f1, f2, f3, f4, f5, f6, f7, f8;
+  message_filters::Synchronizer<Policy9> sync(f0, f1, f2, f3, f4, f5, f6, f7, f8);
 }
 
 void function2(const MsgConstPtr&, const MsgConstPtr&) {}
@@ -151,53 +149,53 @@ void function5(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const
 void function6(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&) {}
 void function7(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&) {}
 void function8(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&) {}
-void function9(const MsgConstPtr&, MsgConstPtr, const MsgPtr&, MsgPtr, const Msg&, Msg, const MessageEvent<Msg const>&, const MessageEvent<Msg>&, const MsgConstPtr&) {}
+void function9(const MsgConstPtr&, MsgConstPtr, const MsgPtr&, MsgPtr, const Msg&, Msg, const message_filters::MessageEvent<Msg const>&, const message_filters::MessageEvent<Msg>&, const MsgConstPtr&) {}
 
 TEST(Synchronizer, compileFunction2)
 {
-  Synchronizer<Policy2> sync;
+  message_filters::Synchronizer<Policy2> sync;
   sync.registerCallback(function2);
 }
 
 TEST(Synchronizer, compileFunction3)
 {
-  Synchronizer<Policy3> sync;
+  message_filters::Synchronizer<Policy3> sync;
   sync.registerCallback(function3);
 }
 
 TEST(Synchronizer, compileFunction4)
 {
-  Synchronizer<Policy4> sync;
+  message_filters::Synchronizer<Policy4> sync;
   sync.registerCallback(function4);
 }
 
 TEST(Synchronizer, compileFunction5)
 {
-  Synchronizer<Policy5> sync;
+  message_filters::Synchronizer<Policy5> sync;
   sync.registerCallback(function5);
 }
 
 TEST(Synchronizer, compileFunction6)
 {
-  Synchronizer<Policy6> sync;
+  message_filters::Synchronizer<Policy6> sync;
   sync.registerCallback(function6);
 }
 
 TEST(Synchronizer, compileFunction7)
 {
-  Synchronizer<Policy7> sync;
+  message_filters::Synchronizer<Policy7> sync;
   sync.registerCallback(function7);
 }
 
 TEST(Synchronizer, compileFunction8)
 {
-  Synchronizer<Policy8> sync;
+  message_filters::Synchronizer<Policy8> sync;
   sync.registerCallback(function8);
 }
 
 TEST(Synchronizer, compileFunction9)
 {
-  Synchronizer<Policy9> sync;
+  message_filters::Synchronizer<Policy9> sync;
   sync.registerCallback(function9);
 }
 
@@ -209,62 +207,62 @@ struct MethodHelper
   void method5(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&) {}
   void method6(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&) {}
   void method7(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&) {}
-  void method8(const MsgConstPtr&, MsgConstPtr, const MsgPtr&, MsgPtr, const Msg&, Msg, const MessageEvent<Msg const>&, const MessageEvent<Msg>&) {}
+  void method8(const MsgConstPtr&, MsgConstPtr, const MsgPtr&, MsgPtr, const Msg&, Msg, const message_filters::MessageEvent<Msg const>&, const message_filters::MessageEvent<Msg>&) {}
   // Can only do 8 here because the object instance counts as a parameter and bind only supports 9
 };
 
 TEST(Synchronizer, compileMethod2)
 {
   MethodHelper h;
-  Synchronizer<Policy2> sync;
+  message_filters::Synchronizer<Policy2> sync;
   sync.registerCallback(&MethodHelper::method2, &h);
 }
 
 TEST(Synchronizer, compileMethod3)
 {
   MethodHelper h;
-  Synchronizer<Policy3> sync;
+  message_filters::Synchronizer<Policy3> sync;
   sync.registerCallback(&MethodHelper::method3, &h);
 }
 
 TEST(Synchronizer, compileMethod4)
 {
   MethodHelper h;
-  Synchronizer<Policy4> sync;
+  message_filters::Synchronizer<Policy4> sync;
   sync.registerCallback(&MethodHelper::method4, &h);
 }
 
 TEST(Synchronizer, compileMethod5)
 {
   MethodHelper h;
-  Synchronizer<Policy5> sync;
+  message_filters::Synchronizer<Policy5> sync;
   sync.registerCallback(&MethodHelper::method5, &h);
 }
 
 TEST(Synchronizer, compileMethod6)
 {
   MethodHelper h;
-  Synchronizer<Policy6> sync;
+  message_filters::Synchronizer<Policy6> sync;
   sync.registerCallback(&MethodHelper::method6, &h);
 }
 
 TEST(Synchronizer, compileMethod7)
 {
   MethodHelper h;
-  Synchronizer<Policy7> sync;
+  message_filters::Synchronizer<Policy7> sync;
   sync.registerCallback(&MethodHelper::method7, &h);
 }
 
 TEST(Synchronizer, compileMethod8)
 {
   MethodHelper h;
-  Synchronizer<Policy8> sync;
+  message_filters::Synchronizer<Policy8> sync;
   sync.registerCallback(&MethodHelper::method8, &h);
 }
 
 TEST(Synchronizer, add2)
 {
-  Synchronizer<Policy2> sync;
+  message_filters::Synchronizer<Policy2> sync;
   MsgPtr m(std::make_shared<Msg>());
 
   ASSERT_EQ(sync.added_[0], 0);
@@ -277,7 +275,7 @@ TEST(Synchronizer, add2)
 
 TEST(Synchronizer, add3)
 {
-  Synchronizer<Policy3> sync;
+  message_filters::Synchronizer<Policy3> sync;
   MsgPtr m(std::make_shared<Msg>());
 
   ASSERT_EQ(sync.added_[0], 0);
@@ -293,7 +291,7 @@ TEST(Synchronizer, add3)
 
 TEST(Synchronizer, add4)
 {
-  Synchronizer<Policy4> sync;
+  message_filters::Synchronizer<Policy4> sync;
   MsgPtr m(std::make_shared<Msg>());
 
   ASSERT_EQ(sync.added_[0], 0);
@@ -312,7 +310,7 @@ TEST(Synchronizer, add4)
 
 TEST(Synchronizer, add5)
 {
-  Synchronizer<Policy5> sync;
+  message_filters::Synchronizer<Policy5> sync;
   MsgPtr m(std::make_shared<Msg>());
 
   ASSERT_EQ(sync.added_[0], 0);
@@ -334,7 +332,7 @@ TEST(Synchronizer, add5)
 
 TEST(Synchronizer, add6)
 {
-  Synchronizer<Policy6> sync;
+  message_filters::Synchronizer<Policy6> sync;
   MsgPtr m(std::make_shared<Msg>());
 
   ASSERT_EQ(sync.added_[0], 0);
@@ -359,7 +357,7 @@ TEST(Synchronizer, add6)
 
 TEST(Synchronizer, add7)
 {
-  Synchronizer<Policy7> sync;
+  message_filters::Synchronizer<Policy7> sync;
   MsgPtr m(std::make_shared<Msg>());
 
   ASSERT_EQ(sync.added_[0], 0);
@@ -387,7 +385,7 @@ TEST(Synchronizer, add7)
 
 TEST(Synchronizer, add8)
 {
-  Synchronizer<Policy8> sync;
+  message_filters::Synchronizer<Policy8> sync;
   MsgPtr m(std::make_shared<Msg>());
 
   ASSERT_EQ(sync.added_[0], 0);
@@ -418,7 +416,7 @@ TEST(Synchronizer, add8)
 
 TEST(Synchronizer, add9)
 {
-  Synchronizer<Policy9> sync;
+  message_filters::Synchronizer<Policy9> sync;
   MsgPtr m(std::make_shared<Msg>());
 
   ASSERT_EQ(sync.added_[0], 0);
@@ -450,7 +448,8 @@ TEST(Synchronizer, add9)
   ASSERT_EQ(sync.added_[8], 1);
 }
 
-int main(int argc, char **argv){
+int main(int argc, char **argv)
+{
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/test/time_sequencer_unittest.cpp
+++ b/test/time_sequencer_unittest.cpp
@@ -34,16 +34,15 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
+
 #include <rclcpp/rclcpp.hpp>
 #include "message_filters/time_sequencer.h"
-
-using namespace message_filters;
 
 struct Header
 {
   rclcpp::Time stamp;
 };
-
 
 struct Msg
 {
@@ -86,7 +85,7 @@ public:
 TEST(TimeSequencer, simple)
 {
   rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_node");
-  TimeSequencer<Msg> seq(rclcpp::Duration(0, 250000000), rclcpp::Duration(0, 10000000), 10, node);
+  message_filters::TimeSequencer<Msg> seq(rclcpp::Duration(0, 250000000), rclcpp::Duration(0, 10000000), 10, node);
   Helper h;
   seq.registerCallback(std::bind(&Helper::cb, &h, std::placeholders::_1));
   MsgPtr msg(std::make_shared<Msg>());
@@ -107,35 +106,34 @@ TEST(TimeSequencer, simple)
 TEST(TimeSequencer, compilation)
 {
   rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_node");
-  TimeSequencer<Msg> seq(rclcpp::Duration(1, 0), rclcpp::Duration(0, 10000000), 10, node);
-  TimeSequencer<Msg> seq2(rclcpp::Duration(1, 0), rclcpp::Duration(0, 10000000), 10, node);
+  message_filters::TimeSequencer<Msg> seq(rclcpp::Duration(1, 0), rclcpp::Duration(0, 10000000), 10, node);
+  message_filters::TimeSequencer<Msg> seq2(rclcpp::Duration(1, 0), rclcpp::Duration(0, 10000000), 10, node);
   seq2.connectInput(seq);
 }
 
 struct EventHelper
 {
 public:
-  void cb(const MessageEvent<Msg const>& evt)
+  void cb(const message_filters::MessageEvent<Msg const> & evt)
   {
     event_ = evt;
   }
 
-  MessageEvent<Msg const> event_;
+  message_filters::MessageEvent<Msg const> event_;
 };
 
 TEST(TimeSequencer, eventInEventOut)
 {
   rclcpp::Node::SharedPtr nh = std::make_shared<rclcpp::Node>("test_node");
-  TimeSequencer<Msg> seq(rclcpp::Duration(1, 0), rclcpp::Duration(0, 10000000), 10, nh);
-  TimeSequencer<Msg> seq2(seq, rclcpp::Duration(1, 0), rclcpp::Duration(0, 10000000), 10, nh);
+  message_filters::TimeSequencer<Msg> seq(rclcpp::Duration(1, 0), rclcpp::Duration(0, 10000000), 10, nh);
+  message_filters::TimeSequencer<Msg> seq2(seq, rclcpp::Duration(1, 0), rclcpp::Duration(0, 10000000), 10, nh);
   EventHelper h;
   seq2.registerCallback(&EventHelper::cb, &h);
 
-  MessageEvent<Msg const> evt(std::make_shared<Msg const>(), rclcpp::Clock().now());
+  message_filters::MessageEvent<Msg const> evt(std::make_shared<Msg const>(), rclcpp::Clock().now());
   seq.add(evt);
 
-  while (!h.event_.getMessage())
-  {
+  while (!h.event_.getMessage()) {
     rclcpp::Rate(100).sleep();
     rclcpp::spin_some(nh);
   }
@@ -144,7 +142,8 @@ TEST(TimeSequencer, eventInEventOut)
   EXPECT_EQ(h.event_.getMessage(), evt.getMessage());
 }
 
-int main(int argc, char **argv){
+int main(int argc, char **argv)
+{
   testing::InitGoogleTest(&argc, argv);
 
   rclcpp::init(argc, argv);

--- a/test/time_synchronizer_unittest.cpp
+++ b/test/time_synchronizer_unittest.cpp
@@ -34,18 +34,17 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
+
 #include "message_filters/time_synchronizer.h"
 #include "message_filters/pass_through.h"
 #include "message_filters/message_traits.h"
 #include <rclcpp/rclcpp.hpp>
 
-using namespace message_filters;
-
 struct Header
 {
   rclcpp::Time stamp;
 };
-
 
 struct Msg
 {
@@ -94,50 +93,50 @@ public:
 
 TEST(TimeSynchronizer, compile2)
 {
-  NullFilter<Msg> f0, f1;
-  TimeSynchronizer<Msg, Msg> sync(f0, f1, 1);
+  message_filters::NullFilter<Msg> f0, f1;
+  message_filters::TimeSynchronizer<Msg, Msg> sync(f0, f1, 1);
 }
 
 TEST(TimeSynchronizer, compile3)
 {
-  NullFilter<Msg> f0, f1, f2;
-  TimeSynchronizer<Msg, Msg, Msg> sync(f0, f1, f2, 1);
+  message_filters::NullFilter<Msg> f0, f1, f2;
+  message_filters::TimeSynchronizer<Msg, Msg, Msg> sync(f0, f1, f2, 1);
 }
 
 TEST(TimeSynchronizer, compile4)
 {
-  NullFilter<Msg> f0, f1, f2, f3;
-  TimeSynchronizer<Msg, Msg, Msg, Msg> sync(f0, f1, f2, f3, 1);
+  message_filters::NullFilter<Msg> f0, f1, f2, f3;
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg> sync(f0, f1, f2, f3, 1);
 }
 
 TEST(TimeSynchronizer, compile5)
 {
-  NullFilter<Msg> f0, f1, f2, f3, f4;
-  TimeSynchronizer<Msg, Msg, Msg, Msg, Msg> sync(f0, f1, f2, f3, f4, 1);
+  message_filters::NullFilter<Msg> f0, f1, f2, f3, f4;
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg> sync(f0, f1, f2, f3, f4, 1);
 }
 
 TEST(TimeSynchronizer, compile6)
 {
-  NullFilter<Msg> f0, f1, f2, f3, f4, f5;
-  TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg> sync(f0, f1, f2, f3, f4, f5, 1);
+  message_filters::NullFilter<Msg> f0, f1, f2, f3, f4, f5;
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg> sync(f0, f1, f2, f3, f4, f5, 1);
 }
 
 TEST(TimeSynchronizer, compile7)
 {
-  NullFilter<Msg> f0, f1, f2, f3, f4, f5, f6;
-  TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(f0, f1, f2, f3, f4, f5, f6, 1);
+  message_filters::NullFilter<Msg> f0, f1, f2, f3, f4, f5, f6;
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(f0, f1, f2, f3, f4, f5, f6, 1);
 }
 
 TEST(TimeSynchronizer, compile8)
 {
-  NullFilter<Msg> f0, f1, f2, f3, f4, f5, f6, f7;
-  TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(f0, f1, f2, f3, f4, f5, f6, f7, 1);
+  message_filters::NullFilter<Msg> f0, f1, f2, f3, f4, f5, f6, f7;
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(f0, f1, f2, f3, f4, f5, f6, f7, 1);
 }
 
 TEST(TimeSynchronizer, compile9)
 {
-  NullFilter<Msg> f0, f1, f2, f3, f4, f5, f6, f7, f8;
-  TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(f0, f1, f2, f3, f4, f5, f6, f7, f8, 1);
+  message_filters::NullFilter<Msg> f0, f1, f2, f3, f4, f5, f6, f7, f8;
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(f0, f1, f2, f3, f4, f5, f6, f7, f8, 1);
 }
 
 void function2(const MsgConstPtr&, const MsgConstPtr&) {}
@@ -147,53 +146,53 @@ void function5(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const
 void function6(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&) {}
 void function7(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&) {}
 void function8(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&) {}
-void function9(const MsgConstPtr&, MsgConstPtr, const MsgPtr&, MsgPtr, const Msg&, Msg, const MessageEvent<Msg const>&, const MessageEvent<Msg>&, const MsgConstPtr&) {}
+void function9(const MsgConstPtr&, MsgConstPtr, const MsgPtr&, MsgPtr, const Msg&, Msg, const message_filters::MessageEvent<Msg const>&, const message_filters::MessageEvent<Msg>&, const MsgConstPtr&) {}
 
 TEST(TimeSynchronizer, compileFunction2)
 {
-  TimeSynchronizer<Msg, Msg> sync(1);
+  message_filters::TimeSynchronizer<Msg, Msg> sync(1);
   sync.registerCallback(function2);
 }
 
 TEST(TimeSynchronizer, compileFunction3)
 {
-  TimeSynchronizer<Msg, Msg, Msg> sync(1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg> sync(1);
   sync.registerCallback(function3);
 }
 
 TEST(TimeSynchronizer, compileFunction4)
 {
-  TimeSynchronizer<Msg, Msg, Msg, Msg> sync(1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg> sync(1);
   sync.registerCallback(function4);
 }
 
 TEST(TimeSynchronizer, compileFunction5)
 {
-  TimeSynchronizer<Msg, Msg, Msg, Msg, Msg> sync(1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg> sync(1);
   sync.registerCallback(function5);
 }
 
 TEST(TimeSynchronizer, compileFunction6)
 {
-  TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
   sync.registerCallback(function6);
 }
 
 TEST(TimeSynchronizer, compileFunction7)
 {
-  TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
   sync.registerCallback(function7);
 }
 
 TEST(TimeSynchronizer, compileFunction8)
 {
-  TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
   sync.registerCallback(function8);
 }
 
 TEST(TimeSynchronizer, compileFunction9)
 {
-  TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
   sync.registerCallback(function9);
 }
 
@@ -205,62 +204,62 @@ struct MethodHelper
   void method5(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&) {}
   void method6(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&) {}
   void method7(const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&, const MsgConstPtr&) {}
-  void method8(const MsgConstPtr&, MsgConstPtr, const MsgPtr&, MsgPtr, const Msg&, Msg, const MessageEvent<Msg const>&, const MessageEvent<Msg>&) {}
+  void method8(const MsgConstPtr&, MsgConstPtr, const MsgPtr&, MsgPtr, const Msg&, Msg, const message_filters::MessageEvent<Msg const>&, const message_filters::MessageEvent<Msg>&) {}
   // Can only do 8 here because the object instance counts as a parameter and bind only supports 9
 };
 
 TEST(TimeSynchronizer, compileMethod2)
 {
   MethodHelper h;
-  TimeSynchronizer<Msg, Msg> sync(1);
+  message_filters::TimeSynchronizer<Msg, Msg> sync(1);
   sync.registerCallback(&MethodHelper::method2, &h);
 }
 
 TEST(TimeSynchronizer, compileMethod3)
 {
   MethodHelper h;
-  TimeSynchronizer<Msg, Msg, Msg> sync(1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg> sync(1);
   sync.registerCallback(&MethodHelper::method3, &h);
 }
 
 TEST(TimeSynchronizer, compileMethod4)
 {
   MethodHelper h;
-  TimeSynchronizer<Msg, Msg, Msg, Msg> sync(1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg> sync(1);
   sync.registerCallback(&MethodHelper::method4, &h);
 }
 
 TEST(TimeSynchronizer, compileMethod5)
 {
   MethodHelper h;
-  TimeSynchronizer<Msg, Msg, Msg, Msg, Msg> sync(1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg> sync(1);
   sync.registerCallback(&MethodHelper::method5, &h);
 }
 
 TEST(TimeSynchronizer, compileMethod6)
 {
   MethodHelper h;
-  TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
   sync.registerCallback(&MethodHelper::method6, &h);
 }
 
 TEST(TimeSynchronizer, compileMethod7)
 {
   MethodHelper h;
-  TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
   sync.registerCallback(&MethodHelper::method7, &h);
 }
 
 TEST(TimeSynchronizer, compileMethod8)
 {
   MethodHelper h;
-  TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
   sync.registerCallback(&MethodHelper::method8, &h);
 }
 
 TEST(TimeSynchronizer, immediate2)
 {
-  TimeSynchronizer<Msg, Msg> sync(1);
+  message_filters::TimeSynchronizer<Msg, Msg> sync(1);
   Helper h;
   sync.registerCallback(std::bind(&Helper::cb, &h));
   MsgPtr m(std::make_shared<Msg>());
@@ -274,7 +273,7 @@ TEST(TimeSynchronizer, immediate2)
 
 TEST(TimeSynchronizer, immediate3)
 {
-  TimeSynchronizer<Msg, Msg, Msg> sync(1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg> sync(1);
   Helper h;
   sync.registerCallback(std::bind(&Helper::cb, &h));
   MsgPtr m(std::make_shared<Msg>());
@@ -290,7 +289,7 @@ TEST(TimeSynchronizer, immediate3)
 
 TEST(TimeSynchronizer, immediate4)
 {
-  TimeSynchronizer<Msg, Msg, Msg, Msg> sync(1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg> sync(1);
   Helper h;
   sync.registerCallback(std::bind(&Helper::cb, &h));
   MsgPtr m(std::make_shared<Msg>());
@@ -308,7 +307,7 @@ TEST(TimeSynchronizer, immediate4)
 
 TEST(TimeSynchronizer, immediate5)
 {
-  TimeSynchronizer<Msg, Msg, Msg, Msg, Msg> sync(1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg> sync(1);
   Helper h;
   sync.registerCallback(std::bind(&Helper::cb, &h));
   MsgPtr m(std::make_shared<Msg>());
@@ -328,7 +327,7 @@ TEST(TimeSynchronizer, immediate5)
 
 TEST(TimeSynchronizer, immediate6)
 {
-  TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
   Helper h;
   sync.registerCallback(std::bind(&Helper::cb, &h));
   MsgPtr m(std::make_shared<Msg>());
@@ -350,7 +349,7 @@ TEST(TimeSynchronizer, immediate6)
 
 TEST(TimeSynchronizer, immediate7)
 {
-  TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
   Helper h;
   sync.registerCallback(std::bind(&Helper::cb, &h));
   MsgPtr m(std::make_shared<Msg>());
@@ -374,7 +373,7 @@ TEST(TimeSynchronizer, immediate7)
 
 TEST(TimeSynchronizer, immediate8)
 {
-  TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
   Helper h;
   sync.registerCallback(std::bind(&Helper::cb, &h));
   MsgPtr m(std::make_shared<Msg>());
@@ -400,7 +399,7 @@ TEST(TimeSynchronizer, immediate8)
 
 TEST(TimeSynchronizer, immediate9)
 {
-  TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
   Helper h;
   sync.registerCallback(std::bind(&Helper::cb, &h));
   MsgPtr m(std::make_shared<Msg>());
@@ -432,7 +431,7 @@ TEST(TimeSynchronizer, immediate9)
 //////////////////////////////////////////////////////////////////////////////////////////////////
 TEST(TimeSynchronizer, multipleTimes)
 {
-  TimeSynchronizer<Msg, Msg, Msg> sync(2);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg> sync(2);
   Helper h;
   sync.registerCallback(std::bind(&Helper::cb, &h));
   MsgPtr m(std::make_shared<Msg>());
@@ -453,7 +452,7 @@ TEST(TimeSynchronizer, multipleTimes)
 
 TEST(TimeSynchronizer, queueSize)
 {
-  TimeSynchronizer<Msg, Msg, Msg> sync(1);
+  message_filters::TimeSynchronizer<Msg, Msg, Msg> sync(1);
   Helper h;
   sync.registerCallback(std::bind(&Helper::cb, &h));
   MsgPtr m(std::make_shared<Msg>());
@@ -479,7 +478,7 @@ TEST(TimeSynchronizer, queueSize)
 
 TEST(TimeSynchronizer, dropCallback)
 {
-  TimeSynchronizer<Msg, Msg> sync(1);
+  message_filters::TimeSynchronizer<Msg, Msg> sync(1);
   Helper h;
   sync.registerCallback(std::bind(&Helper::cb, &h));
   sync.registerDropCallback(std::bind(&Helper::dropcb, &h));
@@ -496,22 +495,22 @@ TEST(TimeSynchronizer, dropCallback)
 
 struct EventHelper
 {
-  void callback(const MessageEvent<Msg const>& e1, const MessageEvent<Msg const>& e2)
+  void callback(const message_filters::MessageEvent<Msg const> & e1, const message_filters::MessageEvent<Msg const> & e2)
   {
     e1_ = e1;
     e2_ = e2;
   }
 
-  MessageEvent<Msg const> e1_;
-  MessageEvent<Msg const> e2_;
+  message_filters::MessageEvent<Msg const> e1_;
+  message_filters::MessageEvent<Msg const> e2_;
 };
 
 TEST(TimeSynchronizer, eventInEventOut)
 {
-  TimeSynchronizer<Msg, Msg> sync(2);
+  message_filters::TimeSynchronizer<Msg, Msg> sync(2);
   EventHelper h;
   sync.registerCallback(&EventHelper::callback, &h);
-  MessageEvent<Msg const> evt(std::make_shared<Msg>(), rclcpp::Time(4, 0));
+  message_filters::MessageEvent<Msg const> evt(std::make_shared<Msg>(), rclcpp::Time(4, 0));
 
   sync.add<0>(evt);
   sync.add<1>(evt);
@@ -524,8 +523,8 @@ TEST(TimeSynchronizer, eventInEventOut)
 
 TEST(TimeSynchronizer, connectConstructor)
 {
-  PassThrough<Msg> pt1, pt2;
-  TimeSynchronizer<Msg, Msg> sync(pt1, pt2, 1);
+  message_filters::PassThrough<Msg> pt1, pt2;
+  message_filters::TimeSynchronizer<Msg, Msg> sync(pt1, pt2, 1);
   Helper h;
   sync.registerCallback(std::bind(&Helper::cb, &h));
   MsgPtr m(std::make_shared<Msg>());
@@ -537,9 +536,8 @@ TEST(TimeSynchronizer, connectConstructor)
   ASSERT_EQ(h.count_, 1);
 }
 
-//TEST(TimeSynchronizer, connectToSimple)
-
-int main(int argc, char **argv){
+int main(int argc, char **argv)
+{
   testing::InitGoogleTest(&argc, argv);
   rclcpp::init(argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
The 'using' keyword can cause problems if multiple APIs have the same named functions in different namespaces.  Further, we tend not to use it very much in ROS 2.

Thus, this PR just removes the keyword 'using' from all of the tests in message_filters.  There is also a minor amount of style cleanup; a follow-up PR will go deeper into that to attempt to get our linters running here.