### PR TITLE
get rid of deprecated rclcpp::spin_some().

### DIFF
--- a/test/test_fuzz.cpp
+++ b/test/test_fuzz.cpp
@@ -78,6 +78,8 @@ static void fuzz_msg(MsgPtr msg)
 TEST(TimeSequencer, fuzz_sequencer)
 {
   rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_node");
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
   message_filters::TimeSequencer<Msg> seq(rclcpp::Duration(0, 10000000), rclcpp::Duration(
       0, 1000000),
     10, node);
@@ -94,9 +96,9 @@ TEST(TimeSequencer, fuzz_sequencer)
 
     rclcpp::Rate(20).sleep();
     ASSERT_EQ(h.count_, 0);
-    rclcpp::spin_some(node);
+    executor.spin_some();
     rclcpp::Rate(100).sleep();
-    rclcpp::spin_some(node);
+    executor.spin_some();
     ASSERT_EQ(h.count_, 1);
   }
 }
@@ -128,6 +130,8 @@ TEST(TimeSynchronizer, fuzz_synchronizer)
 TEST(Subscriber, fuzz_subscriber)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
   Helper h;
   rclcpp::QoS default_qos =
     rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));
@@ -143,10 +147,10 @@ TEST(Subscriber, fuzz_subscriber)
     msg->header.stamp = ros_clock.now();
     pub->publish(*msg);
     rclcpp::Rate(50).sleep();
-    rclcpp::spin_some(node);
+    executor.spin_some();
     ASSERT_EQ(h.count_, 1);
   }
-  rclcpp::spin_some(node);
+  executor.spin_some();
 }
 
 int main(int argc, char ** argv)

--- a/test/test_input_aligner.cpp
+++ b/test/test_input_aligner.cpp
@@ -284,6 +284,8 @@ TEST_F(InputAlignerTest, dispatch_by_timer)
 {
   message_filters::InputAligner<Msg1, Msg2> aligner(timeout_);
   aligner.setupDispatchTimer(node_, update_rate_);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node_);
 
   // register callbacks
   InputAlignerTest * test_fixture = dynamic_cast<InputAlignerTest *>(this);
@@ -298,7 +300,7 @@ TEST_F(InputAlignerTest, dispatch_by_timer)
   aligner.add<0>(createMsg<Msg1>(std::chrono::milliseconds(1), 1));
 
   rclcpp::Rate(50).sleep();
-  rclcpp::spin_some(node_);
+  executor.spin_some();
 
   ASSERT_EQ(cb_content_.size(), 2);
   for (size_t i = 0; i < cb_content_.size(); i++) {

--- a/test/time_sequencer_unittest.cpp
+++ b/test/time_sequencer_unittest.cpp
@@ -79,6 +79,8 @@ public:
 TEST(TimeSequencer, simple)
 {
   rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_node");
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
   message_filters::TimeSequencer<Msg> seq(rclcpp::Duration(0, 250000000),
     rclcpp::Duration(0, 10000000), 10, node);
   Helper h;
@@ -88,12 +90,12 @@ TEST(TimeSequencer, simple)
   seq.add(msg);
 
   rclcpp::Rate(10).sleep();
-  rclcpp::spin_some(node);
+  executor.spin_some();
   ASSERT_EQ(h.count_, 0);
 
   // Must be longer than the first duration above
   rclcpp::Rate(3).sleep();
-  rclcpp::spin_some(node);
+  executor.spin_some();
 
   ASSERT_EQ(h.count_, 1);
 }
@@ -123,6 +125,8 @@ public:
 TEST(TimeSequencer, eventInEventOut)
 {
   rclcpp::Node::SharedPtr nh = std::make_shared<rclcpp::Node>("test_node");
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(nh);
   message_filters::TimeSequencer<Msg> seq(rclcpp::Duration(1, 0), rclcpp::Duration(0, 10000000), 10,
     nh);
   message_filters::TimeSequencer<Msg> seq2(seq, rclcpp::Duration(1, 0), rclcpp::Duration(
@@ -138,7 +142,7 @@ TEST(TimeSequencer, eventInEventOut)
 
   while (!h.event_.getMessage()) {
     rclcpp::Rate(100).sleep();
-    rclcpp::spin_some(nh);
+    executor.spin_some();
   }
 
   EXPECT_EQ(h.event_.getReceiptTime(), evt.getReceiptTime());


### PR DESCRIPTION
## Description

~~This depends on https://github.com/ros2/rclcpp/pull/2848~~

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

No

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
