### PR TITLE
fix typo: Cache.getLastestTime -> Cache.getLatestTime

### DIFF
--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -32,6 +32,7 @@
 from functools import reduce
 import itertools
 import threading
+from typing_extensions import deprecated
 # import builtin_interfaces
 
 import rclpy
@@ -171,6 +172,15 @@ class Cache(SimpleFilter):
         if not older:
             return None
         return older[-1]
+
+    @deprecated("Deprecated in favour of :py:classmethod:Cache.getLatestTime:.")
+    def getLastestTime(self):
+        """
+        Return the newest recorded timestamp.
+
+        Deprecated in favour of :py:classmethod:Cache.getLatestTime:.
+        """
+        return self.getLatestTime()
 
     def getLatestTime(self):
         """Return the newest recorded timestamp."""

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -172,7 +172,7 @@ class Cache(SimpleFilter):
             return None
         return older[-1]
 
-    def getLastestTime(self):
+    def getLatestTime(self):
         """Return the newest recorded timestamp."""
         if not self.cache_times:
             return None
@@ -185,9 +185,9 @@ class Cache(SimpleFilter):
         return self.cache_times[0]
 
     def getLast(self):
-        if self.getLastestTime() is None:
+        if self.getLatestTime() is None:
             return None
-        return self.getElemAfterTime(self.getLastestTime())
+        return self.getElemAfterTime(self.getLatestTime())
 
 
 class TimeSynchronizer(SimpleFilter):

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -32,7 +32,6 @@
 from functools import reduce
 import itertools
 import threading
-from typing_extensions import deprecated
 # import builtin_interfaces
 
 import rclpy
@@ -40,6 +39,8 @@ from rclpy.clock import ROSClock
 from rclpy.duration import Duration
 from rclpy.logging import LoggingSeverity
 from rclpy.time import Time
+
+from typing_extensions import deprecated
 
 
 class SimpleFilter(object):
@@ -173,7 +174,7 @@ class Cache(SimpleFilter):
             return None
         return older[-1]
 
-    @deprecated("Deprecated in favour of :py:classmethod:Cache.getLatestTime:.")
+    @deprecated('Deprecated in favour of :py:classmethod:Cache.getLatestTime:.')
     def getLastestTime(self):
         """
         Return the newest recorded timestamp.

--- a/test/test_message_filters_cache.py
+++ b/test/test_message_filters_cache.py
@@ -111,9 +111,9 @@ class TestCache(unittest.TestCase):
         self.assertEqual(s, Time(seconds=3),
                          'invalid msg return by getElemBeforeTime')
 
-        s = cache.getLastestTime()
+        s = cache.getLatestTime()
         self.assertEqual(s, Time(seconds=4),
-                         'invalid stamp return by getLastestTime')
+                         'invalid stamp return by getLatestTime')
 
         s = cache.getOldestTime()
         self.assertEqual(s, Time(),


### PR DESCRIPTION
Now matches the cpp implementation https://github.com/ros2/message_filters/blob/77c31e69acbb21e221fc521c1b652bf0c4d1cb45/include/message_filters/cache.hpp#L301-L314