### PR TITLE
[LatestTimeSync] Fix crash when Synchronizer is started before the messges are available.

### DIFF
--- a/include/message_filters/sync_policies/latest_time.h
+++ b/include/message_filters/sync_policies/latest_time.h
@@ -73,8 +73,6 @@ void callback(const sensor_msgs::CameraInfo::ConstPtr&, const sensor_msgs::Image
 #include <tuple>
 #include <vector>
 
-#include <iostream>
-
 #include <rclcpp/rclcpp.hpp>
 
 #include "message_filters/message_traits.h"

--- a/include/message_filters/sync_policies/latest_time.h
+++ b/include/message_filters/sync_policies/latest_time.h
@@ -73,6 +73,8 @@ void callback(const sensor_msgs::CameraInfo::ConstPtr&, const sensor_msgs::Image
 #include <tuple>
 #include <vector>
 
+#include <iostream>
+
 #include <rclcpp/rclcpp.hpp>
 
 #include "message_filters/message_traits.h"
@@ -255,7 +257,14 @@ private:
     {
       bool step_change_detected = false;
       do {
-        double period = (now-prev).seconds();
+        double period = 0.0;
+        try {
+          period = (now-prev).seconds();
+        } catch (const std::runtime_error & /*e*/) {
+          // Different time sources that might happen on initialization if the messages are not yet available.
+          // std::cout << "Exception: " << e.what() << std::endl;
+          return false;
+        }
         if (period <= 0.0) {
           // multiple messages and time isn't updating
           return false;


### PR DESCRIPTION
This is tested on `humble` it might be the same issue on master too.

### Issue

When synchronizer with LastTime is used and messages are not yet available on subsribers, the `prev` time variable get somehow different time source then `now` variable.
I have tried to set the clock in the constructor and manually later using `setClock` method.
Nothing has helped.

### Proposed solution
Catch `str::runtime_error` thrown when differnet time sources are tried to be substracted from each other.
Here the example output with error with 4 sensors that sometimes need more time to come up.

```
[laser_scan_unifier-1] Previous time is: 94704.3
[laser_scan_unifier-1] Current time is: 1.72182e+09
[laser_scan_unifier-1] Exception: can't subtract times with different time sources [1 != 0]
[laser_scan_unifier-1] Previous time is: 94704.3
[laser_scan_unifier-1] Current time is: 1.72182e+09
[laser_scan_unifier-1] Exception: can't subtract times with different time sources [1 != 0]
[laser_scan_unifier-1] Previous time is: 94704.3
[laser_scan_unifier-1] Current time is: 1.72182e+09
[laser_scan_unifier-1] Exception: can't subtract times with different time sources [1 != 0]
[laser_scan_unifier-1] Previous time is: 1.72182e+09
[laser_scan_unifier-1] Current time is: 1.72182e+09
[laser_scan_unifier-1] Previous time is: 0
[laser_scan_unifier-1] Current time is: 1.72182e+09
[laser_scan_unifier-1] Exception: can't subtract times with different time sources [1 != 0]
[laser_scan_unifier-1] Previous time is: 1.72182e+09
[laser_scan_unifier-1] Current time is: 1.72182e+09
[laser_scan_unifier-1] Previous time is: 0
[laser_scan_unifier-1] Current time is: 1.72182e+09
[laser_scan_unifier-1] Exception: can't subtract times with different time sources [1 != 0]
```

After few more such outputs, when messages are there, everything works fine!

We are using this in ROS 2 port of [`laser_scan_unifier`](https://github.com/StoglRobotics-forks/laser_scan_unifier/tree/ros2-scan-unifier)

### Disclamer

I would love to solve the issue in its core, but couldn't get better place or way to do this from the code, as it seems that during initilisation `prev` variable get the wrong time source, independently from the provided clock.
