### PR TITLE
Resolve jazzy backport conflict

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,6 @@ if(BUILD_TESTING)
 
   # python tests with python interfaces of message filters
   find_package(ament_cmake_pytest REQUIRED)
-<<<<<<< HEAD
   ament_add_pytest_test(test_time_synchronizer.py "test/test_time_synchronizer.py"
     PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}")
   ament_add_pytest_test(test_approxsync.py "test/test_approxsync.py"
@@ -156,13 +155,8 @@ if(BUILD_TESTING)
     PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}")
   ament_add_pytest_test(test_message_filters_chain.py "test/test_message_filters_chain.py"
     PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}")
-=======
-  ament_add_pytest_test(test_time_synchronizer.py "test/test_time_synchronizer.py")
-  ament_add_pytest_test(test_approxsync.py "test/test_approxsync.py")
-  ament_add_pytest_test(test_message_filters_cache.py "test/test_message_filters_cache.py")
-  ament_add_pytest_test(test_message_filters_chain.py "test/test_message_filters_chain.py")
-  ament_add_pytest_test(test_input_aligner.py "test/test_input_aligner.py")
->>>>>>> e8277a6 (feat(python): add python implementation of InputAligner  (#283))
+  ament_add_pytest_test(test_input_aligner.py "test/test_input_aligner.py"
+    PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}")
 endif()
 
 ament_package()

--- a/src/message_filters/__init__.py
+++ b/src/message_filters/__init__.py
@@ -48,31 +48,7 @@ from rclpy.node import Node
 from rclpy.qos import QoSProfile
 from rclpy.time import Time
 
-<<<<<<< HEAD
-
-class SimpleFilter(object):
-
-    def __init__(self):
-        self.callbacks = {}
-
-    def registerCallback(self, cb, *args):
-        """
-        Register a callback function `cb` to be called when this filter
-        has output.
-        The filter calls the function ``cb`` with a filter-dependent
-        list of arguments,followed by the call-supplied arguments ``args``.
-        """
-
-        conn = len(self.callbacks)
-        self.callbacks[conn] = (cb, args)
-        return conn
-
-    def signalMessage(self, *msg):
-        for (cb, args) in self.callbacks.values():
-            cb(*(msg + args))
-=======
 from .simple_filter import SimpleFilter
->>>>>>> e8277a6 (feat(python): add python implementation of InputAligner  (#283))
 
 class Subscriber(SimpleFilter):
 


### PR DESCRIPTION
Resolve the `jazzy` backport conflicts from #288.

This keeps the backported `InputAligner` changes from #283 while preserving Jazzy-specific test registration:
- import `SimpleFilter` from `.simple_filter`
- remove the old inline `SimpleFilter` definition from `src/message_filters/__init__.py`
- add `test_input_aligner.py` with the existing `PYTHON_EXECUTABLE` argument style in `CMakeLists.txt`

Validation:
- `python3 -m compileall -q src/message_filters test/test_input_aligner.py`
- `git diff --check`