### PR TITLE
(issue #253): Chain Python: Remove dataclass dependency

### DIFF
--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -32,8 +32,6 @@ Message Filter Objects
 
 """Message Filter Objects."""
 
-from bisect import insort_right
-from dataclasses import dataclass
 from functools import reduce
 import itertools
 import threading
@@ -238,10 +236,14 @@ class Chain(SimpleFilter):
     to the callback you've registered with Chain::registerCallback.
     """
 
-    @dataclass
     class FilterInfo:
-        message_filter: any
-        connection_callback_index: int
+        def __init__(
+            self,
+            message_filter: any,
+            connection_callback_index: int,
+        ):
+            self.message_filter = message_filter
+            self.connection_callback_index = connection_callback_index
 
     def __init__(self, message_filter=None):
         SimpleFilter.__init__(self)


### PR DESCRIPTION
…lterInfo a regular class with regular __init__

## Description

Get rid of dataclass dependency. Make `FilterInfo` in `Chain` a regular class.

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #253 

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
