### PR TITLE
Docs - Remove C++ implementation limit of 9 channels

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -80,11 +80,11 @@ The TimeSynchronizer filter synchronizes incoming channels by the timestamps con
 3.1 Connections
 ~~~~~~~~~~~~~~~
 Input:
-  * C++: Up to 9 separate filters, each of which is of the form ``void callback(const std::shared_ptr<M const>&)``. The number of filters supported is determined by the number of template arguments the class was created with.
+  * C++: N separate filters, each of which is of the form ``void callback(const std::shared_ptr<M const>&)``. The number of filters supported is determined by the number of template arguments the class was created with.
   * Python: N separate filters, each of which has signature ``callback(msg)``.
 
 Output:
-  * C++: For message types M0..M8, ``void callback(const std::shared_ptr<M0 const>&, ..., const std::shared_ptr<M8 const>&)``. The number of parameters is determined by the number of template arguments the class was created with.
+  * C++: For message types M0..MN, ``void callback(const std::shared_ptr<M0 const>&, ..., const std::shared_ptr<MN const>&)``. The number of parameters is determined by the number of template arguments the class was created with.
   * Python: ``callback(msg0.. msgN)``. The number of parameters is determined by the number of template arguments the class was created with.
 
 4. Time Sequencer

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -75,7 +75,7 @@ or
 
 3. Time Synchronizer
 --------------------
-The TimeSynchronizer filter synchronizes incoming channels by the timestamps contained in their headers, and outputs them in the form of a single callback that takes the same number of channels. The C++ implementation can synchronize up to 9 channels.
+The TimeSynchronizer filter synchronizes incoming channels by the timestamps contained in their headers, and outputs them in the form of a single callback that takes the same number of channels.
 
 3.1 Connections
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
After #93 got merged, this should not be true anymore.

To be backported on Jazzy too :)