### PR TITLE
Add sync_arrival_time flag to ApproximateTimeSynchronizer

### DIFF
--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -263,17 +263,24 @@ class ApproximateTimeSynchronizer(TimeSynchronizer):
     The ``allow_headerless`` option specifies whether to allow storing
     headerless messages with current ROS time instead of timestamp. You should
     avoid this as much as you can, since the delays are unpredictable.
+    The ```sync_arrival_time``` option enables synchronizing incoming messages 
+    with the arrival ROS time instead of the message timestamp. You should
+    avoid this as much as you can, since the delays are unpredictable.
     """
 
-    def __init__(self, fs, queue_size, slop, queue_offset=False, allow_headerless=False):
+    def __init__(self, fs, queue_size, slop, 
+                 queue_offset=False, 
+                 allow_headerless=False,
+                 sync_arrival_time=False):
         TimeSynchronizer.__init__(self, fs, queue_size)
         self.slop = Duration(seconds=slop)
         self.allow_headerless = allow_headerless
         self.queue_offset = queue_offset
+        self.sync_arrival_time = sync_arrival_time
 
     def add(self, msg, my_queue, my_queue_index=None):
-        if not hasattr(msg, 'header') or not hasattr(msg.header, 'stamp'):
-            if not self.allow_headerless:
+        if not hasattr(msg, 'header') or not hasattr(msg.header, 'stamp') or self.sync_arrival_time:
+            if not self.allow_headerless and not self.sync_arrival_time:
                 msg_filters_logger = rclpy.logging.get_logger('message_filters_approx')
                 msg_filters_logger.set_level(LoggingSeverity.INFO)
                 msg_filters_logger.warn('can not use message filters messages '

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -263,13 +263,13 @@ class ApproximateTimeSynchronizer(TimeSynchronizer):
     The ``allow_headerless`` option specifies whether to allow storing
     headerless messages with current ROS time instead of timestamp. You should
     avoid this as much as you can, since the delays are unpredictable.
-    The ```sync_arrival_time``` option enables synchronizing incoming messages 
+    The ```sync_arrival_time``` option enables synchronizing incoming messages
     with the arrival ROS time instead of the message timestamp. You should
     avoid this as much as you can, since the delays are unpredictable.
     """
 
-    def __init__(self, fs, queue_size, slop, 
-                 queue_offset=False, 
+    def __init__(self, fs, queue_size, slop,
+                 queue_offset=False,
                  allow_headerless=False,
                  sync_arrival_time=False):
         TimeSynchronizer.__init__(self, fs, queue_size)
@@ -279,7 +279,8 @@ class ApproximateTimeSynchronizer(TimeSynchronizer):
         self.sync_arrival_time = sync_arrival_time
 
     def add(self, msg, my_queue, my_queue_index=None):
-        if not hasattr(msg, 'header') or not hasattr(msg.header, 'stamp') or self.sync_arrival_time:
+        if not hasattr(msg, 'header') or not hasattr(msg.header, 'stamp') or \
+                self.sync_arrival_time:
             if not self.allow_headerless and not self.sync_arrival_time:
                 msg_filters_logger = rclpy.logging.get_logger('message_filters_approx')
                 msg_filters_logger.set_level(LoggingSeverity.INFO)


### PR DESCRIPTION
Hello everyone!
The ApproximateTimeSynchronizer works great if the timestamp is accurate or unavailable (headerless)
However, the clocks/timestamps could be inconsistent when running on ROS2 systems with multiple machines or using SITL configurations
I added a `sync_arrival_time ` flag to `ApproximateTimeSynchronizer `, which synchronizes the messages based on arrival time instead of the message timestamp