### PR TITLE
Fix comparison of different time sources in C++ TimeSequencer

### DIFF
--- a/include/message_filters/time_sequencer.hpp
+++ b/include/message_filters/time_sequencer.hpp
@@ -96,6 +96,7 @@ public:
     , update_rate_(update_rate)
     , queue_size_(queue_size)
     , node_(node)
+    , last_time_ (0, 0, RCL_ROS_TIME)
   {
     init();
     connectInput(f);
@@ -118,6 +119,7 @@ public:
     , update_rate_(update_rate)
     , queue_size_(queue_size)
     , node_(node)
+    , last_time_ (0, 0, RCL_ROS_TIME)
   {
     init();
   }
@@ -199,7 +201,7 @@ public:
       while (!messages_.empty()) {
         const EventType & e = *messages_.begin();
         rclcpp::Time stamp = mt::TimeStamp<M>::value(*e.getMessage());
-        if ((stamp + delay_) <= rclcpp::Clock().now()) {
+        if ((stamp + delay_) <= node_->get_clock()->now()) {
           last_time_ = stamp;
           to_call.push_back(e);
           messages_.erase(messages_.begin());
@@ -220,7 +222,7 @@ public:
 
   void init()
   {
-    update_timer_ = node_->create_wall_timer(
+    update_timer_ = rclcpp::create_timer(node_, node_->get_clock(), 
       std::chrono::nanoseconds(update_rate_.nanoseconds()), [this]() {
         dispatch();
       });

--- a/include/message_filters/time_sequencer.hpp
+++ b/include/message_filters/time_sequencer.hpp
@@ -222,7 +222,9 @@ public:
 
   void init()
   {
-    update_timer_ = rclcpp::create_timer(node_, node_->get_clock(), 
+    update_timer_ = rclcpp::create_timer(
+      node_,
+      node_->get_clock(),
       std::chrono::nanoseconds(update_rate_.nanoseconds()), [this]() {
         dispatch();
       });

--- a/test/test_fuzz.cpp
+++ b/test/test_fuzz.cpp
@@ -85,7 +85,7 @@ TEST(TimeSequencer, fuzz_sequencer)
     10, node);
   Helper h;
   seq.registerCallback(std::bind(&Helper::cb, &h, std::placeholders::_1));
-  rclcpp::Clock ros_clock;
+  rclcpp::Clock ros_clock(RCL_ROS_TIME);
   auto start = ros_clock.now();
   auto msg = std::make_shared<Msg>();
   while ((ros_clock.now() - start) < rclcpp::Duration(5, 0)) {

--- a/test/time_sequencer_unittest.cpp
+++ b/test/time_sequencer_unittest.cpp
@@ -55,7 +55,7 @@ struct TimeStamp<Msg>
 {
   static rclcpp::Time value(const Msg & m)
   {
-    return m.header.stamp;
+    return rclcpp::Time(m.header.stamp, RCL_ROS_TIME);
   }
 };
 }  // namespace message_traits
@@ -86,7 +86,7 @@ TEST(TimeSequencer, simple)
   Helper h;
   seq.registerCallback(std::bind(&Helper::cb, &h, std::placeholders::_1));
   MsgPtr msg(std::make_shared<Msg>());
-  msg->header.stamp = rclcpp::Clock().now();
+  msg->header.stamp = rclcpp::Clock(RCL_ROS_TIME).now();
   seq.add(msg);
 
   rclcpp::Rate(10).sleep();
@@ -137,7 +137,7 @@ TEST(TimeSequencer, eventInEventOut)
   seq2.registerCallback(&EventHelper::cb, &h);
 
   message_filters::MessageEvent<Msg const> evt(std::make_shared<Msg const>(),
-    rclcpp::Clock().now());
+    rclcpp::Clock(RCL_ROS_TIME).now());
   seq.add(evt);
 
   while (!h.event_.getMessage()) {


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Related to issues #21 and #175 

Currently, the C++ implementation of the TimeSequencer is not working, as the following error is thrown:
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  can't compare times with different time sources
[ros2run]: Aborted
```
The proposed fix implements the suggested solutions from the issues and initializes `last_time_` in the constructor to use the clock type `RCL_ROS_TIME`. This is necessary because the message time stamp
```
rclcpp::Time stamp = mt::TimeStamp<M>::value(*e.getMessage());
``` 
([here](https://github.com/ros2/message_filters/blob/c5bc6dee3e2990cb2cc3920199db32d524bfae14/include/message_filters/time_sequencer.hpp#L201)) is returned with clock type `RCL_ROS_TIME` and comparing two different clock types is not allowed. The clock type in its corresponding test files is also changed.

Additionally, the timer `update_timer_` is created using the node's clock instead of the wall clock to also work in simulation with sim-time.

### Is this user-facing behavior change?
No

### Did you use Generative AI?
No

### Additional Information
Tested under ROS2 Jazzy and ROS2 Rolling.
