### PR TITLE
Resolve kilted backport conflict

### DIFF
--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -47,33 +47,9 @@ from rclpy.qos import QoSProfile
 from rclpy.time import Time
 from rclpy.type_support import MsgT
 
-<<<<<<< HEAD
 from typing_extensions import deprecated
 
-
-class SimpleFilter(object):
-
-    def __init__(self):
-        self.callbacks = {}
-
-    def registerCallback(self, cb, *args):
-        """
-        Register a callback `cb` to be called when this filter has output.
-
-        The filter calls the function ``cb`` with a filter-dependent.
-
-        list of arguments,followed by the call-supplied arguments ``args.``.
-        """
-        conn = len(self.callbacks)
-        self.callbacks[conn] = (cb, args)
-        return conn
-
-    def signalMessage(self, *msg):
-        for (cb, args) in self.callbacks.values():
-            cb(*(msg + args))
-=======
 from .simple_filter import SimpleFilter
->>>>>>> e8277a6 (feat(python): add python implementation of InputAligner  (#283))
 
 
 class Subscriber(SimpleFilter):


### PR DESCRIPTION
Resolve the `kilted` backport conflict from #287.

This keeps the backported `SimpleFilter` split from #283:
- import `SimpleFilter` from `.simple_filter`
- remove the old inline `SimpleFilter` definition from `src/message_filters/__init__.py`

Validation:
- `python3 -m compileall -q src/message_filters test/test_input_aligner.py`
- `git diff --check`