### PR TITLE
(#285, #282) jazzy: Replace MsgT import with MsgType import

### DIFF
--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -36,7 +36,7 @@ from builtin_interfaces.msg import Time as TimeMsg
 from rclpy.duration import Duration
 from rclpy.node import Node
 from rclpy.time import Time
-from rclpy.type_support import MsgT
+from rclpy.node import MsgType
 
 from .simple_filter import SimpleFilter
 
@@ -174,7 +174,7 @@ class InputAligner:
     def registerCallback(
         self,
         index: int,
-        callback: tp.Callable[tp.Concatenate[MsgT, ...], None],
+        callback: tp.Callable[tp.Concatenate[MsgType, ...], None],
         *args: tp.Any,
     ) -> int:
         return self.signals[index].registerCallback(callback, *args)

--- a/src/message_filters/simple_filter.py
+++ b/src/message_filters/simple_filter.py
@@ -27,7 +27,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 import typing as tp
 
-from rclpy.type_support import MsgT
+from rclpy.node import MsgType
 
 
 class SimpleFilter:
@@ -37,7 +37,7 @@ class SimpleFilter:
 
     def registerCallback(
         self,
-        callback: tp.Callable[tp.Concatenate[MsgT, ...], None],
+        callback: tp.Callable[tp.Concatenate[MsgType, ...], None],
         *args
     ):
         """


### PR DESCRIPTION
## Description

Replace MagT import with MsgType import as there is no such type as MagT in rclpy

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
