### PR TITLE
Jazzy - Fix doc link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ROS 2 message filters
 Package that implements different filters for ros messages.
 
-Refer to [index.rst](index.rst) for more information.
+Refer to [index.rst](doc/index.rst) for more information.
 
 The implementation with the details can be found in [src/message_filters/__init__.py](src/message_filters/__init__.py)


### PR DESCRIPTION
This is already fixed in Rolling, but broken in Jazzy