### PR TITLE
feat(python): add python implementation of InputAligner 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ if(BUILD_TESTING)
   ament_add_pytest_test(test_approxsync.py "test/test_approxsync.py")
   ament_add_pytest_test(test_message_filters_cache.py "test/test_message_filters_cache.py")
   ament_add_pytest_test(test_message_filters_chain.py "test/test_message_filters_chain.py")
+  ament_add_pytest_test(test_input_aligner.py "test/test_input_aligner.py")
 endif()
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,10 +26,10 @@ endif()
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
-ament_target_dependencies(${PROJECT_NAME} PUBLIC
-  rclcpp
-  rcutils
-  std_msgs
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  rclcpp::rclcpp
+  rcutils::rcutils
+  std_msgs::std_msgs
 )
 
 install(
@@ -88,11 +88,8 @@ if(BUILD_TESTING)
 
   ament_add_gtest(${PROJECT_NAME}-test_subscriber test/test_subscriber.cpp)
   if(TARGET ${PROJECT_NAME}-test_subscriber)
-    target_link_libraries(${PROJECT_NAME}-test_subscriber ${PROJECT_NAME})
-    ament_target_dependencies(${PROJECT_NAME}-test_subscriber
-      rclcpp
-      rclcpp_lifecycle
-      sensor_msgs)
+    target_link_libraries(${PROJECT_NAME}-test_subscriber ${PROJECT_NAME} rclcpp::rclcpp
+    rclcpp_lifecycle::rclcpp_lifecycle sensor_msgs::sensor_msgs)
   endif()
 
   ament_add_gtest(${PROJECT_NAME}-test_synchronizer test/test_synchronizer.cpp)
@@ -127,18 +124,12 @@ if(BUILD_TESTING)
 
   ament_add_gtest(${PROJECT_NAME}-test_fuzz test/test_fuzz.cpp SKIP_TEST)
   if(TARGET ${PROJECT_NAME}-test_fuzz)
-    target_link_libraries(${PROJECT_NAME}-test_fuzz ${PROJECT_NAME})
-    ament_target_dependencies(${PROJECT_NAME}-test_fuzz
-      rclcpp
-      sensor_msgs)
+    target_link_libraries(${PROJECT_NAME}-test_fuzz ${PROJECT_NAME} rclcpp::rclcpp sensor_msgs::sensor_msgs)
   endif()
 
   ament_add_gtest(${PROJECT_NAME}-test_message_traits test/test_message_traits.cpp)
   if(TARGET ${PROJECT_NAME}-test_message_traits)
-    target_link_libraries(${PROJECT_NAME}-test_message_traits ${PROJECT_NAME})
-    ament_target_dependencies(${PROJECT_NAME}-test_message_traits
-      rclcpp
-      std_msgs)
+    target_link_libraries(${PROJECT_NAME}-test_message_traits ${PROJECT_NAME} rclcpp::rclcpp std_msgs::std_msgs)
   endif()
 
   ament_add_gtest(${PROJECT_NAME}-test_input_aligner test/test_input_aligner.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,10 +26,10 @@ endif()
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
-target_link_libraries(${PROJECT_NAME} PUBLIC
-  rclcpp::rclcpp
-  rcutils::rcutils
-  std_msgs::std_msgs
+ament_target_dependencies(${PROJECT_NAME} PUBLIC
+  rclcpp
+  rcutils
+  std_msgs
 )
 
 install(
@@ -88,8 +88,11 @@ if(BUILD_TESTING)
 
   ament_add_gtest(${PROJECT_NAME}-test_subscriber test/test_subscriber.cpp)
   if(TARGET ${PROJECT_NAME}-test_subscriber)
-    target_link_libraries(${PROJECT_NAME}-test_subscriber ${PROJECT_NAME} rclcpp::rclcpp
-    rclcpp_lifecycle::rclcpp_lifecycle sensor_msgs::sensor_msgs)
+    target_link_libraries(${PROJECT_NAME}-test_subscriber ${PROJECT_NAME})
+    ament_target_dependencies(${PROJECT_NAME}-test_subscriber
+      rclcpp
+      rclcpp_lifecycle
+      sensor_msgs)
   endif()
 
   ament_add_gtest(${PROJECT_NAME}-test_synchronizer test/test_synchronizer.cpp)
@@ -124,12 +127,18 @@ if(BUILD_TESTING)
 
   ament_add_gtest(${PROJECT_NAME}-test_fuzz test/test_fuzz.cpp SKIP_TEST)
   if(TARGET ${PROJECT_NAME}-test_fuzz)
-    target_link_libraries(${PROJECT_NAME}-test_fuzz ${PROJECT_NAME} rclcpp::rclcpp sensor_msgs::sensor_msgs)
+    target_link_libraries(${PROJECT_NAME}-test_fuzz ${PROJECT_NAME})
+    ament_target_dependencies(${PROJECT_NAME}-test_fuzz
+      rclcpp
+      sensor_msgs)
   endif()
 
   ament_add_gtest(${PROJECT_NAME}-test_message_traits test/test_message_traits.cpp)
   if(TARGET ${PROJECT_NAME}-test_message_traits)
-    target_link_libraries(${PROJECT_NAME}-test_message_traits ${PROJECT_NAME} rclcpp::rclcpp std_msgs::std_msgs)
+    target_link_libraries(${PROJECT_NAME}-test_message_traits ${PROJECT_NAME})
+    ament_target_dependencies(${PROJECT_NAME}-test_message_traits
+      rclcpp
+      std_msgs)
   endif()
 
   ament_add_gtest(${PROJECT_NAME}-test_input_aligner test/test_input_aligner.cpp)

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -50,6 +50,8 @@ from rclpy.subscription_content_filter_options import ContentFilterOptions
 from rclpy.time import Time
 from rclpy.type_support import MsgT
 
+from .input_aligner import InputAligner, QueueStatus
+
 
 class SimpleFilter(object):
 

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -34,7 +34,7 @@ from dataclasses import dataclass
 from functools import reduce
 import itertools
 import threading
-from typing import Optional, Type, TypeVar, Union
+from typing import Optional, Type, Union
 
 from builtin_interfaces.msg import Time as TimeMsg
 import rclpy
@@ -46,15 +46,9 @@ from rclpy.logging import LoggingSeverity
 from rclpy.node import Node
 from rclpy.qos import QoSProfile
 from rclpy.qos_overriding_options import QoSOverridingOptions
-try:
-    from rclpy.subscription_content_filter_options import ContentFilterOptions
-except ImportError:
-    ContentFilterOptions = None
+from rclpy.subscription_content_filter_options import ContentFilterOptions
 from rclpy.time import Time
-try:
-    from rclpy.type_support import MsgT
-except ImportError:
-    MsgT = TypeVar("MsgT")
+from rclpy.type_support import MsgT
 
 from .simple_filter import SimpleFilter
 from .input_aligner import InputAligner

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -46,15 +46,9 @@ from rclpy.logging import LoggingSeverity
 from rclpy.node import Node
 from rclpy.qos import QoSProfile
 from rclpy.qos_overriding_options import QoSOverridingOptions
-try:
-    from rclpy.subscription_content_filter_options import ContentFilterOptions
-except ImportError:
-    ContentFilterOptions = None
+from rclpy.subscription_content_filter_options import ContentFilterOptions
 from rclpy.time import Time
-try:
-    from rclpy.type_support import MsgT
-except ImportError:
-    MsgT = TypeVar("MsgT")
+from rclpy.type_support import MsgT
 
 
 class SimpleFilter(object):
@@ -144,7 +138,7 @@ class Subscriber(SimpleFilter):
         return self.sub.__getattribute__(key)
 
 
-from message_filters.input_aligner import InputAligner, QueueStatus
+from message_filters.input_aligner import InputAligner
 
 
 class Cache(SimpleFilter):
@@ -588,4 +582,3 @@ class TimeSequencer(SimpleFilter):
         """Clean up the TimeSequencer."""
         self.update_timer.cancel()
         self.node.destroy_timer(self.update_timer)
-

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -50,6 +50,7 @@ from rclpy.subscription_content_filter_options import ContentFilterOptions
 from rclpy.time import Time
 from rclpy.type_support import MsgT
 
+from message_filters.input_aligner import InputAligner, QueueStatus
 
 
 class SimpleFilter(object):
@@ -581,4 +582,3 @@ class TimeSequencer(SimpleFilter):
         self.update_timer.cancel()
         self.node.destroy_timer(self.update_timer)
 
-from message_filters.input_aligner import InputAligner, QueueStatus

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -72,6 +72,9 @@ class SimpleFilter(object):
         for (cb, args) in self.callbacks.values():
             cb(*(msg + args))
 
+    def unregisterCallback(self, conn):
+        self.callbacks.pop(conn, None)
+
 
 class Subscriber(SimpleFilter):
     """

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -34,7 +34,7 @@ from dataclasses import dataclass
 from functools import reduce
 import itertools
 import threading
-from typing import Optional, Type, TypeVar, Union
+from typing import Optional, Type, Union
 
 from builtin_interfaces.msg import Time as TimeMsg
 import rclpy

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -51,7 +51,6 @@ from rclpy.time import Time
 from rclpy.type_support import MsgT
 
 from .simple_filter import SimpleFilter
-from .input_aligner import InputAligner
 
 
 class Subscriber(SimpleFilter):

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -34,7 +34,7 @@ from dataclasses import dataclass
 from functools import reduce
 import itertools
 import threading
-from typing import Optional, Type, Union
+from typing import Optional, Type, TypeVar, Union
 
 from builtin_interfaces.msg import Time as TimeMsg
 import rclpy
@@ -46,11 +46,15 @@ from rclpy.logging import LoggingSeverity
 from rclpy.node import Node
 from rclpy.qos import QoSProfile
 from rclpy.qos_overriding_options import QoSOverridingOptions
-from rclpy.subscription_content_filter_options import ContentFilterOptions
+try:
+    from rclpy.subscription_content_filter_options import ContentFilterOptions
+except ImportError:
+    ContentFilterOptions = None
 from rclpy.time import Time
-from rclpy.type_support import MsgT
-
-from message_filters.input_aligner import InputAligner, QueueStatus
+try:
+    from rclpy.type_support import MsgT
+except ImportError:
+    MsgT = TypeVar("MsgT")
 
 
 class SimpleFilter(object):
@@ -138,6 +142,9 @@ class Subscriber(SimpleFilter):
     def __getattr__(self, key):
         """Serve same API as rospy.Subscriber."""
         return self.sub.__getattribute__(key)
+
+
+from message_filters.input_aligner import InputAligner, QueueStatus
 
 
 class Cache(SimpleFilter):

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -34,7 +34,7 @@ from dataclasses import dataclass
 from functools import reduce
 import itertools
 import threading
-from typing import Optional, Type, Union
+from typing import Optional, Type, TypeVar, Union
 
 from builtin_interfaces.msg import Time as TimeMsg
 import rclpy
@@ -46,34 +46,18 @@ from rclpy.logging import LoggingSeverity
 from rclpy.node import Node
 from rclpy.qos import QoSProfile
 from rclpy.qos_overriding_options import QoSOverridingOptions
-from rclpy.subscription_content_filter_options import ContentFilterOptions
+try:
+    from rclpy.subscription_content_filter_options import ContentFilterOptions
+except ImportError:
+    ContentFilterOptions = None
 from rclpy.time import Time
-from rclpy.type_support import MsgT
+try:
+    from rclpy.type_support import MsgT
+except ImportError:
+    MsgT = TypeVar("MsgT")
 
-
-class SimpleFilter(object):
-
-    def __init__(self):
-        self.callbacks = {}
-
-    def registerCallback(self, cb, *args):
-        """
-        Register a callback `cb` to be called when this filter has output.
-
-        The filter calls the function ``cb`` with a filter-dependent.
-
-        list of arguments,followed by the call-supplied arguments ``args.``.
-        """
-        conn = len(self.callbacks)
-        self.callbacks[conn] = (cb, args)
-        return conn
-
-    def signalMessage(self, *msg):
-        for (cb, args) in self.callbacks.values():
-            cb(*(msg + args))
-
-    def unregisterCallback(self, conn):
-        self.callbacks.pop(conn, None)
+from .simple_filter import SimpleFilter
+from .input_aligner import InputAligner
 
 
 class Subscriber(SimpleFilter):
@@ -139,9 +123,6 @@ class Subscriber(SimpleFilter):
     def __getattr__(self, key):
         """Serve same API as rospy.Subscriber."""
         return self.sub.__getattribute__(key)
-
-
-from message_filters.input_aligner import InputAligner
 
 
 class Cache(SimpleFilter):

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -50,7 +50,6 @@ from rclpy.subscription_content_filter_options import ContentFilterOptions
 from rclpy.time import Time
 from rclpy.type_support import MsgT
 
-from .input_aligner import InputAligner, QueueStatus
 
 
 class SimpleFilter(object):
@@ -581,3 +580,5 @@ class TimeSequencer(SimpleFilter):
         """Clean up the TimeSequencer."""
         self.update_timer.cancel()
         self.node.destroy_timer(self.update_timer)
+
+from message_filters.input_aligner import InputAligner, QueueStatus

--- a/src/message_filters/delta_filter.py
+++ b/src/message_filters/delta_filter.py
@@ -31,7 +31,7 @@ from abc import ABC
 from functools import partial
 from typing import Any, Callable
 
-from .simple_filter import SimpleFilter
+from message_filters.simple_filter import SimpleFilter
 from rclpy.type_support import MsgT
 
 

--- a/src/message_filters/delta_filter.py
+++ b/src/message_filters/delta_filter.py
@@ -31,7 +31,7 @@ from abc import ABC
 from functools import partial
 from typing import Any, Callable
 
-from message_filters import SimpleFilter
+from .simple_filter import SimpleFilter
 from rclpy.type_support import MsgT
 
 

--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -1,0 +1,151 @@
+from bisect import insort_right
+from dataclasses import dataclass
+import threading
+
+from builtin_interfaces.msg import Time as TimeMsg
+from rclpy.duration import Duration
+from rclpy.time import Time
+
+
+@dataclass
+class QueueStatus:
+    active: bool
+    queue_size: int
+    msgs_processed: int
+    msgs_dropped: int
+
+
+class _Signal:
+    def __init__(self):
+        self.callbacks = {}
+
+    def registerCallback(self, cb, *args):
+        conn = len(self.callbacks)
+        self.callbacks[conn] = (cb, args)
+        return conn
+
+    def signalMessage(self, *msg):
+        for (cb, args) in self.callbacks.values():
+            cb(*(msg + args))
+
+
+def _ros_zero_time():
+    return Time.from_msg(TimeMsg())
+
+
+def _ros_max_time():
+    zero = _ros_zero_time()
+    return Time(nanoseconds=9223372036854775807, clock_type=zero.clock_type)
+
+
+class _EventQueue:
+    def __init__(self):
+        self.events = []
+        self.next_ts = _ros_max_time()
+        self.period = Duration(seconds=0)
+        self.active = False
+        self.msgs_processed = 0
+        self.msgs_dropped = 0
+
+    def first_timestamp(self):
+        if self.events:
+            first_ts = self.events[0][0]
+            self.next_ts = first_ts + self.period
+            self.active = True
+            return first_ts
+        if self.active:
+            return self.next_ts
+        return _ros_max_time()
+
+    def pop_first(self):
+        self.events.pop(0)
+        self.msgs_processed += 1
+
+    def msg_dropped(self):
+        self.msgs_dropped += 1
+
+    def set_period(self, period):
+        self.period = period
+
+    def set_active(self, active):
+        self.active = active
+
+    def get_status(self):
+        return QueueStatus(self.active, len(self.events), self.msgs_processed, self.msgs_dropped)
+
+
+class InputAligner:
+    def __init__(self, timeout, *filters):
+        self.timeout = timeout
+        zero_time = _ros_zero_time()
+        self.last_in_ts = zero_time
+        self.last_out_ts = zero_time
+        self.name = ''
+        self.lock = threading.Lock()
+        self.event_queues = []
+        self.input_connections = []
+        self.signals = []
+        self.dispatch_timer = None
+        if filters:
+            self.connectInput(*filters)
+
+    def connectInput(self, *filters):
+        self.disconnectAll()
+        self.event_queues = [_EventQueue() for _ in filters]
+        self.signals = [_Signal() for _ in filters]
+        self.input_connections = [f.registerCallback(self.add, idx) for idx, f in enumerate(filters)]
+
+    def disconnectAll(self):
+        self.input_connections = []
+
+    def registerCallback(self, index, cb, *args):
+        return self.signals[index].registerCallback(cb, *args)
+
+    def setName(self, name):
+        self.name = name
+
+    def getName(self):
+        return self.name
+
+    def add(self, msg, queue_index):
+        msg_timestamp = Time.from_msg(msg.header.stamp)
+        with self.lock:
+            queue = self.event_queues[queue_index]
+            if msg_timestamp < self.last_out_ts:
+                queue.msg_dropped()
+                return
+            if msg_timestamp > self.last_in_ts:
+                self.last_in_ts = msg_timestamp
+            insort_right(queue.events, (msg_timestamp, msg), key=lambda x: x[0].nanoseconds)
+
+    def setInputPeriod(self, index, period):
+        self.event_queues[index].set_period(period)
+
+    def getQueueStatus(self, index):
+        return self.event_queues[index].get_status()
+
+    def setupDispatchTimer(self, node, update_rate):
+        self.dispatch_timer = node.create_timer(update_rate.nanoseconds / 1e9, self.dispatchMessages)
+
+    def dispatchMessages(self):
+        with self.lock:
+            if not any(queue.events for queue in self.event_queues):
+                return
+            input_available = True
+            while input_available:
+                input_available = self._dispatch_first_message()
+
+    def _dispatch_first_message(self):
+        timestamps = [queue.first_timestamp() for queue in self.event_queues]
+        idx = min(range(len(timestamps)), key=lambda i: timestamps[i].nanoseconds)
+        queue = self.event_queues[idx]
+        if queue.events:
+            stamp, msg = queue.events[0]
+            self.last_out_ts = stamp
+            self.signals[idx].signalMessage(msg)
+            queue.pop_first()
+            return True
+        if (self.last_in_ts - queue.first_timestamp()) >= self.timeout:
+            queue.set_active(False)
+            return True
+        return False

--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -1,6 +1,6 @@
 from bisect import insort_right
 from dataclasses import dataclass
-from queue import PriorityQueue
+from queue import Queue
 import threading
 
 from builtin_interfaces.msg import Time as TimeMsg
@@ -42,7 +42,7 @@ def _ros_max_time():
 
 class _EventQueue:
     def __init__(self):
-        self.events = PriorityQueue()
+        self.events = Queue()
         self.next_ts = _ros_max_time()
         self.period = Duration(seconds=0)
         self.active = False

--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -31,7 +31,7 @@ class _Signal:
             cb(*(msg + args))
 
 
-def _ros_zero_time():
+def _ros_zero_time() -> Time:
     return Time.from_msg(TimeMsg())
 
 
@@ -103,7 +103,12 @@ class InputAligner(SimpleFilter):
     def disconnectAll(self):
         self.input_connections = []
 
-    def registerCallback(self, index, cb, *args):
+    def registerCallback(
+        self,
+        index: int,
+        callback: tp.Callable[..., tp.Any],
+        *args: tp.Any,
+    ) -> None:
         return self.signals[index].registerCallback(cb, *args)
 
     def setName(self, name):

--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -34,9 +34,10 @@ import threading
 import typing as tp
 
 from builtin_interfaces.msg import Time as TimeMsg
-from message_filters import SimpleFilter
 from rclpy.duration import Duration
 from rclpy.time import Time
+
+from .simple_filter import SimpleFilter
 
 
 @dataclass

--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -61,7 +61,8 @@ def _ros_max_time() -> Time:
 
 
 class InputAligner:
-    """Align N inputs by timestamp and forward each to its own output signal.
+    """
+    Align N inputs by timestamp and forward each to its own output signal.
 
     Unlike a single-output filter, ``InputAligner`` exposes one signal per
     input, so it does not extend :class:`SimpleFilter`. Register downstream
@@ -69,6 +70,7 @@ class InputAligner:
     """
 
     class _EventQueue:
+
         def __init__(self) -> None:
             self.events: list[tuple[Time, int, tp.Any]] = []
             self.next_ts: Time = _ros_max_time()
@@ -138,7 +140,8 @@ class InputAligner:
         self,
         filters: tp.Sequence[SimpleFilter],
     ) -> None:
-        """Connect ``filters`` as inputs, replacing any existing inputs.
+        """
+        Connect ``filters`` as inputs, replacing any existing inputs.
 
         Note: previously-registered downstream callbacks are also dropped,
         since the per-input signals are recreated.
@@ -165,7 +168,7 @@ class InputAligner:
     def registerCallback(
         self,
         index: int,
-        callback: tp.Callable, #TODO: @EsipovPA Fix typing for callable
+        callback: tp.Callable,  # TODO: @EsipovPA Fix typing for callable
         *args: tp.Any,
     ) -> int:
         return self.signals[index].registerCallback(callback, *args)

--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -29,7 +29,7 @@
 """Input aligner for synchronizing messages from multiple sources based on their timestamps."""
 
 from dataclasses import dataclass
-from queue import PriorityQueue as Queue
+from queue import PriorityQueue
 import threading
 import typing as tp
 
@@ -75,7 +75,7 @@ def _ros_max_time() -> Time:
 
 class _EventQueue:
     def __init__(self) -> None:
-        self.events: Queue = Queue()
+        self.events: PriorityQueue = PriorityQueue()
         self.next_ts: Time = _ros_max_time()
         self.period: Duration = Duration(seconds=0)
         self.active: bool = False

--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -1,5 +1,6 @@
 from bisect import insort_right
 from dataclasses import dataclass
+from queue import PriorityQueue
 import threading
 
 from builtin_interfaces.msg import Time as TimeMsg
@@ -41,7 +42,7 @@ def _ros_max_time():
 
 class _EventQueue:
     def __init__(self):
-        self.events = []
+        self.events = PriorityQueue()
         self.next_ts = _ros_max_time()
         self.period = Duration(seconds=0)
         self.active = False
@@ -49,8 +50,8 @@ class _EventQueue:
         self.msgs_dropped = 0
 
     def first_timestamp(self):
-        if self.events:
-            first_ts = self.events[0][0]
+        if not self.events.empty():
+            first_ts = self.events.queue[0][0]
             self.next_ts = first_ts + self.period
             self.active = True
             return first_ts
@@ -59,7 +60,7 @@ class _EventQueue:
         return _ros_max_time()
 
     def pop_first(self):
-        self.events.pop(0)
+        self.events.get_nowait()
         self.msgs_processed += 1
 
     def msg_dropped(self):
@@ -72,7 +73,7 @@ class _EventQueue:
         self.active = active
 
     def get_status(self):
-        return QueueStatus(self.active, len(self.events), self.msgs_processed, self.msgs_dropped)
+        return QueueStatus(self.active, self.events.qsize(), self.msgs_processed, self.msgs_dropped)
 
 
 class InputAligner(SimpleFilter):
@@ -118,7 +119,7 @@ class InputAligner(SimpleFilter):
                 return
             if msg_timestamp > self.last_in_ts:
                 self.last_in_ts = msg_timestamp
-            insort_right(queue.events, (msg_timestamp, msg), key=lambda x: x[0].nanoseconds)
+            insort_right(queue.events.queue, (msg_timestamp, msg), key=lambda x: x[0].nanoseconds)
 
     def setInputPeriod(self, index, period):
         self.event_queues[index].set_period(period)
@@ -131,7 +132,7 @@ class InputAligner(SimpleFilter):
 
     def dispatchMessages(self):
         with self.lock:
-            if not any(queue.events for queue in self.event_queues):
+            if not any(not queue.events.empty() for queue in self.event_queues):
                 return
             input_available = True
             while input_available:
@@ -141,8 +142,8 @@ class InputAligner(SimpleFilter):
         timestamps = [queue.first_timestamp() for queue in self.event_queues]
         idx = min(range(len(timestamps)), key=lambda i: timestamps[i].nanoseconds)
         queue = self.event_queues[idx]
-        if queue.events:
-            stamp, msg = queue.events[0]
+        if not queue.events.empty():
+            stamp, msg = queue.events.queue[0]
             self.last_out_ts = stamp
             self.signals[idx].signalMessage(msg)
             queue.pop_first()

--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -1,4 +1,4 @@
-# Copyright 2009, Willow Garage, Inc. All rights reserved.
+# Copyright 2026, Open Source Robotics Foundation, Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -160,7 +160,7 @@ class InputAligner:
     def registerCallback(
         self,
         index: int,
-        callback: tp.Callable[..., tp.Any],
+        callback: tp.Callable, #TODO: @EsipovPA Fix typing for callable
         *args: tp.Any,
     ) -> int:
         return self.signals[index].registerCallback(callback, *args)

--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -114,7 +114,7 @@ class InputAligner(SimpleFilter):
     def __init__(
         self,
         timeout: Duration,
-        *filters: SimpleFilter
+        filters: tp.Sequence[SimpleFilter] | None = None,
     ) -> None:
         SimpleFilter.__init__(self)
         self.timeout: Duration = timeout
@@ -127,12 +127,12 @@ class InputAligner(SimpleFilter):
         self.input_connections: list[tuple[SimpleFilter, int]] = []
         self.signals: list[InputAligner._Signal] = []
         self.dispatch_timer: tp.Any = None
-        if filters:
-            self.connectInput(*filters)
+        if filters is not None:
+            self.connectInput(filters=filters)
 
     def connectInput(
         self,
-        *filters: SimpleFilter
+        filters: tp.Sequence[SimpleFilter],
     ) -> None:
         with self.lock:
             self.disconnectAll()

--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -35,6 +35,7 @@ import typing as tp
 
 from builtin_interfaces.msg import Time as TimeMsg
 from rclpy.duration import Duration
+from rclpy.node import Node
 from rclpy.time import Time
 
 from .simple_filter import SimpleFilter
@@ -61,15 +62,15 @@ def _ros_max_time() -> Time:
 
 class InputAligner(SimpleFilter):
     class _Signal:
-        def __init__(self):
+        def __init__(self) -> None:
             self.callbacks = {}
 
-        def registerCallback(self, callback, *args):
+        def registerCallback(self, callback, *args) -> int:
             conn = len(self.callbacks)
             self.callbacks[conn] = (callback, args)
             return conn
 
-        def signalMessage(self, *msg):
+        def signalMessage(self, *msg) -> None:
             for (callback, args) in self.callbacks.values():
                 callback(*(msg + args))
 
@@ -178,7 +179,7 @@ class InputAligner(SimpleFilter):
     def getQueueStatus(self, index: int) -> QueueStatus:
         return self.event_queues[index].get_status()
 
-    def setupDispatchTimer(self, node: tp.Any, update_rate: Duration) -> None:
+    def setupDispatchTimer(self, node: Node, update_rate: Duration) -> None:
         self.dispatch_timer = node.create_timer(update_rate.nanoseconds / 1e9, self.dispatchMessages)
 
     def dispatchMessages(self) -> None:

--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -109,7 +109,12 @@ class InputAligner:
             self.active = active
 
         def get_status(self) -> QueueStatus:
-            return QueueStatus(self.active, len(self.events), self.msgs_processed, self.msgs_dropped)
+            return QueueStatus(
+                active=self.active,
+                queue_size=len(self.events),
+                msgs_processed=self.msgs_processed,
+                msgs_dropped=self.msgs_dropped
+            )
 
     def __init__(
         self,

--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 import threading
 
 from builtin_interfaces.msg import Time as TimeMsg
+from message_filters import SimpleFilter
 from rclpy.duration import Duration
 from rclpy.time import Time
 
@@ -74,8 +75,9 @@ class _EventQueue:
         return QueueStatus(self.active, len(self.events), self.msgs_processed, self.msgs_dropped)
 
 
-class InputAligner:
+class InputAligner(SimpleFilter):
     def __init__(self, timeout, *filters):
+        SimpleFilter.__init__(self)
         self.timeout = timeout
         zero_time = _ros_zero_time()
         self.last_in_ts = zero_time

--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -35,9 +35,11 @@ def _ros_zero_time():
     return Time.from_msg(TimeMsg())
 
 
-def _ros_max_time():
-    zero = _ros_zero_time()
-    return Time(nanoseconds=9223372036854775807, clock_type=zero.clock_type)
+def _ros_max_time() -> Time:
+    return Time(
+        nanoseconds=9223372036854775807,
+        clock_type=_ros_zero_time().clock_type,
+    )
 
 
 class _EventQueue:

--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -93,9 +93,11 @@ class InputAligner(SimpleFilter):
                 return self.next_ts
             return _ros_max_time()
 
-        def pop_first(self) -> None:
-            self.events.get_nowait()
+        def pop_first(self) -> tuple[Time, int, tp.Any] | None:
+            if self.events.empty():
+                return None
             self.msgs_processed += 1
+            return self.events.get_nowait()
 
         def msg_dropped(self) -> None:
             self.msgs_dropped += 1

--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -1,3 +1,33 @@
+# Copyright 2009, Willow Garage, Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Willow Garage nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Input aligner for synchronizing messages from multiple sources based on their timestamps."""
+
 from dataclasses import dataclass
 from queue import PriorityQueue as Queue
 import threading

--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -29,7 +29,7 @@
 """Input aligner for synchronizing messages from multiple sources based on their timestamps."""
 
 from dataclasses import dataclass
-from queue import PriorityQueue
+import heapq
 import threading
 import typing as tp
 
@@ -60,23 +60,17 @@ def _ros_max_time() -> Time:
     )
 
 
-class InputAligner(SimpleFilter):
-    class _Signal:
-        def __init__(self) -> None:
-            self.callbacks = {}
+class InputAligner:
+    """Align N inputs by timestamp and forward each to its own output signal.
 
-        def registerCallback(self, callback, *args) -> int:
-            conn = len(self.callbacks)
-            self.callbacks[conn] = (callback, args)
-            return conn
-
-        def signalMessage(self, *msg) -> None:
-            for (callback, args) in self.callbacks.values():
-                callback(*(msg + args))
+    Unlike a single-output filter, ``InputAligner`` exposes one signal per
+    input, so it does not extend :class:`SimpleFilter`. Register downstream
+    callbacks via :meth:`registerCallback` with an explicit ``index``.
+    """
 
     class _EventQueue:
         def __init__(self) -> None:
-            self.events: PriorityQueue = PriorityQueue()
+            self.events: list[tuple[Time, int, tp.Any]] = []
             self.next_ts: Time = _ros_max_time()
             self.period: Duration = Duration(seconds=0)
             self.active: bool = False
@@ -84,9 +78,15 @@ class InputAligner(SimpleFilter):
             self.msgs_dropped: int = 0
             self.seq_id: int = 0
 
+        def push(self, stamp: Time, msg: tp.Any) -> None:
+            # seq_id is a strictly-increasing tie-breaker so messages with
+            # equal timestamps stay orderable (heap items are tuples).
+            heapq.heappush(self.events, (stamp, self.seq_id, msg))
+            self.seq_id += 1
+
         def first_timestamp(self) -> Time:
-            if not self.events.empty():
-                first_ts = self.events.queue[0][0]
+            if self.events:
+                first_ts = self.events[0][0]
                 self.next_ts = first_ts + self.period
                 self.active = True
                 return first_ts
@@ -94,11 +94,10 @@ class InputAligner(SimpleFilter):
                 return self.next_ts
             return _ros_max_time()
 
-        def pop_first(self) -> tuple[Time, int, tp.Any] | None:
-            if self.events.empty():
-                return None
+        def pop_first(self) -> tuple[Time, tp.Any]:
+            stamp, _, msg = heapq.heappop(self.events)
             self.msgs_processed += 1
-            return self.events.get_nowait()
+            return stamp, msg
 
         def msg_dropped(self) -> None:
             self.msgs_dropped += 1
@@ -110,23 +109,22 @@ class InputAligner(SimpleFilter):
             self.active = active
 
         def get_status(self) -> QueueStatus:
-            return QueueStatus(self.active, self.events.qsize(), self.msgs_processed, self.msgs_dropped)
+            return QueueStatus(self.active, len(self.events), self.msgs_processed, self.msgs_dropped)
 
     def __init__(
         self,
         timeout: Duration,
         filters: tp.Sequence[SimpleFilter] | None = None,
     ) -> None:
-        SimpleFilter.__init__(self)
         self.timeout: Duration = timeout
         zero_time = _ros_zero_time()
         self.last_in_ts: Time = zero_time
         self.last_out_ts: Time = zero_time
         self.name: str = ''
-        self.lock: threading.Lock = threading.Lock()
+        self.lock: threading.RLock = threading.RLock()
         self.event_queues: list[InputAligner._EventQueue] = []
         self.input_connections: list[tuple[SimpleFilter, int]] = []
-        self.signals: list[InputAligner._Signal] = []
+        self.signals: list[SimpleFilter] = []
         self.dispatch_timer: tp.Any = None
         if filters is not None:
             self.connectInput(filters=filters)
@@ -135,13 +133,26 @@ class InputAligner(SimpleFilter):
         self,
         filters: tp.Sequence[SimpleFilter],
     ) -> None:
+        """Connect ``filters`` as inputs, replacing any existing inputs.
+
+        Note: previously-registered downstream callbacks are also dropped,
+        since the per-input signals are recreated.
+        """
         with self.lock:
-            self.disconnectAll()
+            self._disconnect_all_locked()
             self.event_queues = [InputAligner._EventQueue() for _ in filters]
-            self.signals = [InputAligner._Signal() for _ in filters]
-            self.input_connections = [(f, f.registerCallback(self.add, idx)) for idx, f in enumerate(filters)]
+            self.signals = [SimpleFilter() for _ in filters]
+            # SimpleFilter.registerCallback appends extra args after the message,
+            # so registering ``self.add`` with ``idx`` invokes ``add(msg, idx)``.
+            self.input_connections = [
+                (f, f.registerCallback(self.add, idx)) for idx, f in enumerate(filters)
+            ]
 
     def disconnectAll(self) -> None:
+        with self.lock:
+            self._disconnect_all_locked()
+
+    def _disconnect_all_locked(self) -> None:
         for input_filter, conn in self.input_connections:
             input_filter.unregisterCallback(conn)
         self.input_connections = []
@@ -169,9 +180,7 @@ class InputAligner(SimpleFilter):
                 return
             if msg_timestamp > self.last_in_ts:
                 self.last_in_ts = msg_timestamp
-            # Use seq_id as a tie-breaker so duplicate timestamps stay orderable.
-            queue.events.put_nowait((msg_timestamp, queue.seq_id, msg))
-            queue.seq_id += 1
+            queue.push(msg_timestamp, msg)
 
     def setInputPeriod(self, index: int, period: Duration) -> None:
         self.event_queues[index].set_period(period)
@@ -180,25 +189,24 @@ class InputAligner(SimpleFilter):
         return self.event_queues[index].get_status()
 
     def setupDispatchTimer(self, node: Node, update_rate: Duration) -> None:
-        self.dispatch_timer = node.create_timer(update_rate.nanoseconds / 1e9, self.dispatchMessages)
+        self.dispatch_timer = node.create_timer(
+            update_rate.nanoseconds / 1e9, self.dispatchMessages)
 
     def dispatchMessages(self) -> None:
         with self.lock:
-            if not any(not queue.events.empty() for queue in self.event_queues):
+            if not any(queue.events for queue in self.event_queues):
                 return
-            input_available = True
-            while input_available:
-                input_available = self._dispatch_first_message()
+            while self._dispatch_first_message():
+                pass
 
     def _dispatch_first_message(self) -> bool:
         timestamps = [queue.first_timestamp() for queue in self.event_queues]
         idx = min(range(len(timestamps)), key=lambda i: timestamps[i].nanoseconds)
         queue = self.event_queues[idx]
-        if not queue.events.empty():
-            stamp, _, msg = queue.events.queue[0]
+        if queue.events:
+            stamp, msg = queue.pop_first()
             self.last_out_ts = stamp
             self.signals[idx].signalMessage(msg)
-            queue.pop_first()
             return True
         if (self.last_in_ts - queue.first_timestamp()) >= self.timeout:
             queue.set_active(False)

--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -62,7 +62,7 @@ class _EventQueue:
         return _ros_max_time()
 
     def pop_first(self):
-        self.events.get_nowait()
+        self.events.pop(0)
         self.msgs_processed += 1
 
     def msg_dropped(self):

--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -133,10 +133,11 @@ class InputAligner(SimpleFilter):
         self,
         *filters: SimpleFilter
     ) -> None:
-        self.disconnectAll()
-        self.event_queues = [_EventQueue() for _ in filters]
-        self.signals = [_Signal() for _ in filters]
-        self.input_connections = [(f, f.registerCallback(self.add, idx)) for idx, f in enumerate(filters)]
+        with self.lock:
+            self.disconnectAll()
+            self.event_queues = [_EventQueue() for _ in filters]
+            self.signals = [_Signal() for _ in filters]
+            self.input_connections = [(f, f.registerCallback(self.add, idx)) for idx, f in enumerate(filters)]
 
     def disconnectAll(self) -> None:
         for input_filter, conn in self.input_connections:

--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -80,6 +80,7 @@ class _EventQueue:
         self.active: bool = False
         self.msgs_processed: int = 0
         self.msgs_dropped: int = 0
+        self.seq_id: int = 0
 
     def first_timestamp(self) -> Time:
         if not self.events.empty():
@@ -122,7 +123,7 @@ class InputAligner(SimpleFilter):
         self.name: str = ''
         self.lock: threading.Lock = threading.Lock()
         self.event_queues: list[_EventQueue] = []
-        self.input_connections: list[int] = []
+        self.input_connections: list[tuple[SimpleFilter, int]] = []
         self.signals: list[_Signal] = []
         self.dispatch_timer: tp.Any = None
         if filters:
@@ -135,9 +136,11 @@ class InputAligner(SimpleFilter):
         self.disconnectAll()
         self.event_queues = [_EventQueue() for _ in filters]
         self.signals = [_Signal() for _ in filters]
-        self.input_connections = [f.registerCallback(self.add, idx) for idx, f in enumerate(filters)]
+        self.input_connections = [(f, f.registerCallback(self.add, idx)) for idx, f in enumerate(filters)]
 
     def disconnectAll(self) -> None:
+        for input_filter, conn in self.input_connections:
+            input_filter.unregisterCallback(conn)
         self.input_connections = []
 
     def registerCallback(
@@ -163,7 +166,9 @@ class InputAligner(SimpleFilter):
                 return
             if msg_timestamp > self.last_in_ts:
                 self.last_in_ts = msg_timestamp
-            queue.events.put_nowait((msg_timestamp, msg))
+            # Use seq_id as a tie-breaker so duplicate timestamps stay orderable.
+            queue.events.put_nowait((msg_timestamp, queue.seq_id, msg))
+            queue.seq_id += 1
 
     def setInputPeriod(self, index: int, period: Duration) -> None:
         self.event_queues[index].set_period(period)
@@ -187,7 +192,7 @@ class InputAligner(SimpleFilter):
         idx = min(range(len(timestamps)), key=lambda i: timestamps[i].nanoseconds)
         queue = self.event_queues[idx]
         if not queue.events.empty():
-            stamp, msg = queue.events.queue[0]
+            stamp, _, msg = queue.events.queue[0]
             self.last_out_ts = stamp
             self.signals[idx].signalMessage(msg)
             queue.pop_first()

--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -1,7 +1,7 @@
-from bisect import insort_right
 from dataclasses import dataclass
-from queue import Queue
+from queue import PriorityQueue as Queue
 import threading
+import typing as tp
 
 from builtin_interfaces.msg import Time as TimeMsg
 from message_filters import SimpleFilter
@@ -43,15 +43,15 @@ def _ros_max_time() -> Time:
 
 
 class _EventQueue:
-    def __init__(self):
-        self.events = Queue()
-        self.next_ts = _ros_max_time()
-        self.period = Duration(seconds=0)
-        self.active = False
-        self.msgs_processed = 0
-        self.msgs_dropped = 0
+    def __init__(self) -> None:
+        self.events: Queue = Queue()
+        self.next_ts: Time = _ros_max_time()
+        self.period: Duration = Duration(seconds=0)
+        self.active: bool = False
+        self.msgs_processed: int = 0
+        self.msgs_dropped: int = 0
 
-    def first_timestamp(self):
+    def first_timestamp(self) -> Time:
         if not self.events.empty():
             first_ts = self.events.queue[0][0]
             self.next_ts = first_ts + self.period
@@ -61,46 +61,46 @@ class _EventQueue:
             return self.next_ts
         return _ros_max_time()
 
-    def pop_first(self):
-        self.events.pop(0)
+    def pop_first(self) -> None:
+        self.events.get_nowait()
         self.msgs_processed += 1
 
-    def msg_dropped(self):
+    def msg_dropped(self) -> None:
         self.msgs_dropped += 1
 
-    def set_period(self, period):
+    def set_period(self, period: Duration) -> None:
         self.period = period
 
-    def set_active(self, active):
+    def set_active(self, active: bool) -> None:
         self.active = active
 
-    def get_status(self):
+    def get_status(self) -> QueueStatus:
         return QueueStatus(self.active, self.events.qsize(), self.msgs_processed, self.msgs_dropped)
 
 
 class InputAligner(SimpleFilter):
-    def __init__(self, timeout, *filters):
+    def __init__(self, timeout: Duration, *filters: SimpleFilter) -> None:
         SimpleFilter.__init__(self)
-        self.timeout = timeout
+        self.timeout: Duration = timeout
         zero_time = _ros_zero_time()
-        self.last_in_ts = zero_time
-        self.last_out_ts = zero_time
-        self.name = ''
-        self.lock = threading.Lock()
-        self.event_queues = []
-        self.input_connections = []
-        self.signals = []
-        self.dispatch_timer = None
+        self.last_in_ts: Time = zero_time
+        self.last_out_ts: Time = zero_time
+        self.name: str = ''
+        self.lock: threading.Lock = threading.Lock()
+        self.event_queues: list[_EventQueue] = []
+        self.input_connections: list[int] = []
+        self.signals: list[_Signal] = []
+        self.dispatch_timer: tp.Any = None
         if filters:
             self.connectInput(*filters)
 
-    def connectInput(self, *filters):
+    def connectInput(self, *filters: SimpleFilter) -> None:
         self.disconnectAll()
         self.event_queues = [_EventQueue() for _ in filters]
         self.signals = [_Signal() for _ in filters]
         self.input_connections = [f.registerCallback(self.add, idx) for idx, f in enumerate(filters)]
 
-    def disconnectAll(self):
+    def disconnectAll(self) -> None:
         self.input_connections = []
 
     def registerCallback(
@@ -108,16 +108,16 @@ class InputAligner(SimpleFilter):
         index: int,
         callback: tp.Callable[..., tp.Any],
         *args: tp.Any,
-    ) -> None:
-        return self.signals[index].registerCallback(cb, *args)
+    ) -> int:
+        return self.signals[index].registerCallback(callback, *args)
 
-    def setName(self, name):
+    def setName(self, name: str) -> None:
         self.name = name
 
-    def getName(self):
+    def getName(self) -> str:
         return self.name
 
-    def add(self, msg, queue_index):
+    def add(self, msg: tp.Any, queue_index: int) -> None:
         msg_timestamp = Time.from_msg(msg.header.stamp)
         with self.lock:
             queue = self.event_queues[queue_index]
@@ -126,18 +126,18 @@ class InputAligner(SimpleFilter):
                 return
             if msg_timestamp > self.last_in_ts:
                 self.last_in_ts = msg_timestamp
-            insort_right(queue.events.queue, (msg_timestamp, msg), key=lambda x: x[0].nanoseconds)
+            queue.events.put_nowait((msg_timestamp, msg))
 
-    def setInputPeriod(self, index, period):
+    def setInputPeriod(self, index: int, period: Duration) -> None:
         self.event_queues[index].set_period(period)
 
-    def getQueueStatus(self, index):
+    def getQueueStatus(self, index: int) -> QueueStatus:
         return self.event_queues[index].get_status()
 
-    def setupDispatchTimer(self, node, update_rate):
+    def setupDispatchTimer(self, node: tp.Any, update_rate: Duration) -> None:
         self.dispatch_timer = node.create_timer(update_rate.nanoseconds / 1e9, self.dispatchMessages)
 
-    def dispatchMessages(self):
+    def dispatchMessages(self) -> None:
         with self.lock:
             if not any(not queue.events.empty() for queue in self.event_queues):
                 return
@@ -145,7 +145,7 @@ class InputAligner(SimpleFilter):
             while input_available:
                 input_available = self._dispatch_first_message()
 
-    def _dispatch_first_message(self):
+    def _dispatch_first_message(self) -> bool:
         timestamps = [queue.first_timestamp() for queue in self.event_queues]
         idx = min(range(len(timestamps)), key=lambda i: timestamps[i].nanoseconds)
         queue = self.event_queues[idx]

--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -79,7 +79,11 @@ class _EventQueue:
 
 
 class InputAligner(SimpleFilter):
-    def __init__(self, timeout: Duration, *filters: SimpleFilter) -> None:
+    def __init__(
+        self,
+        timeout: Duration,
+        *filters: SimpleFilter
+    ) -> None:
         SimpleFilter.__init__(self)
         self.timeout: Duration = timeout
         zero_time = _ros_zero_time()
@@ -94,7 +98,10 @@ class InputAligner(SimpleFilter):
         if filters:
             self.connectInput(*filters)
 
-    def connectInput(self, *filters: SimpleFilter) -> None:
+    def connectInput(
+        self,
+        *filters: SimpleFilter
+    ) -> None:
         self.disconnectAll()
         self.event_queues = [_EventQueue() for _ in filters]
         self.signals = [_Signal() for _ in filters]

--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -52,14 +52,14 @@ class _Signal:
     def __init__(self):
         self.callbacks = {}
 
-    def registerCallback(self, cb, *args):
+    def registerCallback(self, callback, *args):
         conn = len(self.callbacks)
-        self.callbacks[conn] = (cb, args)
+        self.callbacks[conn] = (callback, args)
         return conn
 
     def signalMessage(self, *msg):
-        for (cb, args) in self.callbacks.values():
-            cb(*(msg + args))
+        for (callback, args) in self.callbacks.values():
+            callback(*(msg + args))
 
 
 def _ros_zero_time() -> Time:

--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -48,20 +48,6 @@ class QueueStatus:
     msgs_dropped: int
 
 
-class _Signal:
-    def __init__(self):
-        self.callbacks = {}
-
-    def registerCallback(self, callback, *args):
-        conn = len(self.callbacks)
-        self.callbacks[conn] = (callback, args)
-        return conn
-
-    def signalMessage(self, *msg):
-        for (callback, args) in self.callbacks.values():
-            callback(*(msg + args))
-
-
 def _ros_zero_time() -> Time:
     return Time.from_msg(TimeMsg())
 
@@ -73,44 +59,56 @@ def _ros_max_time() -> Time:
     )
 
 
