### PR TITLE
Avoid vector assignment in message_filters signal callback

### DIFF
--- a/include/message_filters/signal1.hpp
+++ b/include/message_filters/signal1.hpp
@@ -106,7 +106,10 @@ public:
     V_CallbackHelper1 local_callbacks;
     {
       std::lock_guard<std::mutex> lock(mutex_);
-      local_callbacks = callbacks_;
+      local_callbacks.reserve(callbacks_.size());
+      for (const auto & callback : callbacks_) {
+        local_callbacks.push_back(callback);
+      }
     }
     bool nonconst_force_copy = local_callbacks.size() > 1;
     for (const CallbackHelper1Ptr & helper : local_callbacks) {

--- a/include/message_filters/signal9.hpp
+++ b/include/message_filters/signal9.hpp
@@ -143,7 +143,10 @@ public:
     V_CallbackHelper9 local_callbacks;
     {
       std::lock_guard<std::mutex> lock(mutex_);
-      local_callbacks = callbacks_;
+      local_callbacks.reserve(callbacks_.size());
+      for (const auto & callback : callbacks_) {
+        local_callbacks.push_back(callback);
+      }
     }
     bool nonconst_force_copy = local_callbacks.size() > 1;
     for (const CallbackHelper9Ptr & helper : local_callbacks) {


### PR DESCRIPTION
## Description

Hi, I am testing Nav2 on Lyrical, and we are getting the following warning:


```
--- stderr: nav2_amcl                                  
In file included from /usr/include/c++/15/bits/shared_ptr.h:53,
                 from /usr/include/c++/15/memory:82,
                 from /root/nav2_ws/src/navigation2/nav2_amcl/include/nav2_amcl/amcl_node.hpp:27,
                 from /root/nav2_ws/src/navigation2/nav2_amcl/src/amcl_node.cpp:23:
In member function ‘std::__shared_count<_Lp>& std::__shared_count<_Lp>::operator=(const std::__shared_count<_Lp>&) [with __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’,
    inlined from ‘std::__shared_ptr<_Tp, _Lp>& std::__shared_ptr<_Tp, _Lp>::operator=(const std::__shared_ptr<_Tp, _Lp>&) [with _Tp = message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<std::allocator<void> > >; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’ at /usr/include/c++/15/bits/shared_ptr_base.h:1530:21,
    inlined from ‘std::shared_ptr<_Tp>& std::shared_ptr<_Tp>::operator=(const std::shared_ptr<_Tp>&) [with _Tp = message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<std::allocator<void> > >]’ at /usr/include/c++/15/bits/shared_ptr.h:413:19,
    inlined from ‘constexpr void std::__assign_one(_OutIter&, _InIter&) [with bool _IsMove = false; _OutIter = shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*; _InIter = const shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*]’ at /usr/include/c++/15/bits/stl_algobase.h:407:9,
    inlined from ‘constexpr _OutIter std::__copy_move_a2(_InIter, _Sent, _OutIter) [with bool _IsMove = false; _InIter = const shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*; _Sent = const shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*; _OutIter = shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*]’ at /usr/include/c++/15/bits/stl_algobase.h:462:28,
    inlined from ‘constexpr _OI std::__copy_move_a1(_II, _II, _OI) [with bool _IsMove = false; _II = const shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*; _OI = shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*]’ at /usr/include/c++/15/bits/stl_algobase.h:492:42,
    inlined from ‘constexpr _OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = false; _II = __gnu_cxx::__normal_iterator<const shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*, vector<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >, allocator<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > > > > >; _OI = __gnu_cxx::__normal_iterator<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*, vector<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >, allocator<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > > > > >]’ at /usr/include/c++/15/bits/stl_algobase.h:500:31,
    inlined from ‘constexpr _OI std::copy(_II, _II, _OI) [with _II = __gnu_cxx::__normal_iterator<const shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*, vector<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >, allocator<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > > > > >; _OI = __gnu_cxx::__normal_iterator<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*, vector<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >, allocator<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > > > > >]’ at /usr/include/c++/15/bits/stl_algobase.h:642:7,
    inlined from ‘constexpr std::vector<_Tp, _Alloc>& std::vector<_Tp, _Alloc>::operator=(const std::vector<_Tp, _Alloc>&) [with _Tp = std::shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<std::allocator<void> > > >; _Alloc = std::allocator<std::shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<std::allocator<void> > > > >]’ at /usr/include/c++/15/bits/vector.tcc:250:21,
    inlined from ‘void message_filters::Signal1<M>::call(const message_filters::MessageEvent<const M>&) [with M = sensor_msgs::msg::LaserScan_<std::allocator<void> >]’ at /root/nav2_ws/install/message_filters/include/message_filters/message_filters/signal1.hpp:109:23:
/usr/include/c++/15/bits/shared_ptr_base.h:1083:22: warning: potential null pointer dereference [-Wnull-dereference]
 1083 |         if (__tmp != _M_pi)
      |                      ^~~~~
In member function ‘std::__shared_ptr<_Tp, _Lp>& std::__shared_ptr<_Tp, _Lp>::operator=(const std::__shared_ptr<_Tp, _Lp>&) [with _Tp = message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<std::allocator<void> > >; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’,
    inlined from ‘std::shared_ptr<_Tp>& std::shared_ptr<_Tp>::operator=(const std::shared_ptr<_Tp>&) [with _Tp = message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<std::allocator<void> > >]’ at /usr/include/c++/15/bits/shared_ptr.h:413:19,
    inlined from ‘constexpr void std::__assign_one(_OutIter&, _InIter&) [with bool _IsMove = false; _OutIter = shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*; _InIter = const shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*]’ at /usr/include/c++/15/bits/stl_algobase.h:407:9,
    inlined from ‘constexpr _OutIter std::__copy_move_a2(_InIter, _Sent, _OutIter) [with bool _IsMove = false; _InIter = const shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*; _Sent = const shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*; _OutIter = shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*]’ at /usr/include/c++/15/bits/stl_algobase.h:462:28,
    inlined from ‘constexpr _OI std::__copy_move_a1(_II, _II, _OI) [with bool _IsMove = false; _II = const shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*; _OI = shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*]’ at /usr/include/c++/15/bits/stl_algobase.h:492:42,
    inlined from ‘constexpr _OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = false; _II = __gnu_cxx::__normal_iterator<const shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*, vector<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >, allocator<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > > > > >; _OI = __gnu_cxx::__normal_iterator<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*, vector<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >, allocator<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > > > > >]’ at /usr/include/c++/15/bits/stl_algobase.h:500:31,
    inlined from ‘constexpr _OI std::copy(_II, _II, _OI) [with _II = __gnu_cxx::__normal_iterator<const shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*, vector<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >, allocator<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > > > > >; _OI = __gnu_cxx::__normal_iterator<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*, vector<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >, allocator<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > > > > >]’ at /usr/include/c++/15/bits/stl_algobase.h:642:7,
    inlined from ‘constexpr std::vector<_Tp, _Alloc>& std::vector<_Tp, _Alloc>::operator=(const std::vector<_Tp, _Alloc>&) [with _Tp = std::shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<std::allocator<void> > > >; _Alloc = std::allocator<std::shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<std::allocator<void> > > > >]’ at /usr/include/c++/15/bits/vector.tcc:250:21,
    inlined from ‘void message_filters::Signal1<M>::call(const message_filters::MessageEvent<const M>&) [with M = sensor_msgs::msg::LaserScan_<std::allocator<void> >]’ at /root/nav2_ws/install/message_filters/include/message_filters/message_filters/signal1.hpp:109:23:
/usr/include/c++/15/bits/shared_ptr_base.h:1530:21: warning: potential null pointer dereference [-Wnull-dereference]
 1530 |       __shared_ptr& operator=(const __shared_ptr&) noexcept = default;
      |                     ^~~~~~~~
In member function ‘std::__shared_count<_Lp>& std::__shared_count<_Lp>::operator=(const std::__shared_count<_Lp>&) [with __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’,
    inlined from ‘std::__shared_ptr<_Tp, _Lp>& std::__shared_ptr<_Tp, _Lp>::operator=(const std::__shared_ptr<_Tp, _Lp>&) [with _Tp = message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<std::allocator<void> > >; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’ at /usr/include/c++/15/bits/shared_ptr_base.h:1530:21,
    inlined from ‘std::shared_ptr<_Tp>& std::shared_ptr<_Tp>::operator=(const std::shared_ptr<_Tp>&) [with _Tp = message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<std::allocator<void> > >]’ at /usr/include/c++/15/bits/shared_ptr.h:413:19,
    inlined from ‘constexpr void std::__assign_one(_OutIter&, _InIter&) [with bool _IsMove = false; _OutIter = shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*; _InIter = const shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*]’ at /usr/include/c++/15/bits/stl_algobase.h:407:9,
    inlined from ‘constexpr _OutIter std::__copy_move_a2(_InIter, _Sent, _OutIter) [with bool _IsMove = false; _InIter = const shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*; _Sent = const shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*; _OutIter = shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*]’ at /usr/include/c++/15/bits/stl_algobase.h:462:28,
    inlined from ‘constexpr _OI std::__copy_move_a1(_II, _II, _OI) [with bool _IsMove = false; _II = const shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*; _OI = shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*]’ at /usr/include/c++/15/bits/stl_algobase.h:492:42,
    inlined from ‘constexpr _OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = false; _II = __gnu_cxx::__normal_iterator<const shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*, vector<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >, allocator<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > > > > >; _OI = __gnu_cxx::__normal_iterator<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*, vector<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >, allocator<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > > > > >]’ at /usr/include/c++/15/bits/stl_algobase.h:500:31,
    inlined from ‘constexpr _OI std::copy(_II, _II, _OI) [with _II = __gnu_cxx::__normal_iterator<const shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*, vector<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >, allocator<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > > > > >; _OI = __gnu_cxx::__normal_iterator<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*, vector<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >, allocator<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > > > > >]’ at /usr/include/c++/15/bits/stl_algobase.h:642:7,
    inlined from ‘constexpr std::vector<_Tp, _Alloc>& std::vector<_Tp, _Alloc>::operator=(const std::vector<_Tp, _Alloc>&) [with _Tp = std::shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<std::allocator<void> > > >; _Alloc = std::allocator<std::shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<std::allocator<void> > > > >]’ at /usr/include/c++/15/bits/vector.tcc:250:21,
    inlined from ‘void message_filters::Signal1<M>::call(const message_filters::MessageEvent<const M>&) [with M = sensor_msgs::msg::LaserScan_<std::allocator<void> >]’ at /root/nav2_ws/install/message_filters/include/message_filters/message_filters/signal1.hpp:109:23,
    inlined from ‘void message_filters::SimpleFilter<M>::signalMessage(const message_filters::MessageEvent<const M>&) [with M = sensor_msgs::msg::LaserScan_<std::allocator<void> >]’ at /root/nav2_ws/install/message_filters/include/message_filters/message_filters/simple_filter.hpp:129:17,
    inlined from ‘void message_filters::Subscriber<M>::cb(const EventType&) [with M = sensor_msgs::msg::LaserScan_<std::allocator<void> >]’ at /root/nav2_ws/install/message_filters/include/message_filters/message_filters/subscriber.hpp:360:24,
    inlined from ‘message_filters::Subscriber<sensor_msgs::msg::LaserScan_<std::allocator<void> > >::subscribe(message_filters::SubscriberBase::RequiredInterfaces, const std::string&, const rclcpp::QoS&, rclcpp::SubscriptionOptions)::<lambda(std::shared_ptr<const sensor_msgs::msg::LaserScan_<std::allocator<void> > >)>’ at /root/nav2_ws/install/message_filters/include/message_filters/message_filters/subscriber.hpp:287:21,
    inlined from ‘constexpr _Res std::__invoke_impl(__invoke_other, _Fn&&, _Args&& ...) [with _Res = void; _Fn = message_filters::Subscriber<sensor_msgs::msg::LaserScan_<allocator<void> > >::subscribe(message_filters::SubscriberBase::RequiredInterfaces, const std::string&, const rclcpp::QoS&, rclcpp::SubscriptionOptions)::<lambda(shared_ptr<const sensor_msgs::msg::LaserScan_<allocator<void> > >)>&; _Args = {shared_ptr<const sensor_msgs::msg::LaserScan_<allocator<void> > >}]’ at /usr/include/c++/15/bits/invoke.h:63:36,
    inlined from ‘constexpr std::enable_if_t<((bool)is_invocable_r_v<_Res, _Callable, _Args ...>), _Res> std::__invoke_r(_Callable&&, _Args&& ...) [with _Res = void; _Callable = message_filters::Subscriber<sensor_msgs::msg::LaserScan_<allocator<void> > >::subscribe(message_filters::SubscriberBase::RequiredInterfaces, const std::string&, const rclcpp::QoS&, rclcpp::SubscriptionOptions)::<lambda(shared_ptr<const sensor_msgs::msg::LaserScan_<allocator<void> > >)>&; _Args = {shared_ptr<const sensor_msgs::msg::LaserScan_<allocator<void> > >}]’ at /usr/include/c++/15/bits/invoke.h:113:28,
    inlined from ‘static _Res std::_Function_handler<_Res(_ArgTypes ...), _Functor>::_M_invoke(const std::_Any_data&, _ArgTypes&& ...) [with _Res = void; _Functor = message_filters::Subscriber<sensor_msgs::msg::LaserScan_<std::allocator<void> > >::subscribe(message_filters::SubscriberBase::RequiredInterfaces, const std::string&, const rclcpp::QoS&, rclcpp::SubscriptionOptions)::<lambda(std::shared_ptr<const sensor_msgs::msg::LaserScan_<std::allocator<void> > >)>; _ArgTypes = {std::shared_ptr<const sensor_msgs::msg::LaserScan_<std::allocator<void> > >}]’ at /usr/include/c++/15/bits/std_function.h:292:30:
/usr/include/c++/15/bits/shared_ptr_base.h:1083:22: warning: potential null pointer dereference [-Wnull-dereference]
 1083 |         if (__tmp != _M_pi)
      |                      ^~~~~
In member function ‘std::__shared_ptr<_Tp, _Lp>& std::__shared_ptr<_Tp, _Lp>::operator=(const std::__shared_ptr<_Tp, _Lp>&) [with _Tp = message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<std::allocator<void> > >; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’,
    inlined from ‘std::shared_ptr<_Tp>& std::shared_ptr<_Tp>::operator=(const std::shared_ptr<_Tp>&) [with _Tp = message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<std::allocator<void> > >]’ at /usr/include/c++/15/bits/shared_ptr.h:413:19,
    inlined from ‘constexpr void std::__assign_one(_OutIter&, _InIter&) [with bool _IsMove = false; _OutIter = shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*; _InIter = const shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*]’ at /usr/include/c++/15/bits/stl_algobase.h:407:9,
    inlined from ‘constexpr _OutIter std::__copy_move_a2(_InIter, _Sent, _OutIter) [with bool _IsMove = false; _InIter = const shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*; _Sent = const shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*; _OutIter = shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*]’ at /usr/include/c++/15/bits/stl_algobase.h:462:28,
    inlined from ‘constexpr _OI std::__copy_move_a1(_II, _II, _OI) [with bool _IsMove = false; _II = const shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*; _OI = shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*]’ at /usr/include/c++/15/bits/stl_algobase.h:492:42,
    inlined from ‘constexpr _OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = false; _II = __gnu_cxx::__normal_iterator<const shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*, vector<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >, allocator<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > > > > >; _OI = __gnu_cxx::__normal_iterator<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*, vector<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >, allocator<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > > > > >]’ at /usr/include/c++/15/bits/stl_algobase.h:500:31,
    inlined from ‘constexpr _OI std::copy(_II, _II, _OI) [with _II = __gnu_cxx::__normal_iterator<const shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*, vector<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >, allocator<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > > > > >; _OI = __gnu_cxx::__normal_iterator<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >*, vector<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > >, allocator<shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<allocator<void> > > > > > >]’ at /usr/include/c++/15/bits/stl_algobase.h:642:7,
    inlined from ‘constexpr std::vector<_Tp, _Alloc>& std::vector<_Tp, _Alloc>::operator=(const std::vector<_Tp, _Alloc>&) [with _Tp = std::shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<std::allocator<void> > > >; _Alloc = std::allocator<std::shared_ptr<message_filters::CallbackHelper1<sensor_msgs::msg::LaserScan_<std::allocator<void> > > > >]’ at /usr/include/c++/15/bits/vector.tcc:250:21,
    inlined from ‘void message_filters::Signal1<M>::call(const message_filters::MessageEvent<const M>&) [with M = sensor_msgs::msg::LaserScan_<std::allocator<void> >]’ at /root/nav2_ws/install/message_filters/include/message_filters/message_filters/signal1.hpp:109:23,
    inlined from ‘void message_filters::SimpleFilter<M>::signalMessage(const message_filters::MessageEvent<const M>&) [with M = sensor_msgs::msg::LaserScan_<std::allocator<void> >]’ at /root/nav2_ws/install/message_filters/include/message_filters/message_filters/simple_filter.hpp:129:17,
    inlined from ‘void message_filters::Subscriber<M>::cb(const EventType&) [with M = sensor_msgs::msg::LaserScan_<std::allocator<void> >]’ at /root/nav2_ws/install/message_filters/include/message_filters/message_filters/subscriber.hpp:360:24,
    inlined from ‘message_filters::Subscriber<sensor_msgs::msg::LaserScan_<std::allocator<void> > >::subscribe(message_filters::SubscriberBase::RequiredInterfaces, const std::string&, const rclcpp::QoS&, rclcpp::SubscriptionOptions)::<lambda(std::shared_ptr<const sensor_msgs::msg::LaserScan_<std::allocator<void> > >)>’ at /root/nav2_ws/install/message_filters/include/message_filters/message_filters/subscriber.hpp:287:21,
    inlined from ‘constexpr _Res std::__invoke_impl(__invoke_other, _Fn&&, _Args&& ...) [with _Res = void; _Fn = message_filters::Subscriber<sensor_msgs::msg::LaserScan_<allocator<void> > >::subscribe(message_filters::SubscriberBase::RequiredInterfaces, const std::string&, const rclcpp::QoS&, rclcpp::SubscriptionOptions)::<lambda(shared_ptr<const sensor_msgs::msg::LaserScan_<allocator<void> > >)>&; _Args = {shared_ptr<const sensor_msgs::msg::LaserScan_<allocator<void> > >}]’ at /usr/include/c++/15/bits/invoke.h:63:36,
    inlined from ‘constexpr std::enable_if_t<((bool)is_invocable_r_v<_Res, _Callable, _Args ...>), _Res> std::__invoke_r(_Callable&&, _Args&& ...) [with _Res = void; _Callable = message_filters::Subscriber<sensor_msgs::msg::LaserScan_<allocator<void> > >::subscribe(message_filters::SubscriberBase::RequiredInterfaces, const std::string&, const rclcpp::QoS&, rclcpp::SubscriptionOptions)::<lambda(shared_ptr<const sensor_msgs::msg::LaserScan_<allocator<void> > >)>&; _Args = {shared_ptr<const sensor_msgs::msg::LaserScan_<allocator<void> > >}]’ at /usr/include/c++/15/bits/invoke.h:113:28,
    inlined from ‘static _Res std::_Function_handler<_Res(_ArgTypes ...), _Functor>::_M_invoke(const std::_Any_data&, _ArgTypes&& ...) [with _Res = void; _Functor = message_filters::Subscriber<sensor_msgs::msg::LaserScan_<std::allocator<void> > >::subscribe(message_filters::SubscriberBase::RequiredInterfaces, const std::string&, const rclcpp::QoS&, rclcpp::SubscriptionOptions)::<lambda(std::shared_ptr<const sensor_msgs::msg::LaserScan_<std::allocator<void> > >)>; _ArgTypes = {std::shared_ptr<const sensor_msgs::msg::LaserScan_<std::allocator<void> > >}]’ at /usr/include/c++/15/bits/std_function.h:292:30:
/usr/include/c++/15/bits/shared_ptr_base.h:1530:21: warning: potential null pointer dereference [-Wnull-dereference]
 1530 |       __shared_ptr& operator=(const __shared_ptr&) noexcept = default;
```

This PR should fix the issue

### Is this user-facing behavior change?

No

### Did you use Generative AI?

Yes, Codex

### Additional Information

Please backport this to Lyrical
