### PR TITLE
Deprecated qos_profile in Subscriber

### DIFF
--- a/doc/Tutorials/Approximate-Synchronizer-Cpp.rst
+++ b/doc/Tutorials/Approximate-Synchronizer-Cpp.rst
@@ -70,8 +70,8 @@ Next, we can initialize these private elements within a basic ``Node`` construct
       temp_pub = this->create_publisher<sensor_msgs::msg::Temperature>("temp", qos);
       fluid_pub = this->create_publisher<sensor_msgs::msg::FluidPressure>("fluid", qos);
 
-      temp_sub.subscribe(this, "temp", qos.get_rmw_qos_profile());
-      fluid_sub.subscribe(this, "fluid", qos.get_rmw_qos_profile());
+      temp_sub.subscribe(this, "temp", qos);
+      fluid_sub.subscribe(this, "fluid", qos);
 
       timer = this->create_wall_timer(500ms, std::bind(&TimeSyncNode::TimerCallback, this));
       second_timer = this->create_wall_timer(550ms, std::bind(&TimeSyncNode::SecondTimerCallback, this));

--- a/doc/Tutorials/Writing-A-Time-Synchronizer-Cpp.rst
+++ b/doc/Tutorials/Writing-A-Time-Synchronizer-Cpp.rst
@@ -71,8 +71,8 @@ Next, we can initialize these private elements within a basic ``Node`` construct
       temp_pub = this->create_publisher<sensor_msgs::msg::Temperature>("temp", qos);
       fluid_pub = this->create_publisher<sensor_msgs::msg::FluidPressure>("fluid", qos);
 
-      temp_sub.subscribe(this, "temp", qos.get_rmw_qos_profile());
-      fluid_sub.subscribe(this, "fluid", qos.get_rmw_qos_profile());
+      temp_sub.subscribe(this, "temp", qos);
+      fluid_sub.subscribe(this, "fluid", qos);
 
       timer = this->create_wall_timer(1000ms, std::bind(&TimeSyncNode::TimerCallback, this));
 

--- a/include/message_filters/subscriber.h
+++ b/include/message_filters/subscriber.h
@@ -60,6 +60,69 @@ public:
    */
   virtual void subscribe(
     NodePtr node, const std::string & topic,
+    const rclcpp::QoS & qos) = 0;
+
+  /**
+   * \brief Subscribe to a topic.
+   *
+   * If this Subscriber is already subscribed to a topic, this function will first unsubscribe.
+   *
+   * \param node The rclcpp::Node to use to subscribe.
+   * \param topic The topic to subscribe to.
+   * \param qos (optional) The rclcpp::rmw qos profile to use to subscribe
+   */
+  virtual void subscribe(
+    NodeType * node, const std::string & topic,
+    const rclcpp::QoS & qos) = 0;
+
+  /**
+   * \brief Subscribe to a topic.
+   *
+   * If this Subscriber is already subscribed to a topic, this function will first unsubscribe.
+   * This override allows SubscriptionOptions to be passed into the class without changing API.
+   *
+   * \param node The rclcpp::Node::SharedPtr to use to subscribe.
+   * \param topic The topic to subscribe to.
+   * \param qos (optional) The rclcpp qos profile to use to subscribe.
+   * \param options The subscription options to use to subscribe.
+   */
+  virtual void subscribe(
+    NodePtr node,
+    const std::string & topic,
+    const rclcpp::QoS & qos,
+    rclcpp::SubscriptionOptions options)
+  {
+    this->subscribe(node.get(), topic, qos, options);
+  }
+
+  /**
+   * \brief Subscribe to a topic.
+   *
+   * If this Subscriber is already subscribed to a topic, this function will first unsubscribe.
+   *
+   * \param node The rclcpp::Node to use to subscribe.
+   * \param topic The topic to subscribe to.
+   * \param qos The rmw qos profile to use to subscribe.
+   * \param options The subscription options to use to subscribe.
+   */
+  virtual void subscribe(
+    NodeType * node,
+    const std::string & topic,
+    const rclcpp::QoS & qos,
+    rclcpp::SubscriptionOptions options) = 0;
+
+  /**
+   * \brief Subscribe to a topic.
+   *
+   * If this Subscriber is already subscribed to a topic, this function will first unsubscribe.
+   *
+   * \param node The rclcpp::Node::SharedPtr to use to subscribe.
+   * \param topic The topic to subscribe to.
+   * \param qos (optional) The rmw qos profile to use to subscribe
+   */
+  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
+  virtual void subscribe(
+    NodePtr node, const std::string & topic,
     const rmw_qos_profile_t qos = rmw_qos_profile_default) = 0;
 
   /**
@@ -71,6 +134,7 @@ public:
    * \param topic The topic to subscribe to.
    * \param qos (optional) The rmw qos profile to use to subscribe
    */