-class _EventQueue:
-    def __init__(self) -> None:
-        self.events: PriorityQueue = PriorityQueue()
-        self.next_ts: Time = _ros_max_time()
-        self.period: Duration = Duration(seconds=0)
-        self.active: bool = False
-        self.msgs_processed: int = 0
-        self.msgs_dropped: int = 0
-        self.seq_id: int = 0
-
-    def first_timestamp(self) -> Time:
-        if not self.events.empty():
-            first_ts = self.events.queue[0][0]
-            self.next_ts = first_ts + self.period
-            self.active = True
-            return first_ts
-        if self.active:
-            return self.next_ts
-        return _ros_max_time()
-
-    def pop_first(self) -> None:
-        self.events.get_nowait()
-        self.msgs_processed += 1
-
-    def msg_dropped(self) -> None:
-        self.msgs_dropped += 1
-
-    def set_period(self, period: Duration) -> None:
-        self.period = period
-
-    def set_active(self, active: bool) -> None:
-        self.active = active
-
-    def get_status(self) -> QueueStatus:
-        return QueueStatus(self.active, self.events.qsize(), self.msgs_processed, self.msgs_dropped)
-
-
 class InputAligner(SimpleFilter):
+    class _Signal:
+        def __init__(self):
+            self.callbacks = {}
+
+        def registerCallback(self, callback, *args):
+            conn = len(self.callbacks)
+            self.callbacks[conn] = (callback, args)
+            return conn
+
+        def signalMessage(self, *msg):
+            for (callback, args) in self.callbacks.values():
+                callback(*(msg + args))
+
+    class _EventQueue:
+        def __init__(self) -> None:
+            self.events: PriorityQueue = PriorityQueue()
+            self.next_ts: Time = _ros_max_time()
+            self.period: Duration = Duration(seconds=0)
+            self.active: bool = False
+            self.msgs_processed: int = 0
+            self.msgs_dropped: int = 0
+            self.seq_id: int = 0
+
+        def first_timestamp(self) -> Time:
+            if not self.events.empty():
+                first_ts = self.events.queue[0][0]
+                self.next_ts = first_ts + self.period
+                self.active = True
+                return first_ts
+            if self.active:
+                return self.next_ts
+            return _ros_max_time()
+
+        def pop_first(self) -> None:
+            self.events.get_nowait()
+            self.msgs_processed += 1
+
+        def msg_dropped(self) -> None:
+            self.msgs_dropped += 1
+
+        def set_period(self, period: Duration) -> None:
+            self.period = period
+
+        def set_active(self, active: bool) -> None:
+            self.active = active
+
+        def get_status(self) -> QueueStatus:
+            return QueueStatus(self.active, self.events.qsize(), self.msgs_processed, self.msgs_dropped)
+
     def __init__(
         self,
         timeout: Duration,
@@ -123,9 +121,9 @@ class InputAligner(SimpleFilter):
         self.last_out_ts: Time = zero_time
         self.name: str = ''
         self.lock: threading.Lock = threading.Lock()
-        self.event_queues: list[_EventQueue] = []
+        self.event_queues: list[InputAligner._EventQueue] = []
         self.input_connections: list[tuple[SimpleFilter, int]] = []
-        self.signals: list[_Signal] = []
+        self.signals: list[InputAligner._Signal] = []
         self.dispatch_timer: tp.Any = None
         if filters:
             self.connectInput(*filters)
@@ -136,8 +134,8 @@ class InputAligner(SimpleFilter):
     ) -> None:
         with self.lock:
             self.disconnectAll()
