### PR TITLE
Bugfix/segfault when getting surrounding interval of empty cache

### DIFF
--- a/include/message_filters/cache.hpp
+++ b/include/message_filters/cache.hpp
@@ -209,8 +209,7 @@ public:
     namespace mt = message_filters::message_traits;
 
     std::lock_guard<std::mutex> lock(cache_lock_);
-    if (cache_.size() == 0) 
-    {
+    if (cache_.size() == 0) {
       // early return for empty cache; Logic below is only valid for caches with at least one element.
       return {};
     }

--- a/include/message_filters/cache.hpp
+++ b/include/message_filters/cache.hpp
@@ -210,7 +210,8 @@ public:
 
     std::lock_guard<std::mutex> lock(cache_lock_);
     if (cache_.size() == 0) {
-      // early return for empty cache; Logic below is only valid for caches with at least one element.
+      // Early return for empty cache
+      // Logic below is only valid for caches with at least one element
       return {};
     }
 

--- a/include/message_filters/cache.hpp
+++ b/include/message_filters/cache.hpp
@@ -209,6 +209,12 @@ public:
     namespace mt = message_filters::message_traits;
 
     std::lock_guard<std::mutex> lock(cache_lock_);
+    if (cache_.size() == 0) 
+    {
+      // early return for empty cache; Logic below is only valid for caches with at least one element.
+      return {};
+    }
+
     // Find the starting index. (Find the first index after [or at] the start of the interval)
     int start_index = static_cast<int>(cache_.size()) - 1;
     while (start_index > 0 &&

--- a/test/msg_cache_unittest.cpp
+++ b/test/msg_cache_unittest.cpp
@@ -79,10 +79,7 @@ TEST(Cache, emptySurroundingInterval)
 {
   message_filters::Cache<Msg> cache(10);
   const std::vector<std::shared_ptr<Msg const>> interval_data = cache.getSurroundingInterval(
-    rclcpp::Time(
-      5,
-      0), rclcpp::Time(
-      9, 0));
+    rclcpp::Time(5, 0), rclcpp::Time(9, 0));
 
   EXPECT_EQ(interval_data.size(), (unsigned int) 0);  // empty cache shall return empty interval
 }

--- a/test/msg_cache_unittest.cpp
+++ b/test/msg_cache_unittest.cpp
@@ -78,7 +78,12 @@ void fillCacheEasy(message_filters::Cache<Msg> & cache, unsigned int start, unsi
 TEST(Cache, emptySurroundingInterval)
 {
   message_filters::Cache<Msg> cache(10);
-  const std::vector<std::shared_ptr<Msg const> > interval_data = cache.getSurroundingInterval(rclcpp::Time(5, 0), rclcpp::Time(9, 0));
+  const std::vector<std::shared_ptr<Msg const>> interval_data = cache.getSurroundingInterval(
+    rclcpp::Time(
+      5,
+      0), rclcpp::Time(
+      9, 0));
+
   EXPECT_EQ(interval_data.size(), (unsigned int) 0); // empty cache shall return empty interval
 }
 

--- a/test/msg_cache_unittest.cpp
+++ b/test/msg_cache_unittest.cpp
@@ -84,7 +84,7 @@ TEST(Cache, emptySurroundingInterval)
       0), rclcpp::Time(
       9, 0));
 
-  EXPECT_EQ(interval_data.size(), (unsigned int) 0); // empty cache shall return empty interval
+  EXPECT_EQ(interval_data.size(), (unsigned int) 0);  // empty cache shall return empty interval
 }
 
 TEST(Cache, easyInterval)

--- a/test/msg_cache_unittest.cpp
+++ b/test/msg_cache_unittest.cpp
@@ -75,6 +75,13 @@ void fillCacheEasy(message_filters::Cache<Msg> & cache, unsigned int start, unsi
   }
 }
 
+TEST(Cache, emptySurroundingInterval)
+{
+  message_filters::Cache<Msg> cache(10);
+  const std::vector<std::shared_ptr<Msg const> > interval_data = cache.getSurroundingInterval(rclcpp::Time(5, 0), rclcpp::Time(9, 0));
+  EXPECT_EQ(interval_data.size(), (unsigned int) 0); // empty cache shall return empty interval
+}
+
 TEST(Cache, easyInterval)
 {
   message_filters::Cache<Msg> cache(10);

--- a/test/msg_cache_unittest.cpp
+++ b/test/msg_cache_unittest.cpp
@@ -81,7 +81,8 @@ TEST(Cache, emptySurroundingInterval)
   const std::vector<std::shared_ptr<Msg const>> interval_data = cache.getSurroundingInterval(
     rclcpp::Time(5, 0), rclcpp::Time(9, 0));
 
-  EXPECT_EQ(interval_data.size(), static_cast<unsigned int>(0));  // empty cache shall return empty interval
+  // empty cache shall return empty interval
+  EXPECT_EQ(interval_data.size(), static_cast<unsigned int>(0));
 }
 
 TEST(Cache, easyInterval)

--- a/test/msg_cache_unittest.cpp
+++ b/test/msg_cache_unittest.cpp
@@ -81,7 +81,7 @@ TEST(Cache, emptySurroundingInterval)
   const std::vector<std::shared_ptr<Msg const>> interval_data = cache.getSurroundingInterval(
     rclcpp::Time(5, 0), rclcpp::Time(9, 0));
 
-  EXPECT_EQ(interval_data.size(), (unsigned int) 0);  // empty cache shall return empty interval
+  EXPECT_EQ(interval_data.size(), static_cast<unsigned int>(0));  // empty cache shall return empty interval
 }
 
 TEST(Cache, easyInterval)


### PR DESCRIPTION
This PR fixes a segfault that occurred to me when I tried to get a surrounding interval from a `message_filter::Cache` that was empty. See comment below for where/how.

The PR includes
* a test that should reproduce the segfault when executed without the fix.
* the fix of the segfault

Is it possible to get the fix also to other branches, specifically `humble` (but `iron` would probably also make sense)? That's the version I am using at the moment. I think the fix commit should be cherry-pickable. But the test commit probably needs some minor adaptation due to namespace changes.

Please let me know if I need to follow some specific procedure or provide more information for contributing (e.g. create issue first, or similar).