### PR TITLE
#200 fix inconsistensy between cpp and python exact time synchronizer impl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,7 @@ if(BUILD_TESTING)
 
   # python tests with python interfaces of message filters
   find_package(ament_cmake_pytest REQUIRED)
-  ament_add_pytest_test(directed.py "test/directed.py")
+  ament_add_pytest_test(test_time_synchronizer.py "test/test_time_synchronizer.py")
   ament_add_pytest_test(test_approxsync.py "test/test_approxsync.py")
   ament_add_pytest_test(test_message_filters_cache.py "test/test_message_filters_cache.py")
   ament_add_pytest_test(test_message_filters_chain.py "test/test_message_filters_chain.py")

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -320,12 +320,25 @@ class TimeSynchronizer(SimpleFilter):
             del my_queue[min(my_queue)]
         # common is the set of timestamps that occur in all queues
         common = reduce(set.intersection, [set(q) for q in self.queues])
+        signaled_time = None
         for t in sorted(common):
             # msgs is list of msgs (one from each queue) with stamp t
             msgs = [q[t] for q in self.queues]
             self.signalMessage(*msgs)
             for q in self.queues:
                 del q[t]
+            signaled_time = t
+            break
+
+        # for consistency with the C++ implementation:
+        #     Delete all stored messages with a timestamp
+        #     older than the time of the latest signaled time
+        if signaled_time is not None:
+            for queue in self.queues:
+                for stamp in list(queue.keys()):
+                    if stamp < signaled_time:
+                        del queue[stamp]
+
         self.lock.release()
 
 

--- a/test/directed.py
+++ b/test/directed.py
@@ -41,6 +41,7 @@
 #
 #    wide.registerCallback(boost::bind(&PersonDataRecorder::wideCB, this, _1, _2, _3, _4));
 
+import functools
 import random
 import unittest
 
@@ -66,6 +67,7 @@ class MockFilter(SimpleFilter):
 
 class TestDirected(unittest.TestCase):
 
+    # TODO: Replace global variable with local
     def cb_collector_2msg(self, msg1, msg2):
         self.collector.append((msg1, msg2))
 
@@ -105,8 +107,88 @@ class TestDirected(unittest.TestCase):
                 m1.signalMessage(msg)
             self.assertEqual(set(self.collector), set(zip(seq0, seq1)))
 
+    def test_time_synchronizer_shifted_time_signalling_1(self):
+        def collector_callback(msg1, msg2, collector):
+            collector.append((msg1, msg2))
+
+        collector = []
+
+        filter_0 = MockFilter()
+        filter_1 = MockFilter()
+        ts = TimeSynchronizer([filter_0, filter_1], 10)
+        ts.registerCallback(
+            functools.partial(
+                collector_callback,
+                collector=collector,
+            )
+        )
+
+        t1 = 0
+        t2 = 1
+
+        x0 = MockMessage(t1, 1)
+        x1 = MockMessage(t1, 2)
+
+        y0 = MockMessage(t2, 1)
+        y1 = MockMessage(t2, 2)
+
+        filter_0.signalMessage(x0)
+        assert len(collector) == 0
+
+        filter_1.signalMessage(y1)
+        assert len(collector) == 0
+
+        filter_0.signalMessage(y0)
+        assert len(collector) == 1
+        assert collector[0] == (y0, y1)
+
+        filter_1.signalMessage(x1)
+        assert len(collector) == 1
+        assert collector[0] == (y0, y1)
+
+    def test_time_synchronizer_shifted_time_signalling_2(self):
+        def collector_callback(msg1, msg2, collector):
+            collector.append((msg1, msg2))
+
+        collector = []
+
+        filter_0 = MockFilter()
+        filter_1 = MockFilter()
+        ts = TimeSynchronizer([filter_0, filter_1], 10)
+        ts.registerCallback(
+            functools.partial(
+                collector_callback,
+                collector=collector,
+            )
+        )
+
+        t1 = 0
+        t2 = 1
+
+        x0 = MockMessage(t1, 1)
+        x1 = MockMessage(t1, 2)
+
+        y0 = MockMessage(t2, 1)
+        y1 = MockMessage(t2, 2)
+
+        filter_0.signalMessage(x0)
+        assert len(collector) == 0
+
+        filter_0.signalMessage(y0)
+        assert len(collector) == 0
+
+        filter_1.signalMessage(x1)
+        assert len(collector) == 1
+        assert collector[0] == (x0, x1)
+
+        filter_1.signalMessage(y1)
+        assert len(collector) == 2
+        assert collector[0] == (x0, x1)
+        assert collector[1] == (y0, y1)
+
 
 if __name__ == '__main__':
     suite = unittest.TestSuite()
     suite.addTest(TestDirected('test_synchronizer'))
+    suite.addTest(TestDirected('test_time_synchronizer_old_msgs_drop'))
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/test/test_time_synchronizer.py
+++ b/test/test_time_synchronizer.py
@@ -42,7 +42,6 @@
 #    wide.registerCallback(boost::bind(&PersonDataRecorder::wideCB, this, _1, _2, _3, _4));
 
 import functools
