### PR TITLE
Stop using python_cmake_module.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,24 +132,11 @@ if(BUILD_TESTING)
     target_link_libraries(${PROJECT_NAME}-test_message_traits ${PROJECT_NAME} rclcpp::rclcpp ${std_msgs_TARGETS})
   endif()
 
-  # Provides PYTHON_EXECUTABLE_DEBUG
-  find_package(python_cmake_module REQUIRED)
-  find_package(PythonExtra REQUIRED)
-  set(_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
-  if(WIN32)
-    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-      set(_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
-    endif()
-  endif()
-
   # python tests with python interfaces of message filters
   find_package(ament_cmake_pytest REQUIRED)
-  ament_add_pytest_test(directed.py "test/directed.py"
-    PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}")
-  ament_add_pytest_test(test_approxsync.py "test/test_approxsync.py"
-    PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}")
-  ament_add_pytest_test(test_message_filters_cache.py "test/test_message_filters_cache.py"
-    PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}")
+  ament_add_pytest_test(directed.py "test/directed.py")
+  ament_add_pytest_test(test_approxsync.py "test/test_approxsync.py")
+  ament_add_pytest_test(test_message_filters_cache.py "test/test_message_filters_cache.py")
 endif()
 
 ament_package()

--- a/package.xml
+++ b/package.xml
@@ -20,7 +20,6 @@
 
   <buildtool_depend>ament_cmake_python</buildtool_depend>
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
-  <buildtool_depend>python_cmake_module</buildtool_depend>
 
   <depend>rclcpp</depend>
   <depend>rcutils</depend>


### PR DESCRIPTION
We really don't need it anymore, and can just use the builtin find_package(Python3).

This must be merged before https://github.com/ros2/ros2/pull/1524 ; see that pull request for more information about this change.