-            self.event_queues = [_EventQueue() for _ in filters]
-            self.signals = [_Signal() for _ in filters]
+            self.event_queues = [InputAligner._EventQueue() for _ in filters]
+            self.signals = [InputAligner._Signal() for _ in filters]
             self.input_connections = [(f, f.registerCallback(self.add, idx)) for idx, f in enumerate(filters)]
 
     def disconnectAll(self) -> None:

--- a/src/message_filters/simple_filter.py
+++ b/src/message_filters/simple_filter.py
@@ -1,0 +1,52 @@
+# Copyright 2009, Willow Garage, Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Willow Garage nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+class SimpleFilter:
+
+    def __init__(self):
+        self.callbacks = {}
+
+    def registerCallback(self, callback, *args):
+        """
+        Register a callback `callback` to be called when this filter has output.
+
+        The filter calls the function ``callback`` with a filter-dependent.
+
+        list of arguments,followed by the call-supplied arguments ``args.``.
+        """
+        conn = len(self.callbacks)
+        self.callbacks[conn] = (callback, args)
+        return conn
+
+    def signalMessage(self, *msg):
+        for (callback, args) in self.callbacks.values():
+            callback(*(msg + args))
+
+    def unregisterCallback(self, conn):
+        self.callbacks.pop(conn, None)