-import random
 import unittest
 
 from builtin_interfaces.msg import Time as TimeMsg
@@ -67,50 +66,35 @@ class MockFilter(SimpleFilter):
 
 class TestDirected(unittest.TestCase):
 
-    # TODO: Replace global variable with local
-    def cb_collector_2msg(self, msg1, msg2):
-        self.collector.append((msg1, msg2))
+    @staticmethod
+    def collector_callback(msg1, msg2, collector):
+        collector.append((msg1, msg2))
 
-    def test_synchronizer(self):
-        m0 = MockFilter()
-        m1 = MockFilter()
-        ts = TimeSynchronizer([m0, m1], 1)
-        ts.registerCallback(self.cb_collector_2msg)
-
-        if 0:
-            # Simple case, pairs of messages, make sure that they get combined
-            for t in range(10):
-                self.collector = []
-                msg0 = MockMessage(t, 33)
-                msg1 = MockMessage(t, 34)
-                m0.signalMessage(msg0)
-                self.assertEqual(self.collector, [])
-                m1.signalMessage(msg1)
-                self.assertEqual(self.collector, [(msg0, msg1)])
-
-        # Scramble sequences of length N.
-        # Make sure that TimeSequencer recombines them.
-        random.seed(0)
+    def test_time_synchronizer_queue_lentgth(self):
         for N in range(1, 10):
+            seq0 = [MockMessage(t, 0) for t in range(N)]
+            seq1 = [MockMessage(t, 0) for t in range(N)]
+
             m0 = MockFilter()
             m1 = MockFilter()
-            seq0 = [MockMessage(t, random.random()) for t in range(N)]
-            seq1 = [MockMessage(t, random.random()) for t in range(N)]
-            # random.shuffle(seq0)
             ts = TimeSynchronizer([m0, m1], N)
-            ts.registerCallback(self.cb_collector_2msg)
-            self.collector = []
-            for msg in random.sample(seq0, N):
+
+            collector = []
+            ts.registerCallback(
+                functools.partial(
+                    self.collector_callback,
+                    collector=collector,
+                )
+            )
+
+            for msg in seq0:
                 m0.signalMessage(msg)
-            self.assertEqual(self.collector, [])
-            for msg in random.sample(seq1, N):
+            self.assertEqual(collector, [])
+            for msg in seq1:
                 m1.signalMessage(msg)
-            self.assertEqual(set(self.collector), set(zip(seq0, seq1)))
+            self.assertEqual(set(collector), set(zip(seq0, seq1)))
 
-    def test_time_synchronizer_shifted_time_signalling_1(self):
-        def collector_callback(msg1, msg2, collector):
-            collector.append((msg1, msg2))
-
+    def test_time_synchronizer_drop_old_messages(self):
         collector = []
 
         filter_0 = MockFilter()
@@ -118,7 +102,7 @@ class TestDirected(unittest.TestCase):
         ts = TimeSynchronizer([filter_0, filter_1], 10)
         ts.registerCallback(
             functools.partial(
-                collector_callback,
+                self.collector_callback,
                 collector=collector,
             )
         )
@@ -146,10 +130,7 @@ class TestDirected(unittest.TestCase):
         assert len(collector) == 1
         assert collector[0] == (y0, y1)
 
-    def test_time_synchronizer_shifted_time_signalling_2(self):
-        def collector_callback(msg1, msg2, collector):
-            collector.append((msg1, msg2))
-
+    def test_time_synchronizer_shifted_time_signalling(self):
         collector = []
 
         filter_0 = MockFilter()
@@ -157,7 +138,7 @@ class TestDirected(unittest.TestCase):
         ts = TimeSynchronizer([filter_0, filter_1], 10)
         ts.registerCallback(
             functools.partial(
-                collector_callback,
+                self.collector_callback,
                 collector=collector,
             )
         )
@@ -189,6 +170,7 @@ class TestDirected(unittest.TestCase):
 
 if __name__ == '__main__':
     suite = unittest.TestSuite()
-    suite.addTest(TestDirected('test_synchronizer'))
-    suite.addTest(TestDirected('test_time_synchronizer_old_msgs_drop'))
+    suite.addTest(TestDirected('test_time_synchronizer_queue_lentgth'))
+    suite.addTest(TestDirected('test_time_synchronizer_drop_old_messages'))
+    suite.addTest(TestDirected('test_time_synchronizer_shifted_time_signalling'))
     unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

In `Python3` implementation, messages with timestamps, older then the last that caused signalling, are removed and do not cause signalling in the future. As in `C++` implementation.

See the issue #200 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #200 

### Is this user-facing behavior change?
Yes.
Makes `Python3` behavior of the `TymeSynchronizer` filter consistent with `C++` behavior.

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
No, I did not
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

@authaldo can you take a look at this one?
As an author of the original fix.

<!--
If applicable, provide any additional context or details about the changes.
-->