+  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
   virtual void subscribe(
     NodeType * node, const std::string & topic,
     const rmw_qos_profile_t qos = rmw_qos_profile_default) = 0;
@@ -86,6 +150,7 @@ public:
    * \param qos (optional) The rmw qos profile to use to subscribe.
    * \param options The subscription options to use to subscribe.
    */
+  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
   virtual void subscribe(
     NodePtr node,
     const std::string & topic,
@@ -105,6 +170,7 @@ public:
    * \param qos The rmw qos profile to use to subscribe.
    * \param options The subscription options to use to subscribe.
    */
+  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
   virtual void subscribe(
     NodeType * node,
     const std::string & topic,
@@ -170,7 +236,6 @@ public:
   typedef std::shared_ptr<NodeType> NodePtr;
   typedef message_type_t<M> MessageType;
   typedef MessageEvent<MessageType const> EventType;
-
   /**
    * \brief Constructor
    *
@@ -182,14 +247,14 @@ public:
    */
   Subscriber(
     NodePtr node, const std::string & topic,
-    const rmw_qos_profile_t qos = rmw_qos_profile_default)
+    const rclcpp::QoS & qos)
   {
     subscribe(node, topic, qos);
   }
 
   Subscriber(
     NodeType * node, const std::string & topic,
-    const rmw_qos_profile_t qos = rmw_qos_profile_default)
+    const rclcpp::QoS & qos)
   {
     subscribe(node, topic, qos);
   }
@@ -207,12 +272,67 @@ public:
   Subscriber(
     NodePtr node,
     const std::string & topic,
+    const rclcpp::QoS & qos,
+    rclcpp::SubscriptionOptions options)
+  {
+    subscribe(node.get(), topic, qos, options);
+  }
+
+  Subscriber(
+    NodeType * node,
+    const std::string & topic,
+    const rclcpp::QoS & qos,
+    rclcpp::SubscriptionOptions options)
+  {
+    subscribe(node, topic, qos, options);
+  }
+
+  /**
+   * \brief Constructor
+   *
+   * See the rclcpp::Node::subscribe() variants for more information on the parameters
+   *
+   * \param node The rclcpp::Node::SharedPtr to use to subscribe.
+   * \param topic The topic to subscribe to.
+   * \param qos (optional) The rmw qos profile to use to subscribe
+   */
+  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
+  Subscriber(
+    NodePtr node, const std::string & topic,
+    const rmw_qos_profile_t qos = rmw_qos_profile_default)
+  {
+    subscribe(node, topic, qos);
+  }
+
+  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
+  Subscriber(
+    NodeType * node, const std::string & topic,
+    const rmw_qos_profile_t qos = rmw_qos_profile_default)
+  {
+    subscribe(node, topic, qos);
+  }
+
+  /**
+   * \brief Constructor
+   *
+   * See the rclcpp::Node::subscribe() variants for more information on the parameters
+   *
+   * \param node The rclcpp::Node::SharedPtr to use to subscribe.
+   * \param topic The topic to subscribe to.
+   * \param qos The rmw qos profile to use to subscribe.
+   * \param options The subscription options to use to subscribe.
+   */
+  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
+  Subscriber(
+    NodePtr node,
+    const std::string & topic,
     const rmw_qos_profile_t qos,
     rclcpp::SubscriptionOptions options)
   {
     subscribe(node.get(), topic, qos, options);
   }
 
