### PR TITLE
Remove import of the abcent from rclpy.type_support import MsgT class

### DIFF
--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -47,7 +47,6 @@ from rclpy.logging import LoggingSeverity
 from rclpy.node import Node
 from rclpy.qos import QoSProfile
 from rclpy.time import Time
-from rclpy.type_support import MsgT
 
 
 class SimpleFilter(object):
@@ -84,7 +83,7 @@ class Subscriber(SimpleFilter):
     def __init__(
         self,
         node: Node,
-        msg_type: Type[MsgT],
+        msg_type: Type,
         topic: str,
         qos_profile: Union[QoSProfile, int] = QoSProfile(depth=10),
     ) -> None:


### PR DESCRIPTION
## Description
Remove import of the abcent from rclpy.type_support import MsgT class
<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