--- a/src/message_filters/simple_filter.py
+++ b/src/message_filters/simple_filter.py
@@ -1,4 +1,4 @@
-# Copyright 2009, Willow Garage, Inc. All rights reserved.
+# Copyright 2026, Open Source Robotics Foundation, Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/test/test_input_aligner.py
+++ b/test/test_input_aligner.py
@@ -1,0 +1,203 @@
+import time
+import unittest
+
+from builtin_interfaces.msg import Time as TimeMsg
+from message_filters import InputAligner, SimpleFilter
+import rclpy
+from rclpy.duration import Duration
+from rclpy.time import Time
+
+
+class Header:
+    def __init__(self, stamp=None):
+        self.stamp = stamp if stamp is not None else TimeMsg()
+
+
+class Msg1:
+    def __init__(self, stamp=None, data=None):
+        self.header = Header(stamp)
+        self.data = data
+
+
+class Msg2:
+    def __init__(self, stamp=None, data=None):
+        self.header = Header(stamp)
+        self.data = data
+
+
+class TestInputAligner(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = rclpy.create_node('test_input_aligner_node')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.timeout = Duration(seconds=1.0)
+        self.update_rate = Duration(nanoseconds=10000000)
+        self.cb_content = []
+
+    def cb(self, msg):
+        self.cb_content.append(msg.data)
+
+    def create_msg(self, cls, milliseconds, data):
+        return cls(stamp=Time(nanoseconds=int(milliseconds * 1e6)).to_msg(), data=data)
+
+    def test_init(self):
+        f0, f1, f2, f3 = SimpleFilter(), SimpleFilter(), SimpleFilter(), SimpleFilter()
+        aligner1 = InputAligner(self.timeout, f0, f1, f2, f3)
+        self.assertEqual(len(aligner1.event_queues), 4)
+        aligner2 = InputAligner(self.timeout)
+        aligner2.connectInput(f0, f2, f3)
+        self.assertEqual(len(aligner2.event_queues), 3)
+
+    def test_dispatch_inputs_in_order(self):
+        aligner = InputAligner(self.timeout)
+        aligner.connectInput(SimpleFilter(), SimpleFilter(), SimpleFilter(), SimpleFilter())
+        for i in range(4):
+            aligner.registerCallback(i, self.cb)
+            aligner.setInputPeriod(i, Duration(nanoseconds=int(4e6)))
+        aligner.add(self.create_msg(Msg1, 3, 3), 2)
+        aligner.add(self.create_msg(Msg1, 1, 1), 0)
+        aligner.add(self.create_msg(Msg1, 7, 7), 2)
+        aligner.add(self.create_msg(Msg1, 5, 5), 0)
+        aligner.add(self.create_msg(Msg2, 2, 2), 3)
+        aligner.add(self.create_msg(Msg1, 9, 9), 0)
+        aligner.add(self.create_msg(Msg2, 4, 4), 1)
+        aligner.add(self.create_msg(Msg2, 8, 8), 1)
+        aligner.add(self.create_msg(Msg2, 6, 6), 3)
+        aligner.dispatchMessages()
+        self.assertEqual(self.cb_content, list(range(1, 10)))
+
+    def test_ignores_inactive_inputs(self):
+        aligner = InputAligner(self.timeout)
+        aligner.connectInput(SimpleFilter(), SimpleFilter(), SimpleFilter())
+        for i in range(3):
+            aligner.registerCallback(i, self.cb)
+            aligner.setInputPeriod(i, Duration(nanoseconds=int(2e6)))
+        aligner.add(self.create_msg(Msg1, 2, 2), 2)
+        aligner.add(self.create_msg(Msg2, 1, 1), 1)
+        aligner.add(self.create_msg(Msg1, 4, 4), 2)
+        aligner.add(self.create_msg(Msg2, 3, 3), 1)
+        aligner.add(self.create_msg(Msg2, 5, 5), 1)
+        aligner.dispatchMessages()
+        self.assertEqual(self.cb_content, [1, 2, 3, 4, 5])
+
+    def test_input_timeout(self):
+        self.timeout = Duration(nanoseconds=int(1e7))
+        aligner = InputAligner(self.timeout)
+        aligner.connectInput(SimpleFilter(), SimpleFilter())
+        for i in range(2):
+            aligner.registerCallback(i, self.cb)
+            aligner.setInputPeriod(i, Duration(nanoseconds=int(2e6)))
+        for i in range(1, 17, 2):
+            aligner.add(self.create_msg(Msg1, i, i), 0)
+        aligner.add(self.create_msg(Msg2, 2, 2), 1)
+        aligner.add(self.create_msg(Msg2, 4, 4), 1)
+        aligner.dispatchMessages()
+        self.assertEqual(self.cb_content, [1, 2, 3, 4, 5])
+        aligner.add(self.create_msg(Msg1, 17, 17), 0)
+        aligner.dispatchMessages()
+        self.assertEqual(self.cb_content, [1, 2, 3, 4, 5, 7, 9, 11, 13, 15, 17])
+
+    def test_drops_msgs(self):
+        aligner = InputAligner(self.timeout)
+        aligner.connectInput(SimpleFilter(), SimpleFilter())
+        for i in range(2):
+            aligner.registerCallback(i, self.cb)
+            aligner.setInputPeriod(i, Duration(nanoseconds=int(2e6)))
+        aligner.add(self.create_msg(Msg2, 4, 4), 1)
+        aligner.add(self.create_msg(Msg1, 3, 3), 0)
+        aligner.dispatchMessages()
+        self.assertEqual(self.cb_content, [3, 4])
+        aligner.add(self.create_msg(Msg1, 1, 1), 0)
+        aligner.add(self.create_msg(Msg1, 5, 5), 0)
+        aligner.add(self.create_msg(Msg1, 7, 7), 0)
+        aligner.add(self.create_msg(Msg2, 2, 2), 1)
+        aligner.add(self.create_msg(Msg2, 6, 6), 1)
+        aligner.dispatchMessages()
+        self.assertEqual(self.cb_content, [3, 4, 5, 6, 7])
+
+    def test_dispatch_by_timer(self):
+        aligner = InputAligner(self.timeout)
+        aligner.connectInput(SimpleFilter(), SimpleFilter())
+        aligner.setupDispatchTimer(self.node, self.update_rate)
+        for i in range(2):
+            aligner.registerCallback(i, self.cb)
+            aligner.setInputPeriod(i, Duration(nanoseconds=int(2e6)))
+        aligner.add(self.create_msg(Msg2, 2, 2), 1)
+        aligner.add(self.create_msg(Msg1, 1, 1), 0)
+        time.sleep(0.05)
+        rclpy.spin_once(self.node, timeout_sec=0.01)
+        self.assertEqual(self.cb_content, [1, 2])
+
+    def test_no_period_information(self):
+        self.timeout = Duration(nanoseconds=int(1e7))
+        aligner = InputAligner(self.timeout)
+        aligner.connectInput(SimpleFilter(), SimpleFilter(), SimpleFilter())
+        for i in range(3):
+            aligner.registerCallback(i, self.cb)
+        aligner.add(self.create_msg(Msg1, 6, 6), 0)
+        aligner.add(self.create_msg(Msg1, 2, 2), 2)
+        aligner.add(self.create_msg(Msg1, 4, 4), 2)
+        aligner.add(self.create_msg(Msg2, 1, 1), 1)
+        aligner.add(self.create_msg(Msg2, 3, 3), 1)
+        aligner.add(self.create_msg(Msg2, 5, 5), 1)
+        aligner.dispatchMessages()
+        self.assertEqual(self.cb_content, [1, 2, 3, 4])
+        aligner.add(self.create_msg(Msg1, 16, 16), 0)
+        aligner.dispatchMessages()
+        self.assertEqual(self.cb_content, [1, 2, 3, 4, 5, 6, 16])
+
+    def test_get_queue_status(self):
+        self.timeout = Duration(nanoseconds=int(1e7))
+        aligner = InputAligner(self.timeout)
+        aligner.connectInput(SimpleFilter(), SimpleFilter())
+        for i in range(2):
+            aligner.registerCallback(i, self.cb)
+            aligner.setInputPeriod(i, Duration(nanoseconds=int(2e6)))
+        aligner.add(self.create_msg(Msg2, 2, 2), 1)
+        aligner.add(self.create_msg(Msg1, 3, 3), 0)
+        aligner.add(self.create_msg(Msg1, 5, 5), 0)
+        status_0 = aligner.getQueueStatus(0)
+        self.assertFalse(status_0.active)
+        self.assertEqual(status_0.queue_size, 2)
+        self.assertEqual(status_0.msgs_processed, 0)
+        self.assertEqual(status_0.msgs_dropped, 0)
+        status_1 = aligner.getQueueStatus(1)
+        self.assertFalse(status_1.active)
+        self.assertEqual(status_1.queue_size, 1)
+        self.assertEqual(status_1.msgs_processed, 0)
+        self.assertEqual(status_1.msgs_dropped, 0)
+        aligner.dispatchMessages()
+        status_0 = aligner.getQueueStatus(0)
+        self.assertTrue(status_0.active)
+        self.assertEqual(status_0.queue_size, 1)
+        self.assertEqual(status_0.msgs_processed, 1)
+        self.assertEqual(status_0.msgs_dropped, 0)
+        status_1 = aligner.getQueueStatus(1)
+        self.assertTrue(status_1.active)
+        self.assertEqual(status_1.queue_size, 0)
+        self.assertEqual(status_1.msgs_processed, 1)
+        self.assertEqual(status_1.msgs_dropped, 0)
+        aligner.add(self.create_msg(Msg1, 1, 1), 0)
+        aligner.add(self.create_msg(Msg1, 17, 17), 0)
+        aligner.dispatchMessages()
+        status_0 = aligner.getQueueStatus(0)
+        self.assertTrue(status_0.active)
+        self.assertEqual(status_0.queue_size, 0)
+        self.assertEqual(status_0.msgs_processed, 3)
+        self.assertEqual(status_0.msgs_dropped, 1)
+        status_1 = aligner.getQueueStatus(1)
+        self.assertFalse(status_1.active)
+        self.assertEqual(status_1.queue_size, 0)
+        self.assertEqual(status_1.msgs_processed, 1)
+        self.assertEqual(status_1.msgs_dropped, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_input_aligner.py
+++ b/test/test_input_aligner.py
@@ -73,6 +73,39 @@ class TestInputAligner(unittest.TestCase):
         aligner.dispatchMessages()
         self.assertEqual(self.cb_content, list(range(1, 10)))
 
+    def test_dispatch_inputs_with_duplicate_timestamps(self):
+        aligner = InputAligner(self.timeout)
+        aligner.connectInput(SimpleFilter(), SimpleFilter(), SimpleFilter(), SimpleFilter())
+        for i in range(4):
+            aligner.registerCallback(i, self.cb)
+            aligner.setInputPeriod(i, Duration(nanoseconds=int(4e6)))
+        aligner.add(self.create_msg(Msg1, 3, 3), 2)
+        aligner.add(self.create_msg(Msg1, 1, 1), 0)
+        aligner.add(self.create_msg(Msg1, 7, 7), 2)
+        aligner.add(self.create_msg(Msg1, 5, 5), 0)
+        aligner.add(self.create_msg(Msg2, 2, 2), 3)
+        aligner.add(self.create_msg(Msg1, 9, 9), 0)
+        aligner.add(self.create_msg(Msg2, 9, 9), 0)
+        aligner.add(self.create_msg(Msg2, 4, 4), 1)
+        aligner.add(self.create_msg(Msg2, 8, 8), 1)
+        aligner.add(self.create_msg(Msg2, 6, 6), 3)
+        aligner.dispatchMessages()
+        self.assertEqual(self.cb_content, [1, 2, 3, 4, 5, 6, 7, 8, 9, 9])
+
+    def test_reconnect_input_disconnects_old_callbacks(self):
+        f0, f1, f2 = SimpleFilter(), SimpleFilter(), SimpleFilter()
+        aligner = InputAligner(self.timeout)
+        aligner.connectInput(f0, f1, f2)
+        aligner.connectInput(f0, f1)
+        for i in range(2):
+            aligner.registerCallback(i, self.cb)
+            aligner.setInputPeriod(i, Duration(nanoseconds=int(2e6)))
+        f2.signalMessage(self.create_msg(Msg1, 1, 1))
+        f0.signalMessage(self.create_msg(Msg1, 2, 2))
+        f1.signalMessage(self.create_msg(Msg2, 3, 3))
+        aligner.dispatchMessages()
+        self.assertEqual(self.cb_content, [2, 3])
+
     def test_ignores_inactive_inputs(self):
         aligner = InputAligner(self.timeout)
         aligner.connectInput(SimpleFilter(), SimpleFilter(), SimpleFilter())

--- a/test/test_input_aligner.py
+++ b/test/test_input_aligner.py
@@ -49,15 +49,15 @@ class TestInputAligner(unittest.TestCase):
 
     def test_init(self):
         f0, f1, f2, f3 = SimpleFilter(), SimpleFilter(), SimpleFilter(), SimpleFilter()
-        aligner1 = InputAligner(self.timeout, f0, f1, f2, f3)
+        aligner1 = InputAligner(self.timeout, filters=[f0, f1, f2, f3])
         self.assertEqual(len(aligner1.event_queues), 4)
         aligner2 = InputAligner(self.timeout)
-        aligner2.connectInput(f0, f2, f3)
+        aligner2.connectInput(filters=[f0, f2, f3])
         self.assertEqual(len(aligner2.event_queues), 3)
 
     def test_dispatch_inputs_in_order(self):
         aligner = InputAligner(self.timeout)
-        aligner.connectInput(SimpleFilter(), SimpleFilter(), SimpleFilter(), SimpleFilter())
+        aligner.connectInput(filters=[SimpleFilter(), SimpleFilter(), SimpleFilter(), SimpleFilter()])
         for i in range(4):
             aligner.registerCallback(i, self.callback)
             aligner.setInputPeriod(i, Duration(nanoseconds=int(4e6)))
@@ -75,7 +75,7 @@ class TestInputAligner(unittest.TestCase):
 
     def test_dispatch_inputs_with_duplicate_timestamps(self):
         aligner = InputAligner(self.timeout)
-        aligner.connectInput(SimpleFilter(), SimpleFilter(), SimpleFilter(), SimpleFilter())
+        aligner.connectInput(filters=[SimpleFilter(), SimpleFilter(), SimpleFilter(), SimpleFilter()])
         for i in range(4):
             aligner.registerCallback(i, self.callback)
             aligner.setInputPeriod(i, Duration(nanoseconds=int(4e6)))
@@ -95,8 +95,8 @@ class TestInputAligner(unittest.TestCase):
     def test_reconnect_input_disconnects_old_callbacks(self):
         f0, f1, f2 = SimpleFilter(), SimpleFilter(), SimpleFilter()
         aligner = InputAligner(self.timeout)
-        aligner.connectInput(f0, f1, f2)
-        aligner.connectInput(f0, f1)
+        aligner.connectInput(filters=[f0, f1, f2])
+        aligner.connectInput(filters=[f0, f1])
         for i in range(2):
             aligner.registerCallback(i, self.callback)
             aligner.setInputPeriod(i, Duration(nanoseconds=int(2e6)))
@@ -108,7 +108,7 @@ class TestInputAligner(unittest.TestCase):
 
     def test_ignores_inactive_inputs(self):
         aligner = InputAligner(self.timeout)
-        aligner.connectInput(SimpleFilter(), SimpleFilter(), SimpleFilter())
+        aligner.connectInput(filters=[SimpleFilter(), SimpleFilter(), SimpleFilter()])
         for i in range(3):
             aligner.registerCallback(i, self.callback)
             aligner.setInputPeriod(i, Duration(nanoseconds=int(2e6)))
@@ -123,7 +123,7 @@ class TestInputAligner(unittest.TestCase):
     def test_input_timeout(self):
         self.timeout = Duration(nanoseconds=int(1e7))
         aligner = InputAligner(self.timeout)
-        aligner.connectInput(SimpleFilter(), SimpleFilter())
+        aligner.connectInput(filters=[SimpleFilter(), SimpleFilter()])
         for i in range(2):
             aligner.registerCallback(i, self.callback)
             aligner.setInputPeriod(i, Duration(nanoseconds=int(2e6)))
@@ -139,7 +139,7 @@ class TestInputAligner(unittest.TestCase):
 
     def test_drops_msgs(self):
         aligner = InputAligner(self.timeout)
-        aligner.connectInput(SimpleFilter(), SimpleFilter())
+        aligner.connectInput(filters=[SimpleFilter(), SimpleFilter()])
         for i in range(2):
             aligner.registerCallback(i, self.callback)
             aligner.setInputPeriod(i, Duration(nanoseconds=int(2e6)))
@@ -157,7 +157,7 @@ class TestInputAligner(unittest.TestCase):
 
     def test_dispatch_by_timer(self):
         aligner = InputAligner(self.timeout)
-        aligner.connectInput(SimpleFilter(), SimpleFilter())
+        aligner.connectInput(filters=[SimpleFilter(), SimpleFilter()])
         aligner.setupDispatchTimer(self.node, self.update_rate)
         for i in range(2):
             aligner.registerCallback(i, self.callback)
@@ -171,7 +171,7 @@ class TestInputAligner(unittest.TestCase):
     def test_no_period_information(self):
         self.timeout = Duration(nanoseconds=int(1e7))
         aligner = InputAligner(self.timeout)
-        aligner.connectInput(SimpleFilter(), SimpleFilter(), SimpleFilter())
+        aligner.connectInput(filters=[SimpleFilter(), SimpleFilter(), SimpleFilter()])
         for i in range(3):
             aligner.registerCallback(i, self.callback)
         aligner.add(self.create_msg(Msg1, 6, 6), 0)
@@ -189,7 +189,7 @@ class TestInputAligner(unittest.TestCase):
     def test_get_queue_status(self):
         self.timeout = Duration(nanoseconds=int(1e7))
         aligner = InputAligner(self.timeout)
-        aligner.connectInput(SimpleFilter(), SimpleFilter())
+        aligner.connectInput(filters=[SimpleFilter(), SimpleFilter()])
         for i in range(2):
             aligner.registerCallback(i, self.callback)
             aligner.setInputPeriod(i, Duration(nanoseconds=int(2e6)))

--- a/test/test_input_aligner.py
+++ b/test/test_input_aligner.py
@@ -189,7 +189,7 @@ class TestInputAligner(unittest.TestCase):
         received = []
         f = SimpleFilter()
         conn_a = f.registerCallback(lambda m: received.append(('a', m)))
-        conn_b = f.registerCallback(lambda m: received.append(('b', m)))
+        f.registerCallback(lambda m: received.append(('b', m)))
         f.signalMessage(1)
         self.assertEqual(received, [('a', 1), ('b', 1)])
         f.unregisterCallback(conn_a)

--- a/test/test_input_aligner.py
+++ b/test/test_input_aligner.py
@@ -39,10 +39,10 @@ class TestInputAligner(unittest.TestCase):
     def setUp(self):
         self.timeout = Duration(seconds=1.0)
         self.update_rate = Duration(nanoseconds=10000000)
-        self.cb_content = []
+        self.callback_content = []
 
-    def cb(self, msg):
-        self.cb_content.append(msg.data)
+    def callback(self, msg):
+        self.callback_content.append(msg.data)
 
     def create_msg(self, cls, milliseconds, data):
         return cls(stamp=Time(nanoseconds=int(milliseconds * 1e6)).to_msg(), data=data)
@@ -59,7 +59,7 @@ class TestInputAligner(unittest.TestCase):
         aligner = InputAligner(self.timeout)
         aligner.connectInput(SimpleFilter(), SimpleFilter(), SimpleFilter(), SimpleFilter())
         for i in range(4):
-            aligner.registerCallback(i, self.cb)
+            aligner.registerCallback(i, self.callback)
             aligner.setInputPeriod(i, Duration(nanoseconds=int(4e6)))
         aligner.add(self.create_msg(Msg1, 3, 3), 2)
         aligner.add(self.create_msg(Msg1, 1, 1), 0)
@@ -71,13 +71,13 @@ class TestInputAligner(unittest.TestCase):
         aligner.add(self.create_msg(Msg2, 8, 8), 1)
         aligner.add(self.create_msg(Msg2, 6, 6), 3)
         aligner.dispatchMessages()
-        self.assertEqual(self.cb_content, list(range(1, 10)))
+        self.assertEqual(self.callback_content, list(range(1, 10)))
 
     def test_dispatch_inputs_with_duplicate_timestamps(self):
         aligner = InputAligner(self.timeout)
         aligner.connectInput(SimpleFilter(), SimpleFilter(), SimpleFilter(), SimpleFilter())
         for i in range(4):
-            aligner.registerCallback(i, self.cb)
+            aligner.registerCallback(i, self.callback)
             aligner.setInputPeriod(i, Duration(nanoseconds=int(4e6)))
         aligner.add(self.create_msg(Msg1, 3, 3), 2)
         aligner.add(self.create_msg(Msg1, 1, 1), 0)
@@ -90,7 +90,7 @@ class TestInputAligner(unittest.TestCase):
         aligner.add(self.create_msg(Msg2, 8, 8), 1)
         aligner.add(self.create_msg(Msg2, 6, 6), 3)
         aligner.dispatchMessages()
-        self.assertEqual(self.cb_content, [1, 2, 3, 4, 5, 6, 7, 8, 9, 9])
+        self.assertEqual(self.callback_content, [1, 2, 3, 4, 5, 6, 7, 8, 9, 9])
 
     def test_reconnect_input_disconnects_old_callbacks(self):
         f0, f1, f2 = SimpleFilter(), SimpleFilter(), SimpleFilter()
@@ -98,19 +98,19 @@ class TestInputAligner(unittest.TestCase):
         aligner.connectInput(f0, f1, f2)
         aligner.connectInput(f0, f1)
         for i in range(2):
-            aligner.registerCallback(i, self.cb)
+            aligner.registerCallback(i, self.callback)
             aligner.setInputPeriod(i, Duration(nanoseconds=int(2e6)))
         f2.signalMessage(self.create_msg(Msg1, 1, 1))
         f0.signalMessage(self.create_msg(Msg1, 2, 2))
         f1.signalMessage(self.create_msg(Msg2, 3, 3))
         aligner.dispatchMessages()
-        self.assertEqual(self.cb_content, [2, 3])
+        self.assertEqual(self.callback_content, [2, 3])
 
     def test_ignores_inactive_inputs(self):
         aligner = InputAligner(self.timeout)
         aligner.connectInput(SimpleFilter(), SimpleFilter(), SimpleFilter())
         for i in range(3):
-            aligner.registerCallback(i, self.cb)
+            aligner.registerCallback(i, self.callback)
             aligner.setInputPeriod(i, Duration(nanoseconds=int(2e6)))
         aligner.add(self.create_msg(Msg1, 2, 2), 2)
         aligner.add(self.create_msg(Msg2, 1, 1), 1)
@@ -118,62 +118,62 @@ class TestInputAligner(unittest.TestCase):
         aligner.add(self.create_msg(Msg2, 3, 3), 1)
         aligner.add(self.create_msg(Msg2, 5, 5), 1)
         aligner.dispatchMessages()
-        self.assertEqual(self.cb_content, [1, 2, 3, 4, 5])
+        self.assertEqual(self.callback_content, [1, 2, 3, 4, 5])
 
     def test_input_timeout(self):
         self.timeout = Duration(nanoseconds=int(1e7))
         aligner = InputAligner(self.timeout)
         aligner.connectInput(SimpleFilter(), SimpleFilter())
         for i in range(2):
-            aligner.registerCallback(i, self.cb)
+            aligner.registerCallback(i, self.callback)
             aligner.setInputPeriod(i, Duration(nanoseconds=int(2e6)))
         for i in range(1, 17, 2):
             aligner.add(self.create_msg(Msg1, i, i), 0)
         aligner.add(self.create_msg(Msg2, 2, 2), 1)
         aligner.add(self.create_msg(Msg2, 4, 4), 1)
         aligner.dispatchMessages()
-        self.assertEqual(self.cb_content, [1, 2, 3, 4, 5])
+        self.assertEqual(self.callback_content, [1, 2, 3, 4, 5])
         aligner.add(self.create_msg(Msg1, 17, 17), 0)
         aligner.dispatchMessages()
-        self.assertEqual(self.cb_content, [1, 2, 3, 4, 5, 7, 9, 11, 13, 15, 17])
+        self.assertEqual(self.callback_content, [1, 2, 3, 4, 5, 7, 9, 11, 13, 15, 17])
 
     def test_drops_msgs(self):
         aligner = InputAligner(self.timeout)
         aligner.connectInput(SimpleFilter(), SimpleFilter())
         for i in range(2):
-            aligner.registerCallback(i, self.cb)
+            aligner.registerCallback(i, self.callback)
             aligner.setInputPeriod(i, Duration(nanoseconds=int(2e6)))
         aligner.add(self.create_msg(Msg2, 4, 4), 1)
         aligner.add(self.create_msg(Msg1, 3, 3), 0)
         aligner.dispatchMessages()
-        self.assertEqual(self.cb_content, [3, 4])
+        self.assertEqual(self.callback_content, [3, 4])
         aligner.add(self.create_msg(Msg1, 1, 1), 0)
         aligner.add(self.create_msg(Msg1, 5, 5), 0)
         aligner.add(self.create_msg(Msg1, 7, 7), 0)
         aligner.add(self.create_msg(Msg2, 2, 2), 1)
         aligner.add(self.create_msg(Msg2, 6, 6), 1)
         aligner.dispatchMessages()
-        self.assertEqual(self.cb_content, [3, 4, 5, 6, 7])
+        self.assertEqual(self.callback_content, [3, 4, 5, 6, 7])
 
     def test_dispatch_by_timer(self):
         aligner = InputAligner(self.timeout)
         aligner.connectInput(SimpleFilter(), SimpleFilter())
         aligner.setupDispatchTimer(self.node, self.update_rate)
         for i in range(2):
-            aligner.registerCallback(i, self.cb)
+            aligner.registerCallback(i, self.callback)
             aligner.setInputPeriod(i, Duration(nanoseconds=int(2e6)))
         aligner.add(self.create_msg(Msg2, 2, 2), 1)
         aligner.add(self.create_msg(Msg1, 1, 1), 0)
         time.sleep(0.05)
         rclpy.spin_once(self.node, timeout_sec=0.01)
-        self.assertEqual(self.cb_content, [1, 2])
+        self.assertEqual(self.callback_content, [1, 2])
 
     def test_no_period_information(self):
         self.timeout = Duration(nanoseconds=int(1e7))
         aligner = InputAligner(self.timeout)
         aligner.connectInput(SimpleFilter(), SimpleFilter(), SimpleFilter())
         for i in range(3):
-            aligner.registerCallback(i, self.cb)
+            aligner.registerCallback(i, self.callback)
         aligner.add(self.create_msg(Msg1, 6, 6), 0)
         aligner.add(self.create_msg(Msg1, 2, 2), 2)
         aligner.add(self.create_msg(Msg1, 4, 4), 2)
@@ -181,17 +181,17 @@ class TestInputAligner(unittest.TestCase):
         aligner.add(self.create_msg(Msg2, 3, 3), 1)
         aligner.add(self.create_msg(Msg2, 5, 5), 1)
         aligner.dispatchMessages()
-        self.assertEqual(self.cb_content, [1, 2, 3, 4])
+        self.assertEqual(self.callback_content, [1, 2, 3, 4])
         aligner.add(self.create_msg(Msg1, 16, 16), 0)
         aligner.dispatchMessages()
-        self.assertEqual(self.cb_content, [1, 2, 3, 4, 5, 6, 16])
+        self.assertEqual(self.callback_content, [1, 2, 3, 4, 5, 6, 16])
 
     def test_get_queue_status(self):
         self.timeout = Duration(nanoseconds=int(1e7))
         aligner = InputAligner(self.timeout)
         aligner.connectInput(SimpleFilter(), SimpleFilter())
         for i in range(2):
-            aligner.registerCallback(i, self.cb)
+            aligner.registerCallback(i, self.callback)
             aligner.setInputPeriod(i, Duration(nanoseconds=int(2e6)))
         aligner.add(self.create_msg(Msg2, 2, 2), 1)
         aligner.add(self.create_msg(Msg1, 3, 3), 0)

--- a/test/test_input_aligner.py
+++ b/test/test_input_aligner.py
@@ -31,30 +31,35 @@ import time
 import unittest
 
 from builtin_interfaces.msg import Time as TimeMsg
-from message_filters import InputAligner, SimpleFilter
+from message_filters import SimpleFilter
+from message_filters.input_aligner import InputAligner
 import rclpy
 from rclpy.duration import Duration
 from rclpy.time import Time
 
 
 class Header:
+
     def __init__(self, stamp=None):
         self.stamp = stamp if stamp is not None else TimeMsg()
 
 
 class Msg1:
+
     def __init__(self, stamp=None, data=None):
         self.header = Header(stamp)
         self.data = data
 
 
 class Msg2:
+
     def __init__(self, stamp=None, data=None):
         self.header = Header(stamp)
         self.data = data
 
 
 class TestInputAligner(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
         rclpy.init()

--- a/test/test_input_aligner.py
+++ b/test/test_input_aligner.py
@@ -1,3 +1,32 @@
+# Copyright 2026, Open Source Robotics Foundation, Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Willow Garage nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
 import time
 import unittest
 
@@ -55,9 +84,16 @@ class TestInputAligner(unittest.TestCase):
         aligner2.connectInput(filters=[f0, f2, f3])
         self.assertEqual(len(aligner2.event_queues), 3)
 
+    def test_set_and_get_name(self):
+        aligner = InputAligner(self.timeout)
+        self.assertEqual(aligner.getName(), '')
+        aligner.setName('camera_aligner')
+        self.assertEqual(aligner.getName(), 'camera_aligner')
+
     def test_dispatch_inputs_in_order(self):
         aligner = InputAligner(self.timeout)
-        aligner.connectInput(filters=[SimpleFilter(), SimpleFilter(), SimpleFilter(), SimpleFilter()])
+        aligner.connectInput(
+            filters=[SimpleFilter(), SimpleFilter(), SimpleFilter(), SimpleFilter()])
         for i in range(4):
             aligner.registerCallback(i, self.callback)
             aligner.setInputPeriod(i, Duration(nanoseconds=int(4e6)))
@@ -75,7 +111,8 @@ class TestInputAligner(unittest.TestCase):
 
     def test_dispatch_inputs_with_duplicate_timestamps(self):
         aligner = InputAligner(self.timeout)
-        aligner.connectInput(filters=[SimpleFilter(), SimpleFilter(), SimpleFilter(), SimpleFilter()])
+        aligner.connectInput(
+            filters=[SimpleFilter(), SimpleFilter(), SimpleFilter(), SimpleFilter()])
         for i in range(4):
             aligner.registerCallback(i, self.callback)
             aligner.setInputPeriod(i, Duration(nanoseconds=int(4e6)))
@@ -85,14 +122,16 @@ class TestInputAligner(unittest.TestCase):
         aligner.add(self.create_msg(Msg1, 5, 5), 0)
         aligner.add(self.create_msg(Msg2, 2, 2), 3)
         aligner.add(self.create_msg(Msg1, 9, 9), 0)
-        aligner.add(self.create_msg(Msg2, 9, 9), 0)
+        # Two messages with identical timestamp on the same queue should
+        # dispatch in insertion order via the seq_id tie-breaker.
+        aligner.add(self.create_msg(Msg1, 9, 9), 0)
         aligner.add(self.create_msg(Msg2, 4, 4), 1)
         aligner.add(self.create_msg(Msg2, 8, 8), 1)
         aligner.add(self.create_msg(Msg2, 6, 6), 3)
         aligner.dispatchMessages()
         self.assertEqual(self.callback_content, [1, 2, 3, 4, 5, 6, 7, 8, 9, 9])
 
-    def test_reconnect_input_disconnects_old_callbacks(self):
+    def test_reconnect_input_disconnects_old_upstream(self):
         f0, f1, f2 = SimpleFilter(), SimpleFilter(), SimpleFilter()
         aligner = InputAligner(self.timeout)
         aligner.connectInput(filters=[f0, f1, f2])
@@ -100,11 +139,62 @@ class TestInputAligner(unittest.TestCase):
         for i in range(2):
             aligner.registerCallback(i, self.callback)
             aligner.setInputPeriod(i, Duration(nanoseconds=int(2e6)))
+        # f2 was dropped on reconnect; messages from it must be ignored.
         f2.signalMessage(self.create_msg(Msg1, 1, 1))
         f0.signalMessage(self.create_msg(Msg1, 2, 2))
         f1.signalMessage(self.create_msg(Msg2, 3, 3))
         aligner.dispatchMessages()
         self.assertEqual(self.callback_content, [2, 3])
+
+    def test_reconnect_input_drops_old_downstream_callbacks(self):
+        # Callbacks registered before reconnect should be discarded along with
+        # the per-input signals they were attached to.
+        stale = []
+        fresh = []
+        f0, f1 = SimpleFilter(), SimpleFilter()
+        aligner = InputAligner(self.timeout)
+        aligner.connectInput(filters=[f0, f1])
+        aligner.registerCallback(0, lambda m: stale.append(m.data))
+        aligner.registerCallback(1, lambda m: stale.append(m.data))
+        aligner.connectInput(filters=[f0, f1])
+        aligner.registerCallback(0, lambda m: fresh.append(m.data))
+        aligner.registerCallback(1, lambda m: fresh.append(m.data))
+        for i in range(2):
+            aligner.setInputPeriod(i, Duration(nanoseconds=int(2e6)))
+        aligner.add(self.create_msg(Msg1, 1, 1), 0)
+        aligner.add(self.create_msg(Msg2, 2, 2), 1)
+        aligner.dispatchMessages()
+        self.assertEqual(stale, [])
+        self.assertEqual(fresh, [1, 2])
+
+    def test_disconnect_all_stops_upstream_delivery(self):
+        f0, f1 = SimpleFilter(), SimpleFilter()
+        aligner = InputAligner(self.timeout)
+        aligner.connectInput(filters=[f0, f1])
+        for i in range(2):
+            aligner.registerCallback(i, self.callback)
+            aligner.setInputPeriod(i, Duration(nanoseconds=int(2e6)))
+        aligner.disconnectAll()
+        f0.signalMessage(self.create_msg(Msg1, 1, 1))
+        f1.signalMessage(self.create_msg(Msg2, 2, 2))
+        aligner.dispatchMessages()
+        self.assertEqual(self.callback_content, [])
+
+    def test_simple_filter_unregister_callback(self):
+        received = []
+        f = SimpleFilter()
+        conn_a = f.registerCallback(lambda m: received.append(('a', m)))
+        conn_b = f.registerCallback(lambda m: received.append(('b', m)))
+        f.signalMessage(1)
+        self.assertEqual(received, [('a', 1), ('b', 1)])
+        f.unregisterCallback(conn_a)
+        f.signalMessage(2)
+        self.assertEqual(received, [('a', 1), ('b', 1), ('b', 2)])
+        # Unregistering an unknown id must be a no-op.
+        f.unregisterCallback(conn_a)
+        f.unregisterCallback(9999)
+        f.signalMessage(3)
+        self.assertEqual(received, [('a', 1), ('b', 1), ('b', 2), ('b', 3)])
 
     def test_ignores_inactive_inputs(self):
         aligner = InputAligner(self.timeout)
@@ -164,8 +254,11 @@ class TestInputAligner(unittest.TestCase):
             aligner.setInputPeriod(i, Duration(nanoseconds=int(2e6)))
         aligner.add(self.create_msg(Msg2, 2, 2), 1)
         aligner.add(self.create_msg(Msg1, 1, 1), 0)
-        time.sleep(0.05)
-        rclpy.spin_once(self.node, timeout_sec=0.01)
+        # Spin until the timer fires and both messages flow through, with a
+        # generous deadline so this is not flaky on slow CI runners.
+        deadline = time.monotonic() + 2.0
+        while len(self.callback_content) < 2 and time.monotonic() < deadline:
+            rclpy.spin_once(self.node, timeout_sec=0.05)
         self.assertEqual(self.callback_content, [1, 2])
 
     def test_no_period_information(self):


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes https://github.com/ros2/message_filters/issues/282
### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

Codex

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

## Summary
- add a Python `InputAligner` implementation on top of the `rolling` branch
- export it from the Python package
- add Python parity tests matching the C++ `test_input_aligner.cpp` coverage

## Details
This PR targets `ros2/message_filters:rolling` from `UniflexAI/message_filters:rolling`.
The Python implementation follows the C++ InputAligner semantics referenced from the upstream `sa-input_aligner` work.

## Test coverage
The Python test file now covers 10 InputAligner cases, including the original C++ parity coverage plus Python-specific regression coverage for recent fixes:
- init
- dispatch_inputs_in_order
- dispatch_inputs_with_duplicate_timestamps
- reconnect_input_disconnects_old_callbacks
- ignores_inactive_inputs
- input_timeout
- drops_msgs
- dispatch_by_timer
- no_period_information
- get_queue_status

## Validation
Validated on a Rolling environment with all 10 Python InputAligner tests passing.