+  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
   Subscriber(
     NodeType * node,
     const std::string & topic,
@@ -243,6 +363,92 @@ public:
    */
   void subscribe(
     NodePtr node, const std::string & topic,
+    const rclcpp::QoS & qos) override
+  {
+    subscribe(node.get(), topic, qos, rclcpp::SubscriptionOptions());
+  }
+
+  /**
+   * \brief Subscribe to a topic.
+   *
+   * If this Subscriber is already subscribed to a topic, this function will first unsubscribe.
+   *
+   * \param node The rclcpp::Node to use to subscribe.
+   * \param topic The topic to subscribe to.
+   * \param qos (optional) The rmw qos profile to use to subscribe
+   */
+  void subscribe(
+    NodeType * node, const std::string & topic,
+    const rclcpp::QoS & qos) override
+  {
+    subscribe(node, topic, qos, rclcpp::SubscriptionOptions());
+  }
+
+  /**
+   * \brief Subscribe to a topic.
+   *
+   * If this Subscriber is already subscribed to a topic, this function will first unsubscribe.
+   *
+   * \param node The rclcpp::Node::SharedPtr to use to subscribe.
+   * \param topic The topic to subscribe to.
+   * \param qos The rmw qos profile to use to subscribe.
+   * \param options The subscription options to use to subscribe.
+   */
+  void subscribe(
+    NodePtr node,
+    const std::string & topic,
+    const rclcpp::QoS & qos,
+    rclcpp::SubscriptionOptions options) override
+  {
+    subscribe(node.get(), topic, qos, options);
+    node_raw_ = nullptr;
+    node_shared_ = node;
+  }
+
+  /**
+   * \brief Subscribe to a topic.
+   *
+   * If this Subscriber is already subscribed to a topic, this function will first unsubscribe.
+   *
+   * \param node The rclcpp::Node to use to subscribe.
+   * \param topic The topic to subscribe to.
+   * \param qos The rmw qos profile to use to subscribe
+   * \param options The subscription options to use to subscribe.
+   */
+  void subscribe(
+    NodeType * node,
+    const std::string & topic,
+    const rclcpp::QoS & qos,
+    rclcpp::SubscriptionOptions options) override
+  {
+    unsubscribe();
+
+    if (!topic.empty()) {
+      topic_ = topic;
+      qos_ = qos;
+      options_ = options;
+      sub_ = node->template create_subscription<M>(
+        topic, qos,
+        [this](const std::shared_ptr<MessageType const> msg) {
+          this->cb(EventType(msg));
+        }, options);
+
+      node_raw_ = node;
+    }
+  }
+
+  /**
+   * \brief Subscribe to a topic.
+   *
+   * If this Subscriber is already subscribed to a topic, this function will first unsubscribe.
+   *
+   * \param node The rclcpp::Node::SharedPtr to use to subscribe.
+   * \param topic The topic to subscribe to.
+   * \param qos (optional) The rmw qos profile to use to subscribe
+   */
+  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
+  void subscribe(
+    NodePtr node, const std::string & topic,
     const rmw_qos_profile_t qos = rmw_qos_profile_default) override
   {
     subscribe(node.get(), topic, qos, rclcpp::SubscriptionOptions());
@@ -257,7 +463,7 @@ public:
    * \param topic The topic to subscribe to.
    * \param qos (optional) The rmw qos profile to use to subscribe
    */
-  // TODO(wjwwood): deprecate in favor of API's that use `rclcpp::QoS` instead.
+  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
   void subscribe(
     NodeType * node, const std::string & topic,
     const rmw_qos_profile_t qos = rmw_qos_profile_default) override
@@ -275,6 +481,7 @@ public:
    * \param qos The rmw qos profile to use to subscribe.
    * \param options The subscription options to use to subscribe.
    */
+  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
   void subscribe(
     NodePtr node,
     const std::string & topic,
@@ -296,7 +503,7 @@ public:
    * \param qos The rmw qos profile to use to subscribe
    * \param options The subscription options to use to subscribe.
    */
-  // TODO(wjwwood): deprecate in favor of API's that use `rclcpp::QoS` instead.
+  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
   void subscribe(
     NodeType * node,
     const std::string & topic,
@@ -308,8 +515,7 @@ public:
     if (!topic.empty()) {
       topic_ = topic;
       rclcpp::QoS rclcpp_qos(rclcpp::QoSInitialization::from_rmw(qos));
-      rclcpp_qos.get_rmw_qos_profile() = qos;
-      qos_ = qos;
+      qos_ = rclcpp_qos;
       options_ = options;
       sub_ = node->template create_subscription<M>(
         topic, rclcpp_qos,
@@ -382,7 +588,7 @@ private:
   NodeType * node_raw_ {nullptr};
 
   std::string topic_;
-  rmw_qos_profile_t qos_;
+  rclcpp::QoS qos_ = rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));
   rclcpp::SubscriptionOptions options_;
 };
 

--- a/include/message_filters/subscriber.h
+++ b/include/message_filters/subscriber.h
@@ -157,7 +157,8 @@ public:
     const rmw_qos_profile_t qos,
     rclcpp::SubscriptionOptions options)
   {
-    this->subscribe(node.get(), topic, qos, options);
+    this->subscribe(
+      node.get(), topic, rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos)), options);
   }
 
   /**
@@ -301,7 +302,7 @@ public:
     NodePtr node, const std::string & topic,
     const rmw_qos_profile_t qos = rmw_qos_profile_default)
   {
-    subscribe(node, topic, qos);
+    subscribe(node, topic, rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos)));
   }
 
   [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
@@ -451,7 +452,9 @@ public:
     NodePtr node, const std::string & topic,
     const rmw_qos_profile_t qos = rmw_qos_profile_default) override
   {
-    subscribe(node.get(), topic, qos, rclcpp::SubscriptionOptions());
+    subscribe(
+      node.get(), topic, rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos)),
+      rclcpp::SubscriptionOptions());
   }
 
   /**
@@ -468,7 +471,9 @@ public:
     NodeType * node, const std::string & topic,
     const rmw_qos_profile_t qos = rmw_qos_profile_default) override
   {
-    subscribe(node, topic, qos, rclcpp::SubscriptionOptions());
+    subscribe(
+      node, topic, rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos)),
+      rclcpp::SubscriptionOptions());
   }
 
   /**
@@ -488,7 +493,7 @@ public:
     const rmw_qos_profile_t qos,
     rclcpp::SubscriptionOptions options) override
   {
-    subscribe(node.get(), topic, qos, options);
+    subscribe(node.get(), topic, rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos)), options);
     node_raw_ = nullptr;
     node_shared_ = node;
   }

--- a/test/test_fuzz.cpp
+++ b/test/test_fuzz.cpp
@@ -129,7 +129,9 @@ TEST(Subscriber, fuzz_subscriber)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
   Helper h;
-  message_filters::Subscriber<Msg> sub(node, "test_topic");
+  rclcpp::QoS default_qos =
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));
+  message_filters::Subscriber<Msg> sub(node, "test_topic", default_qos);
   sub.registerCallback(std::bind(&Helper::cb, &h, std::placeholders::_1));
   auto pub = node->create_publisher<Msg>("test_topic", 10);
   rclcpp::Clock ros_clock;

--- a/test/test_subscriber.cpp
+++ b/test/test_subscriber.cpp
@@ -61,7 +61,9 @@ TEST(Subscriber, simple)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
   Helper h;
-  message_filters::Subscriber<Msg> sub(node, "test_topic");
+  rclcpp::QoS default_qos =
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));
+  message_filters::Subscriber<Msg> sub(node, "test_topic", default_qos);
   sub.registerCallback(std::bind(&Helper::cb, &h, std::placeholders::_1));
   auto pub = node->create_publisher<Msg>("test_topic", 10);
   rclcpp::Clock ros_clock;
@@ -79,7 +81,9 @@ TEST(Subscriber, simple_raw)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
   Helper h;
-  message_filters::Subscriber<Msg> sub(node.get(), "test_topic");
+  rclcpp::QoS default_qos =
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));
+  message_filters::Subscriber<Msg> sub(node.get(), "test_topic", default_qos);
   sub.registerCallback(std::bind(&Helper::cb, &h, std::placeholders::_1));
   auto pub = node->create_publisher<Msg>("test_topic", 10);
   rclcpp::Clock ros_clock;
@@ -97,7 +101,9 @@ TEST(Subscriber, subUnsubSub)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
   Helper h;
-  message_filters::Subscriber<Msg> sub(node, "test_topic");
+  rclcpp::QoS default_qos =
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));
+  message_filters::Subscriber<Msg> sub(node, "test_topic", default_qos);
   sub.registerCallback(std::bind(&Helper::cb, &h, std::placeholders::_1));
   auto pub = node->create_publisher<Msg>("test_topic", 10);
 
@@ -119,7 +125,9 @@ TEST(Subscriber, subUnsubSub_raw)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
   Helper h;
-  message_filters::Subscriber<Msg> sub(node.get(), "test_topic");
+  rclcpp::QoS default_qos =
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));
+  message_filters::Subscriber<Msg> sub(node.get(), "test_topic", default_qos);
   sub.registerCallback(std::bind(&Helper::cb, &h, std::placeholders::_1));
   auto pub = node->create_publisher<Msg>("test_topic", 10);
 
@@ -141,12 +149,14 @@ TEST(Subscriber, switchRawAndShared)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
   Helper h;
-  message_filters::Subscriber<Msg> sub(node, "test_topic");
+  rclcpp::QoS default_qos =
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));
+  message_filters::Subscriber<Msg> sub(node, "test_topic", default_qos);
   sub.registerCallback(std::bind(&Helper::cb, &h, std::placeholders::_1));
   auto pub = node->create_publisher<Msg>("test_topic2", 10);
 
   sub.unsubscribe();
-  sub.subscribe(node.get(), "test_topic2");
+  sub.subscribe(node.get(), "test_topic2", default_qos);
 
   rclcpp::Clock ros_clock;
   auto start = ros_clock.now();
@@ -203,7 +213,9 @@ TEST(Subscriber, singleNonConstCallback)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
   NonConstHelper h;
-  message_filters::Subscriber<Msg> sub(node, "test_topic");
+  rclcpp::QoS default_qos =
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));
+  message_filters::Subscriber<Msg> sub(node, "test_topic", default_qos);
   sub.registerCallback(&NonConstHelper::cb, &h);
   auto pub = node->create_publisher<Msg>("test_topic", 10);
   Msg msg;
@@ -220,7 +232,9 @@ TEST(Subscriber, multipleNonConstCallbacksFilterSubscriber)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
   NonConstHelper h, h2;
-  message_filters::Subscriber<Msg> sub(node, "test_topic");
+  rclcpp::QoS default_qos =
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));
+  message_filters::Subscriber<Msg> sub(node, "test_topic", default_qos);
   sub.registerCallback(&NonConstHelper::cb, &h);
   sub.registerCallback(&NonConstHelper::cb, &h2);
   auto pub = node->create_publisher<Msg>("test_topic", 10);
@@ -241,7 +255,9 @@ TEST(Subscriber, multipleCallbacksSomeFilterSomeDirect)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
   NonConstHelper h, h2;
-  message_filters::Subscriber<Msg> sub(node, "test_topic");
+  rclcpp::QoS default_qos =
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));
+  message_filters::Subscriber<Msg> sub(node, "test_topic", default_qos);
   sub.registerCallback(&NonConstHelper::cb, &h);
   auto sub2 = node->create_subscription<Msg>(
     "test_topic", 10, std::bind(&NonConstHelper::cb, &h2, std::placeholders::_1));
@@ -266,7 +282,10 @@ TEST(Subscriber, lifecycle)
 {
   auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test_node");
   Helper h;
-  message_filters::Subscriber<Msg, rclcpp_lifecycle::LifecycleNode> sub(node, "test_topic");
+  rclcpp::QoS default_qos =
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));
+  message_filters::Subscriber<Msg, rclcpp_lifecycle::LifecycleNode> sub(node, "test_topic",
+    default_qos);
   sub.registerCallback(std::bind(&Helper::cb, &h, std::placeholders::_1));
   auto pub = node->create_publisher<Msg>("test_topic", 10);
   pub->on_activate();

--- a/test/test_subscriber.cpp
+++ b/test/test_subscriber.cpp
@@ -174,7 +174,9 @@ TEST(Subscriber, subInChain)
   auto node = std::make_shared<rclcpp::Node>("test_node");
   Helper h;
   message_filters::Chain<Msg> c;
-  c.addFilter(std::make_shared<message_filters::Subscriber<Msg>>(node, "test_topic"));
+  rclcpp::QoS default_qos =
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));
+  c.addFilter(std::make_shared<message_filters::Subscriber<Msg>>(node, "test_topic", default_qos));
   c.registerCallback(std::bind(&Helper::cb, &h, std::placeholders::_1));
   auto pub = node->create_publisher<Msg>("test_topic", 10);
 


### PR DESCRIPTION
This pull request is meant to solve this TODO: 
>   // TODO(wjwwood): deprecate in favor of API's that use `rclcpp::QoS` instead.

In which we use `rclcpp::QoS` in all of the `subscribe` methods in `message_filters`. Unfortunately when it comes to deprecating functions with default arguments, we can't just change the types of one element, [outlined here](https://en.cppreference.com/w/cpp/language/default_arguments):
> A redeclaration cannot introduce a default argument for a parameter for which a default argument is already visible (even if the value is the same)

So for this, I deprecated all the original methods, then just left the new `qos` argument uninitialized. I don't think this is necessarily the worst way to handle these changes because often times the user is going to need to adjust their `qos` settings anyways. Also, when we go to remove the deprecation in (I guess) [L-turtle](https://docs.ros.org/en/rolling/The-ROS2-Project/Contributing/Developer-Guide.html#deprecation-strategy), we can remove the old, deprecated functions, and re-add default values if it fits our needs. Though I don't think we can leave these methods with the same names and similar default params, I'm open to suggestion on how to improve the situation.