### PR TITLE
Add kwargs passing from Subscriber to node.create_subscription

### DIFF
--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -84,6 +84,7 @@ class Subscriber(SimpleFilter):
         msg_type: Type[MsgT],
         topic: str,
         qos_profile: Union[QoSProfile, int] = QoSProfile(depth=10),
+        **kwargs,
     ) -> None:
         """
         Construct a Subscriber.
@@ -95,6 +96,7 @@ class Subscriber(SimpleFilter):
             subscription. In the case that a history depth is provided, the QoS history is
             set to KEEP_LAST, the QoS history depth is set to the value of the parameter,
             and all other QoS settings are set to their default values.
+        :param kwargs: Additional keyword arguments passed to node.create_subscription.
         """
         SimpleFilter.__init__(self)
         self.node = node
@@ -104,6 +106,7 @@ class Subscriber(SimpleFilter):
             topic=self.topic,
             callback=self.callback,
             qos_profile=qos_profile,
+            **kwargs,
         )
 
     def callback(self, msg):


### PR DESCRIPTION
Fixes message_filters.Susbcriber callers that use callback_group

## Description

Adds kwargs passing from Subscriber to node.create_subscription to allow callers to continue to use callback_group arguments to message_filters.Subscriber.

Fixes https://github.com/ros2/message_filters/issues/246

### Is this user-facing behavior change?

Yes, but backwards compatible (only adds back functionality from before https://github.com/ros2/message_filters/pull/226).

### Did you use Generative AI?

No.
