### PR TITLE
Add temporal offset between topics between ApproximateTimeSynchronizer

### DIFF
--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -258,6 +258,7 @@ class ApproximateTimeSynchronizer(TimeSynchronizer):
         TimeSynchronizer.__init__(self, fs, queue_size)
         self.slop = Duration(seconds=slop)
         self.allow_headerless = allow_headerless
+        self.queue_offset = queue_offset
 
     def add(self, msg, my_queue, my_queue_index=None):
         if not hasattr(msg, 'header') or not hasattr(msg.header, 'stamp'):

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -247,12 +247,14 @@ class ApproximateTimeSynchronizer(TimeSynchronizer):
     by the timestamps contained in their messages' headers. The API is the same
     as TimeSynchronizer except for an extra `slop` parameter in the constructor
     that defines the delay (in seconds) with which messages can be synchronized.
+    The ``queue_offset`` option allow to have temporal offset between subsribers
+    , define as a list of offset int in nanoseconds.
     The ``allow_headerless`` option specifies whether to allow storing
     headerless messages with current ROS time instead of timestamp. You should
     avoid this as much as you can, since the delays are unpredictable.
     """
 
-    def __init__(self, fs, queue_size, slop, allow_headerless=False):
+    def __init__(self, fs, queue_size, slop, queue_offset=False, allow_headerless=False):
         TimeSynchronizer.__init__(self, fs, queue_size)
         self.slop = Duration(seconds=slop)
         self.allow_headerless = allow_headerless
@@ -276,8 +278,11 @@ class ApproximateTimeSynchronizer(TimeSynchronizer):
             if not hasattr(stamp, 'nanoseconds'):
                 stamp = Time.from_msg(stamp)
             # print(stamp)
+        new_timestamp = stamp.nanoseconds
+        if my_queue_index is not None and self.queue_offset:
+            new_timestamp += self.queue_offset[my_queue_index]
         self.lock.acquire()
-        my_queue[stamp.nanoseconds] = msg
+        my_queue[new_timestamp] = msg
         while len(my_queue) > self.queue_size:
             del my_queue[min(my_queue)]
         # self.queues = [topic_0 {stamp: msg}, topic_1 {stamp: msg}, ...]
@@ -291,7 +296,7 @@ class ApproximateTimeSynchronizer(TimeSynchronizer):
         for queue in search_queues:
             topic_stamps = []
             for s in queue:
-                stamp_delta = Duration(nanoseconds=abs(s - stamp.nanoseconds))
+                stamp_delta = Duration(nanoseconds=abs(s - new_timestamp))
                 if stamp_delta > self.slop:
                     continue  # far over the slop
                 topic_stamps.append(((Time(nanoseconds=s,

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -247,7 +247,7 @@ class ApproximateTimeSynchronizer(TimeSynchronizer):
     by the timestamps contained in their messages' headers. The API is the same
     as TimeSynchronizer except for an extra `slop` parameter in the constructor
     that defines the delay (in seconds) with which messages can be synchronized.
-    The ``queue_offset`` option allow to have temporal offset between subsribers
+    The ``queue_offset`` option allow to have temporal offset between subscribers
     , define as a list of offset int in nanoseconds.
     The ``allow_headerless`` option specifies whether to allow storing
     headerless messages with current ROS time instead of timestamp. You should

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -281,7 +281,7 @@ class ApproximateTimeSynchronizer(TimeSynchronizer):
             # print(stamp)
         new_timestamp = stamp.nanoseconds
         if my_queue_index is not None and self.queue_offset:
-            new_timestamp += self.queue_offset[my_queue_index]
+            new_timestamp -= self.queue_offset[my_queue_index]
         self.lock.acquire()
         my_queue[new_timestamp] = msg
         while len(my_queue) > self.queue_size:

--- a/test/test_approxsync.py
+++ b/test/test_approxsync.py
@@ -188,6 +188,7 @@ class TestApproxSync(unittest.TestCase):
                 m1.signalMessage(msg)
             self.assertEqual(set(self.collector), set(zip(seq0, seq1)))
 
+
 if __name__ == '__main__':
     suite = unittest.TestSuite()
     suite.addTest(TestApproxSync('test_approx'))

--- a/test/test_approxsync.py
+++ b/test/test_approxsync.py
@@ -154,7 +154,7 @@ class TestApproxSync(unittest.TestCase):
             seq1 = [MockMessage(Time(seconds=t), random.random())
                     for t in range(N)]
             # random.shuffle(seq0)
-            ts = ApproximateTimeSynchronizer([m0, m1], N, 0.1, queue_offset=[int(0.5*1e9),0])
+            ts = ApproximateTimeSynchronizer([m0, m1], N, 0.1, queue_offset=[int(0.5*1e9), 0])
             ts.registerCallback(self.cb_collector_2msg)
             self.collector = []
             for msg in random.sample(seq0, N):

--- a/test/test_approxsync.py
+++ b/test/test_approxsync.py
@@ -131,7 +131,7 @@ class TestApproxSync(unittest.TestCase):
         # make sure that they get combined
         m0 = MockFilter()
         m1 = MockFilter()
-        ts = ApproximateTimeSynchronizer([m0, m1], 1, 0.1,queue_offset=[int(0.5*1e9),0])
+        ts = ApproximateTimeSynchronizer([m0, m1], 1, 0.1, queue_offset=[int(0.5*1e9), 0])
         ts.registerCallback(self.cb_collector_2msg)
 
         for t in range(10):
@@ -175,7 +175,7 @@ class TestApproxSync(unittest.TestCase):
             seq1 = [MockHeaderlessMessage(random.random()) for t in range(N)]
 
             ts = ApproximateTimeSynchronizer([m0, m1], N, 10,
-                                             queue_offset=[int(0.5*1e9),0],
+                                             queue_offset=[int(0.5*1e9), 0],
                                              allow_headerless=True)
             ts.registerCallback(self.cb_collector_2msg)
             self.collector = []
@@ -188,12 +188,8 @@ class TestApproxSync(unittest.TestCase):
                 m1.signalMessage(msg)
             self.assertEqual(set(self.collector), set(zip(seq0, seq1)))
 
-
-
-
 if __name__ == '__main__':
     suite = unittest.TestSuite()
     suite.addTest(TestApproxSync('test_approx'))
     suite.addTest(TestApproxSync('test_approx_offset'))
-    
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/test/test_approxsync.py
+++ b/test/test_approxsync.py
@@ -125,8 +125,75 @@ class TestApproxSync(unittest.TestCase):
                 m1.signalMessage(msg)
             self.assertEqual(set(self.collector), set(zip(seq0, seq1)))
 
+    def test_approx_offset(self):
+        # Same test than test_approx, but with an offset of 500 ms, 0.5*1e9 ns
+        # Simple case, pairs of messages,
+        # make sure that they get combined
+        m0 = MockFilter()
+        m1 = MockFilter()
+        ts = ApproximateTimeSynchronizer([m0, m1], 1, 0.1,queue_offset=[int(0.5*1e9),0])
+        ts.registerCallback(self.cb_collector_2msg)
+
+        for t in range(10):
+            self.collector = []
+            msg0 = MockMessage(Time(seconds=t+0.5), 33)
+            msg1 = MockMessage(Time(seconds=t), 34)
+            m0.signalMessage(msg0)
+            self.assertEqual(self.collector, [])
+            m1.signalMessage(msg1)
+            self.assertEqual(self.collector, [(msg0, msg1)])
+
+        # Scramble sequences of length N.
+        # Make sure that TimeSequencer recombines them.
+        random.seed(0)
+        for N in range(1, 10):
+            m0 = MockFilter()
+            m1 = MockFilter()
+            seq0 = [MockMessage(Time(seconds=t+0.5), random.random())
+                    for t in range(N)]
+            seq1 = [MockMessage(Time(seconds=t), random.random())
+                    for t in range(N)]
+            # random.shuffle(seq0)
+            ts = ApproximateTimeSynchronizer([m0, m1], N, 0.1, queue_offset=[int(0.5*1e9),0])
+            ts.registerCallback(self.cb_collector_2msg)
+            self.collector = []
+            for msg in random.sample(seq0, N):
+                m0.signalMessage(msg)
+            self.assertEqual(self.collector, [])
+            for msg in random.sample(seq1, N):
+                m1.signalMessage(msg)
+            self.assertEqual(set(self.collector), set(zip(seq0, seq1)))
+
+        # test headerless scenarios: scramble sequences of length N of
+        # headerless and header-having messages.
+        random.seed(0)
+        for N in range(1, 10):
+            m0 = MockFilter()
+            m1 = MockFilter()
+            seq0 = [MockMessage((ROSClock().now() + Duration(seconds=t+0.5)),
+                    random.random()) for t in range(N)]
+            seq1 = [MockHeaderlessMessage(random.random()) for t in range(N)]
+
+            ts = ApproximateTimeSynchronizer([m0, m1], N, 10,
+                                             queue_offset=[int(0.5*1e9),0],
+                                             allow_headerless=True)
+            ts.registerCallback(self.cb_collector_2msg)
+            self.collector = []
+            for msg in random.sample(seq0, N):
+                m0.signalMessage(msg)
+            self.assertEqual(self.collector, [])
+
+            for i in range(N):
+                msg = seq1[i]
+                m1.signalMessage(msg)
+            self.assertEqual(set(self.collector), set(zip(seq0, seq1)))
+
+
+
 
 if __name__ == '__main__':
     suite = unittest.TestSuite()
     suite.addTest(TestApproxSync('test_approx'))
+    suite.addTest(TestApproxSync('test_approx_offset'))
+    
     unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
To be able to keep volontary a temporal offset between topics, to keep a message before another for example.