### PR TITLE
[LatestTimeSync] Fix crash when Synchronizeris started before the messges are available.

### DIFF
--- a/include/message_filters/sync_policies/latest_time.hpp
+++ b/include/message_filters/sync_policies/latest_time.hpp
@@ -250,7 +250,14 @@ private:
     {
       bool step_change_detected = false;
       do {
-        double period = (now - prev).seconds();
+        double period = 0.0;
+        try {
+          period = (now-prev).seconds();
+        } catch (const std::runtime_error & /*e*/) {
+          // Different time sources that might happen on initialization if the messages are not yet available.
+          // std::cout << "Exception: " << e.what() << std::endl;
+          return false;
+        }
         if (period <= 0.0) {
           // multiple messages and time isn't updating
           return false;

--- a/include/message_filters/sync_policies/latest_time.hpp
+++ b/include/message_filters/sync_policies/latest_time.hpp
@@ -252,9 +252,10 @@ private:
       do {
         double period = 0.0;
         try {
-          period = (now-prev).seconds();
+          period = (now - prev).seconds();
         } catch (const std::runtime_error & /*e*/) {
-          // Different time sources that might happen on initialization if the messages are not yet available.
+          // Different time sources that might happen on initialization if the messages are not yet
+          // available.
           // std::cout << "Exception: " << e.what() << std::endl;
           return false;
         }


### PR DESCRIPTION
#136 for rolling.

As now `.hpp` files are used the backport is not straight-forward so opening new PR to use #136 for humble, if convinient.
