### PR TITLE
fix: add `rclcpp::shutdown`

### DIFF
--- a/test/msg_cache_unittest.cpp
+++ b/test/msg_cache_unittest.cpp
@@ -229,5 +229,7 @@ int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   rclcpp::init(argc, argv);
-  return RUN_ALL_TESTS();
+  auto ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }

--- a/test/test_approximate_epsilon_time_policy.cpp
+++ b/test/test_approximate_epsilon_time_policy.cpp
@@ -224,5 +224,7 @@ int main(int argc, char ** argv)
   testing::InitGoogleTest(&argc, argv);
   rclcpp::init(argc, argv);
 
-  return RUN_ALL_TESTS();
+  auto ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }

--- a/test/test_approximate_time_policy.cpp
+++ b/test/test_approximate_time_policy.cpp
@@ -538,5 +538,7 @@ int main(int argc, char ** argv)
   testing::InitGoogleTest(&argc, argv);
   rclcpp::init(argc, argv);
 
-  return RUN_ALL_TESTS();
+  auto ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }

--- a/test/test_chain.cpp
+++ b/test/test_chain.cpp
@@ -174,5 +174,7 @@ int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   rclcpp::init(argc, argv);
-  return RUN_ALL_TESTS();
+  auto ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }

--- a/test/test_exact_time_policy.cpp
+++ b/test/test_exact_time_policy.cpp
@@ -192,5 +192,7 @@ int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   rclcpp::init(argc, argv);
-  return RUN_ALL_TESTS();
+  auto ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }

--- a/test/test_fuzz.cpp
+++ b/test/test_fuzz.cpp
@@ -155,5 +155,7 @@ int main(int argc, char ** argv)
 
   rclcpp::init(argc, argv);
 
-  return RUN_ALL_TESTS();
+  auto ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }

--- a/test/test_latest_time_policy.cpp
+++ b/test/test_latest_time_policy.cpp
@@ -332,5 +332,7 @@ int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   rclcpp::init(argc, argv);
-  return RUN_ALL_TESTS();
+  auto ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }

--- a/test/test_simple.cpp
+++ b/test/test_simple.cpp
@@ -152,5 +152,7 @@ int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   rclcpp::init(argc, argv);
-  return RUN_ALL_TESTS();
+  auto ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }

--- a/test/test_subscriber.cpp
+++ b/test/test_subscriber.cpp
@@ -309,5 +309,7 @@ int main(int argc, char ** argv)
 
   rclcpp::init(argc, argv);
 
-  return RUN_ALL_TESTS();
+  auto ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }

--- a/test/test_synchronizer.cpp
+++ b/test/test_synchronizer.cpp
@@ -469,5 +469,7 @@ TEST(Synchronizer, add9)
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  auto ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }

--- a/test/time_sequencer_unittest.cpp
+++ b/test/time_sequencer_unittest.cpp
@@ -151,5 +151,7 @@ int main(int argc, char ** argv)
 
   rclcpp::init(argc, argv);
 
-  return RUN_ALL_TESTS();
+  auto ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }

--- a/test/time_synchronizer_unittest.cpp
+++ b/test/time_synchronizer_unittest.cpp
@@ -563,5 +563,7 @@ int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   rclcpp::init(argc, argv);
-  return RUN_ALL_TESTS();
+  auto ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }


### PR DESCRIPTION
This PR adds the missing `rclcpp::shutdown`.
