### PR TITLE
Update repository URL in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,7 @@
   <maintainer email="geoff@openrobotics.org">Geoffrey Biggs</maintainer>
 
   <license>BSD</license>
-  <url>https://github.com/intel/ros2_message_filters</url>
+  <url>https://github.com/ros2/message_filters</url>
 
   <author>Dirk Thomas</author>
   <author email="ethan.gao@linux.intel.com">Ethan Gao</author>


### PR DESCRIPTION
## Description

This was fixed in kilted+ in https://github.com/ros2/message_filters/pull/120 . However, Jazzy and Humble still have the wrong link

### Is this user-facing behavior change?


### Did you use Generative AI?

No

### Additional Information

This should be backported to Humble, too
