### PR TITLE
const-correct comparisons and migration from typedef to the using

### DIFF
--- a/include/message_filters/cache.hpp
+++ b/include/message_filters/cache.hpp
@@ -64,8 +64,8 @@ template<class M>
 class Cache : public SimpleFilter<M>
 {
 public:
-  typedef std::shared_ptr<M const> MConstPtr;
-  typedef MessageEvent<M const> EventType;
+  using MConstPtr = std::shared_ptr<M const>;
+  using EventType = MessageEvent<M const>;
 
   template<class F>
   explicit Cache(F & f, unsigned int cache_size = 1)
@@ -117,7 +117,7 @@ public:
   {
     incoming_connection_ = f.registerCallback(
       typename SimpleFilter<M>::EventCallback(
-        std::bind(&Cache::callback, this, std::placeholders::_1)));
+        [this](const EventType & evt) {callback(evt);}));
   }
 
   ~Cache()

--- a/include/message_filters/delta_filter.hpp
+++ b/include/message_filters/delta_filter.hpp
@@ -49,18 +49,18 @@ namespace message_filters
 {
 
 // Supported final field types
-typedef std::variant<
-    bool,
-    std::byte,
-    char,
-    std::uint8_t,
-    std::int16_t, std::uint16_t,
-    std::int32_t, std::uint32_t,
-    std::int64_t, std::uint64_t,
-    float,
-    double,
-    std::string
-> MFieldType;
+using MFieldType = std::variant<
+  bool,
+  std::byte,
+  char,
+  std::uint8_t,
+  std::int16_t, std::uint16_t,
+  std::int32_t, std::uint32_t,
+  std::int64_t, std::uint64_t,
+  float,
+  double,
+  std::string
+>;
 
 
 /**
@@ -72,9 +72,9 @@ template<typename MessageType>
 class ComparisonHandler
 {
 public:
-  typedef std::shared_ptr<MessageType const> MConstPtr;
-  typedef MessageEvent<MessageType const> EventType;
-  typedef std::function<MFieldType(const MConstPtr &)> FieldGetterFunctionType;
+  using MConstPtr = std::shared_ptr<MessageType const>;
+  using EventType = MessageEvent<MessageType const>;
+  using FieldGetterFunctionType = std::function<MFieldType(const MConstPtr &)>;
 
   virtual ~ComparisonHandler() = default;
 
@@ -95,9 +95,9 @@ template<typename MessageType>
 class CachedComparisonHandler : public ComparisonHandler<MessageType>
 {
 public:
-  typedef std::shared_ptr<MessageType const> MConstPtr;
-  typedef MessageEvent<MessageType const> EventType;
-  typedef std::function<MFieldType(const MConstPtr &)> FieldGetterFunctionType;
+  using MConstPtr = std::shared_ptr<MessageType const>;
+  using EventType = MessageEvent<MessageType const>;
+  using FieldGetterFunctionType = std::function<MFieldType(const MConstPtr &)>;
 
   /**
    * Initialize handler.
@@ -163,8 +163,8 @@ template<typename MessageType>
 class DeltaCompare : public CachedComparisonHandler<MessageType>
 {
 public:
-  typedef std::shared_ptr<MessageType const> MConstPtr;
-  typedef std::function<MFieldType(const MConstPtr &)> FieldGetterFunctionType;
+  using MConstPtr = std::shared_ptr<MessageType const>;
+  using FieldGetterFunctionType = std::function<MFieldType(const MConstPtr &)>;
 
   /**
    * Initialize handler.
@@ -205,9 +205,9 @@ template<typename MessageType, template<typename HandlerMessageType> typename Ha
 class ComparisonFilter : public SimpleFilter<MessageType>
 {
 public:
-  typedef std::shared_ptr<MessageType const> MConstPtr;
-  typedef MessageEvent<MessageType const> EventType;
-  typedef std::function<MFieldType(const MConstPtr &)> FieldGetterFunctionType;
+  using MConstPtr = std::shared_ptr<MessageType const>;
+  using EventType = MessageEvent<MessageType const>;
+  using FieldGetterFunctionType = std::function<MFieldType(const MConstPtr &)>;
 
   /**
    * Initialize ComparisonFilter.
@@ -240,11 +240,7 @@ public:
     incoming_connection_.disconnect();
     incoming_connection_ = filter.registerCallback(
       typename SimpleFilter<MessageType>::EventCallback(
-        std::bind(
-          &ComparisonFilter::add,
-          this,
-          std::placeholders::_1
-        )
+        [this](const EventType & evt) {add(evt);}
       )
     );
   }
@@ -274,8 +270,8 @@ template<typename MessageType>
 class DeltaFilter : public ComparisonFilter<MessageType, DeltaCompare>
 {
 public:
-  typedef std::shared_ptr<MessageType const> MConstPtr;
-  typedef std::function<MFieldType(const MConstPtr &)> FieldGetterFunctionType;
+  using MConstPtr = std::shared_ptr<MessageType const>;
+  using FieldGetterFunctionType = std::function<MFieldType(const MConstPtr &)>;
 
   /**
    * \brief Initialize DeltaFilter

--- a/include/message_filters/message_event.hpp
+++ b/include/message_filters/message_event.hpp
@@ -42,8 +42,8 @@
 
 namespace message_filters
 {
-typedef std::map<std::string, std::string> M_string;
-typedef std::shared_ptr<M_string> M_stringPtr;
+using M_string = std::map<std::string, std::string>;
+using M_stringPtr = std::shared_ptr<M_string>;
 
 template<typename M>
 struct DefaultMessageCreator
@@ -64,11 +64,11 @@ template<typename M>
 class MessageEvent
 {
 public:
-  typedef typename std::add_const<M>::type ConstMessage;
-  typedef typename std::remove_const<M>::type Message;
-  typedef std::shared_ptr<Message> MessagePtr;
-  typedef std::shared_ptr<ConstMessage> ConstMessagePtr;
-  typedef std::function<MessagePtr()> CreateFunction;
+  using ConstMessage = typename std::add_const<M>::type;
+  using Message = typename std::remove_const<M>::type;
+  using MessagePtr = std::shared_ptr<Message>;
+  using ConstMessagePtr = std::shared_ptr<ConstMessage>;
+  using CreateFunction = std::function<MessagePtr()>;
 
   MessageEvent()
   : nonconst_need_copy_(true)

--- a/include/message_filters/message_event.hpp
+++ b/include/message_filters/message_event.hpp
@@ -175,7 +175,9 @@ public:
   bool nonConstWillCopy() const {return nonconst_need_copy_;}
   bool getMessageWillCopy() const {return !std::is_const<M>::value && nonconst_need_copy_;}
 
-  bool operator<(const MessageEvent<M> & rhs)
+  // Note: not noexcept. rclcpp::Time relational operators throw std::runtime_error
+  // when the two times have different clock sources.
+  bool operator<(const MessageEvent<M> & rhs) const
   {
     if (message_ != rhs.message_) {
       return message_ < rhs.message_;
@@ -188,15 +190,11 @@ public:
     return nonconst_need_copy_ < rhs.nonconst_need_copy_;
   }
 
-  bool operator==(const MessageEvent<M> & rhs)
+  // operator!= is synthesized from operator== by C++20's rewritten candidates.
+  bool operator==(const MessageEvent<M> & rhs) const
   {
     return message_ == rhs.message_ && receipt_time_ == rhs.receipt_time_ &&
            nonconst_need_copy_ == rhs.nonconst_need_copy_;
-  }
-
-  bool operator!=(const MessageEvent<M> & rhs)
-  {
-    return !(*this == rhs);
   }
 
   const CreateFunction & getMessageFactory() const {return create_;}

--- a/include/message_filters/message_event.hpp
+++ b/include/message_filters/message_event.hpp
@@ -190,7 +190,6 @@ public:
     return nonconst_need_copy_ < rhs.nonconst_need_copy_;
   }
 
-  // operator!= is synthesized from operator== by C++20's rewritten candidates.
   bool operator==(const MessageEvent<M> & rhs) const
   {
     return message_ == rhs.message_ && receipt_time_ == rhs.receipt_time_ &&

--- a/include/message_filters/null_types.hpp
+++ b/include/message_filters/null_types.hpp
@@ -42,7 +42,7 @@ namespace message_filters
 struct NullType
 {
 };
-typedef std::shared_ptr<NullType const> NullTypeConstPtr;
+using NullTypeConstPtr = std::shared_ptr<NullType const>;
 
 template<class M>
 struct NullFilter

--- a/include/message_filters/parameter_adapter.hpp
+++ b/include/message_filters/parameter_adapter.hpp
@@ -69,9 +69,9 @@ void callback(const MessageEvent<M> &);
 template<typename M>
 struct ParameterAdapter
 {
-  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
-  typedef MessageEvent<Message const> Event;
-  typedef M Parameter;
+  using Message = typename std::remove_reference<typename std::remove_const<M>::type>::type;
+  using Event = MessageEvent<Message const>;
+  using Parameter = M;
   static const bool is_const = true;
 
   static Parameter getParameter(const Event & event)
@@ -83,9 +83,9 @@ struct ParameterAdapter
 template<typename M>
 struct ParameterAdapter<const std::shared_ptr<M const> &>
 {
-  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
-  typedef MessageEvent<Message const> Event;
-  typedef const std::shared_ptr<Message const> Parameter;
+  using Message = typename std::remove_reference<typename std::remove_const<M>::type>::type;
+  using Event = MessageEvent<Message const>;
+  using Parameter = const std::shared_ptr<Message const>;
   static const bool is_const = true;
 
   static Parameter getParameter(const Event & event)
@@ -97,9 +97,9 @@ struct ParameterAdapter<const std::shared_ptr<M const> &>
 template<typename M>
 struct ParameterAdapter<const std::shared_ptr<M> &>
 {
-  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
-  typedef MessageEvent<Message const> Event;
-  typedef std::shared_ptr<Message> Parameter;
+  using Message = typename std::remove_reference<typename std::remove_const<M>::type>::type;
+  using Event = MessageEvent<Message const>;
+  using Parameter = std::shared_ptr<Message>;
   static const bool is_const = false;
 
   static Parameter getParameter(const Event & event)
@@ -111,9 +111,9 @@ struct ParameterAdapter<const std::shared_ptr<M> &>
 template<typename M>
 struct ParameterAdapter<const M &>
 {
-  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
-  typedef MessageEvent<Message const> Event;
-  typedef const M & Parameter;
+  using Message = typename std::remove_reference<typename std::remove_const<M>::type>::type;
+  using Event = MessageEvent<Message const>;
+  using Parameter = const M &;
   static const bool is_const = true;
 
   static Parameter getParameter(const Event & event)
@@ -125,9 +125,9 @@ struct ParameterAdapter<const M &>
 template<typename M>
 struct ParameterAdapter<std::shared_ptr<M const>>
 {
-  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
-  typedef MessageEvent<Message const> Event;
-  typedef std::shared_ptr<Message const> Parameter;
+  using Message = typename std::remove_reference<typename std::remove_const<M>::type>::type;
+  using Event = MessageEvent<Message const>;
+  using Parameter = std::shared_ptr<Message const>;
   static const bool is_const = true;
 
   static Parameter getParameter(const Event & event)
@@ -139,9 +139,9 @@ struct ParameterAdapter<std::shared_ptr<M const>>
 template<typename M>
 struct ParameterAdapter<std::shared_ptr<M>>
 {
-  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
-  typedef MessageEvent<Message const> Event;
-  typedef std::shared_ptr<Message> Parameter;
+  using Message = typename std::remove_reference<typename std::remove_const<M>::type>::type;
+  using Event = MessageEvent<Message const>;
+  using Parameter = std::shared_ptr<Message>;
   static const bool is_const = false;
 
   static Parameter getParameter(const Event & event)
@@ -153,9 +153,9 @@ struct ParameterAdapter<std::shared_ptr<M>>
 template<typename M>
 struct ParameterAdapter<const MessageEvent<M const> &>
 {
-  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
-  typedef MessageEvent<Message const> Event;
-  typedef const MessageEvent<Message const> & Parameter;
+  using Message = typename std::remove_reference<typename std::remove_const<M>::type>::type;
+  using Event = MessageEvent<Message const>;
+  using Parameter = const MessageEvent<Message const> &;
   static const bool is_const = true;
 
   static Parameter getParameter(const Event & event)
@@ -167,9 +167,9 @@ struct ParameterAdapter<const MessageEvent<M const> &>
 template<typename M>
 struct ParameterAdapter<const MessageEvent<M> &>
 {
-  typedef typename std::remove_reference<typename std::remove_const<M>::type>::type Message;
-  typedef MessageEvent<Message const> Event;
-  typedef MessageEvent<Message> Parameter;
+  using Message = typename std::remove_reference<typename std::remove_const<M>::type>::type;
+  using Event = MessageEvent<Message const>;
+  using Parameter = MessageEvent<Message>;
   static const bool is_const = false;
 
   static Parameter getParameter(const Event & event)

--- a/include/message_filters/pass_through.hpp
+++ b/include/message_filters/pass_through.hpp
@@ -42,8 +42,8 @@ template<typename M>
 class PassThrough : public SimpleFilter<M>
 {
 public:
-  typedef std::shared_ptr<M const> MConstPtr;
-  typedef MessageEvent<M const> EventType;
+  using MConstPtr = std::shared_ptr<M const>;
+  using EventType = MessageEvent<M const>;
 
   PassThrough()
   {
@@ -63,9 +63,7 @@ public:
     incoming_connection_ =
       f.registerCallback(
       typename SimpleFilter<M>::EventCallback(
-        std::bind(
-          &PassThrough::cb, this,
-          std::placeholders::_1)));
+        [this](const EventType & evt) {cb(evt);}));
   }
 
   void add(const MConstPtr & msg)

--- a/include/message_filters/signal1.hpp
+++ b/include/message_filters/signal1.hpp
@@ -84,10 +84,10 @@ public:
   template<typename P>
   CallbackHelper1Ptr addCallback(const std::function<void(P)> & callback)
   {
-    CallbackHelper1T<P, M> * helper = new CallbackHelper1T<P, M>(callback);
+    auto helper = std::make_shared<CallbackHelper1T<P, M>>(callback);
 
     std::lock_guard<std::mutex> lock(mutex_);
-    callbacks_.emplace_back(CallbackHelper1Ptr(helper));
+    callbacks_.emplace_back(helper);
     return callbacks_.back();
   }
 

--- a/include/message_filters/signal1.hpp
+++ b/include/message_filters/signal1.hpp
@@ -48,16 +48,16 @@ public:
 
   virtual void call(const MessageEvent<M const> & event, bool nonconst_need_copy) = 0;
 
-  typedef std::shared_ptr<CallbackHelper1<M>> Ptr;
+  using Ptr = std::shared_ptr<CallbackHelper1<M>>;
 };
 
 template<typename P, typename M>
 class CallbackHelper1T : public CallbackHelper1<M>
 {
 public:
-  typedef ParameterAdapter<P> Adapter;
-  typedef std::function<void (typename Adapter::Parameter)> Callback;
-  typedef typename Adapter::Event Event;
+  using Adapter = ParameterAdapter<P>;
+  using Callback = std::function<void (typename Adapter::Parameter)>;
+  using Event = typename Adapter::Event;
 
   CallbackHelper1T(const Callback & cb)  // NOLINT(runtime/explicit)
   : callback_(cb)
@@ -77,8 +77,8 @@ private:
 template<class M>
 class Signal1
 {
-  typedef std::shared_ptr<CallbackHelper1<M>> CallbackHelper1Ptr;
-  typedef std::vector<CallbackHelper1Ptr> V_CallbackHelper1;
+  using CallbackHelper1Ptr = std::shared_ptr<CallbackHelper1<M>>;
+  using V_CallbackHelper1 = std::vector<CallbackHelper1Ptr>;
 
 public:
   template<typename P>

--- a/include/message_filters/signal9.hpp
+++ b/include/message_filters/signal9.hpp
@@ -93,10 +93,10 @@ public:
   template<typename ... Ps>
   Connection addCallback(const std::function<void(Ps...)> & callback)
   {
-    CallbackHelper9T<Ps...> * helper = new CallbackHelper9T<Ps...>(callback);
+    auto helper = std::make_shared<CallbackHelper9T<Ps...>>(callback);
 
     std::lock_guard<std::mutex> lock(mutex_);
-    callbacks_.push_back(CallbackHelper9Ptr(helper));
+    callbacks_.push_back(helper);
     return Connection([this, cb = callbacks_.back()]() {removeCallback(cb);});
   }
 

--- a/include/message_filters/signal9.hpp
+++ b/include/message_filters/signal9.hpp
@@ -52,7 +52,7 @@ public:
 
   virtual void call(bool nonconst_force_copy, const MessageEvent<Ms const> & ... es) = 0;
 
-  typedef std::shared_ptr<CallbackHelper9> Ptr;
+  using Ptr = std::shared_ptr<CallbackHelper9>;
 };
 
 template<typename ... Ps>
@@ -60,7 +60,7 @@ class CallbackHelper9T
   : public CallbackHelper9<typename ParameterAdapter<Ps>::Message...>
 {
 public:
-  typedef std::function<void (typename ParameterAdapter<Ps>::Parameter...)> Callback;
+  using Callback = std::function<void (typename ParameterAdapter<Ps>::Parameter...)>;
 
   CallbackHelper9T(const Callback & cb)  // NOLINT(runtime/explicit)
   : callback_(cb)
@@ -84,11 +84,11 @@ private:
 template<typename ... Ms>
 class Signal9
 {
-  typedef std::shared_ptr<CallbackHelper9<Ms...>> CallbackHelper9Ptr;
-  typedef std::vector<CallbackHelper9Ptr> V_CallbackHelper9;
+  using CallbackHelper9Ptr = std::shared_ptr<CallbackHelper9<Ms...>>;
+  using V_CallbackHelper9 = std::vector<CallbackHelper9Ptr>;
 
 public:
-  typedef const std::shared_ptr<NullType const> & NullP;
+  using NullP = const std::shared_ptr<NullType const> &;
 
   template<typename ... Ps>
   Connection addCallback(const std::function<void(Ps...)> & callback)
@@ -97,7 +97,7 @@ public:
 
     std::lock_guard<std::mutex> lock(mutex_);
     callbacks_.push_back(CallbackHelper9Ptr(helper));
-    return Connection(std::bind(&Signal9::removeCallback, this, callbacks_.back()));
+    return Connection([this, cb = callbacks_.back()]() {removeCallback(cb);});
   }
 
   template<typename ... Ps>

--- a/include/message_filters/simple_filter.hpp
+++ b/include/message_filters/simple_filter.hpp
@@ -51,10 +51,10 @@ template<class M>
 class SimpleFilter : public noncopyable
 {
 public:
-  typedef std::shared_ptr<M const> MConstPtr;
-  typedef std::function<void (const MConstPtr &)> Callback;
-  typedef MessageEvent<M const> EventType;
-  typedef std::function<void (const EventType &)> EventCallback;
+  using MConstPtr = std::shared_ptr<M const>;
+  using Callback = std::function<void (const MConstPtr &)>;
+  using EventType = MessageEvent<M const>;
+  using EventCallback = std::function<void (const EventType &)>;
 
   /**
    * \brief Register a callback to be called when this filter has passed
@@ -64,7 +64,7 @@ public:
   Connection registerCallback(const C & callback)
   {
     typename CallbackHelper1<M>::Ptr helper = signal_.addCallback(Callback(callback));
-    return Connection(std::bind(&Signal::removeCallback, &signal_, helper));
+    return Connection([this, helper]() {signal_.removeCallback(helper);});
   }
 
   /**
@@ -74,7 +74,8 @@ public:
   template<typename P>
   Connection registerCallback(const std::function<void(P)> & callback)
   {
-    return Connection(std::bind(&Signal::removeCallback, &signal_, signal_.addCallback(callback)));
+    auto helper = signal_.addCallback(callback);
+    return Connection([this, helper]() {signal_.removeCallback(helper);});
   }
 
   /**
@@ -85,8 +86,8 @@ public:
   Connection registerCallback(void (* callback)(P))
   {
     typename CallbackHelper1<M>::Ptr helper =
-      signal_.template addCallback<P>(std::bind(callback, std::placeholders::_1));
-    return Connection(std::bind(&Signal::removeCallback, &signal_, helper));
+      signal_.template addCallback<P>([callback](auto &&... args) {callback(args ...);});
+    return Connection([this, helper]() {signal_.removeCallback(helper);});
   }
 
   /**
@@ -97,8 +98,8 @@ public:
   Connection registerCallback(void (T::* callback)(P), T * t)
   {
     typename CallbackHelper1<M>::Ptr helper =
-      signal_.template addCallback<P>(std::bind(callback, t, std::placeholders::_1));
-    return Connection(std::bind(&Signal::removeCallback, &signal_, helper));
+      signal_.template addCallback<P>([callback, t](auto &&... args) {(t->*callback)(args ...);});
+    return Connection([this, helper]() {signal_.removeCallback(helper);});
   }
 
   /**
@@ -130,7 +131,7 @@ protected:
   }
 
 private:
-  typedef Signal1<M> Signal;
+  using Signal = Signal1<M>;
 
   Signal signal_;
 

--- a/include/message_filters/subscriber.hpp
+++ b/include/message_filters/subscriber.hpp
@@ -139,8 +139,8 @@ class Subscriber
   public SimpleFilter<message_type_t<M>>
 {
 public:
-  typedef message_type_t<M> MessageType;
-  typedef MessageEvent<MessageType const> EventType;
+  using MessageType = message_type_t<M>;
+  using EventType = MessageEvent<MessageType const>;
 
   /**
    * \brief Constructor

--- a/include/message_filters/sync_policies/approximate_epsilon_time.hpp
+++ b/include/message_filters/sync_policies/approximate_epsilon_time.hpp
@@ -55,13 +55,13 @@ template<typename ... Ms>
 class ApproximateEpsilonTime : public PolicyBase<Ms...>
 {
 public:
-  typedef Synchronizer<ApproximateEpsilonTime> Sync;
-  typedef PolicyBase<Ms...> Super;
-  typedef typename Super::Messages Messages;
-  typedef typename Super::Signal Signal;
-  typedef typename Super::Events Events;
-  typedef typename Super::RealTypeCount RealTypeCount;
-  typedef Events Tuple;
+  using Sync = Synchronizer<ApproximateEpsilonTime>;
+  using Super = PolicyBase<Ms...>;
+  using Messages = typename Super::Messages;
+  using Signal = typename Super::Signal;
+  using Events = typename Super::Events;
+  using RealTypeCount = typename Super::RealTypeCount;
+  using Tuple = Events;
 
   using Super::N_MESSAGES;
 

--- a/include/message_filters/sync_policies/approximate_time.hpp
+++ b/include/message_filters/sync_policies/approximate_time.hpp
@@ -56,14 +56,14 @@ namespace sync_policies
 template<typename ... Ms>
 struct ApproximateTime : public PolicyBase<Ms...>
 {
-  typedef Synchronizer<ApproximateTime> Sync;
-  typedef PolicyBase<Ms...> Super;
-  typedef typename Super::Messages Messages;
-  typedef typename Super::Signal Signal;
-  typedef typename Super::Events Events;
-  typedef Events Tuple;
-  typedef std::tuple<std::deque<MessageEvent<Ms const>>...> DequeTuple;
-  typedef std::tuple<std::vector<MessageEvent<Ms const>>...> VectorTuple;
+  using Sync = Synchronizer<ApproximateTime>;
+  using Super = PolicyBase<Ms...>;
+  using Messages = typename Super::Messages;
+  using Signal = typename Super::Signal;
+  using Events = typename Super::Events;
+  using Tuple = Events;
+  using DequeTuple = std::tuple<std::deque<MessageEvent<Ms const>>...>;
+  using VectorTuple = std::tuple<std::vector<MessageEvent<Ms const>>...>;
 
   using Super::N_MESSAGES;
 

--- a/include/message_filters/sync_policies/exact_time.hpp
+++ b/include/message_filters/sync_policies/exact_time.hpp
@@ -51,13 +51,13 @@ namespace sync_policies
 template<typename ... Ms>
 struct ExactTime : public PolicyBase<Ms...>
 {
-  typedef Synchronizer<ExactTime> Sync;
-  typedef PolicyBase<Ms...> Super;
-  typedef typename Super::Messages Messages;
-  typedef typename Super::Signal Signal;
-  typedef typename Super::Events Events;
-  typedef typename Super::RealTypeCount RealTypeCount;
-  typedef Events Tuple;
+  using Sync = Synchronizer<ExactTime>;
+  using Super = PolicyBase<Ms...>;
+  using Messages = typename Super::Messages;
+  using Signal = typename Super::Signal;
+  using Events = typename Super::Events;
+  using RealTypeCount = typename Super::RealTypeCount;
+  using Tuple = Events;
 
   ExactTime(uint32_t queue_size)  // NOLINT(runtime/explicit)
   : parent_(0)

--- a/include/message_filters/sync_policies/latest_time.hpp
+++ b/include/message_filters/sync_policies/latest_time.hpp
@@ -38,7 +38,7 @@
  * \section usage USAGE
  * Example usage would be:
 \verbatim
-typedef LatestTime<sensor_msgs::CameraInfo, sensor_msgs::Image, sensor_msgs::Image> latest_policy;
+using latest_policy = LatestTime<sensor_msgs::CameraInfo, sensor_msgs::Image, sensor_msgs::Image>;
 Synchronizer<latest_policy> sync_policies(latest_policy(), caminfo_sub, limage_sub, rimage_sub);
 sync_policies.registerCallback(callback);
 \endverbatim
@@ -46,7 +46,7 @@ sync_policies.registerCallback(callback);
  * May also take an instance of a `rclcpp::Clock::SharedPtr` from `rclpp::Node::get_clock()`
  * to use the node's time source (e.g. sim time) as in:
 \verbatim
-typedef LatestTime<sensor_msgs::CameraInfo, sensor_msgs::Image, sensor_msgs::Image> latest_policy;
+using latest_policy = LatestTime<sensor_msgs::CameraInfo, sensor_msgs::Image, sensor_msgs::Image>;
 Synchronizer<latest_policy> sync_policies(latest_policy(node->get_clock()), caminfo_sub, limage_sub, rimage_sub);
 sync_policies.registerCallback(callback);
 \endverbatim
@@ -84,16 +84,16 @@ namespace sync_policies
 template<typename ... M>
 struct LatestTime : public PolicyBase<M...>
 {
-  typedef Synchronizer<LatestTime> Sync;
-  typedef PolicyBase<M...> Super;
-  typedef typename Super::Messages Messages;
-  typedef typename Super::Signal Signal;
-  typedef typename Super::Events Events;
-  typedef typename Super::RealTypeCount RealTypeCount;
+  using Sync = Synchronizer<LatestTime>;
+  using Super = PolicyBase<M...>;
+  using Messages = typename Super::Messages;
+  using Signal = typename Super::Signal;
+  using Events = typename Super::Events;
+  using RealTypeCount = typename Super::RealTypeCount;
 
   /// \brief filter coeffs and error margin factor:
   /// <rate_ema_alpha, error_ema_alpha, rate_step_change_margin_factor>
-  typedef std::tuple<double, double, double> RateConfig;
+  using RateConfig = std::tuple<double, double, double>;
 
   LatestTime()
   : LatestTime(rclcpp::Clock::SharedPtr(new rclcpp::Clock(RCL_ROS_TIME)))

--- a/include/message_filters/synchronizer.hpp
+++ b/include/message_filters/synchronizer.hpp
@@ -47,9 +47,9 @@ template<class Policy>
 class Synchronizer : public noncopyable, public Policy
 {
 public:
-  typedef typename Policy::Messages Messages;
-  typedef typename Policy::Events Events;
-  typedef typename Policy::Signal Signal;
+  using Messages = typename Policy::Messages;
+  using Events = typename Policy::Events;
+  using Signal = typename Policy::Signal;
 
   template<class F0, class F1, class ... Fs>
   Synchronizer(F0 & f0, F1 & f1, Fs &... fs)
@@ -94,8 +94,7 @@ public:
     input_connections_[I] =
       std::get<I>(ftuple).registerCallback(
       std::function<void(const MEvent &)>(
-        std::bind(
-          &Synchronizer::template cb<I>, this, std::placeholders::_1)));
+        [this](const MEvent & evt) {this->template cb<I>(evt);}));
   }
 
   template<class FTuple, std::size_t... Is>
@@ -182,10 +181,10 @@ template<typename ... Ms>
 struct PolicyBase
 {
   static constexpr std::size_t N_MESSAGES = sizeof...(Ms);
-  typedef std::integral_constant<int, N_MESSAGES> RealTypeCount;
-  typedef std::tuple<Ms...> Messages;
-  typedef Signal9<Ms...> Signal;
-  typedef std::tuple<MessageEvent<Ms const>...> Events;
+  using RealTypeCount = std::integral_constant<int, N_MESSAGES>;
+  using Messages = std::tuple<Ms...>;
+  using Signal = Signal9<Ms...>;
+  using Events = std::tuple<MessageEvent<Ms const>...>;
 };
 
 }  // namespace message_filters

--- a/include/message_filters/time_sequencer.hpp
+++ b/include/message_filters/time_sequencer.hpp
@@ -77,8 +77,8 @@ template<class M>
 class TimeSequencer : public SimpleFilter<M>
 {
 public:
-  typedef std::shared_ptr<M const> MConstPtr;
-  typedef MessageEvent<M const> EventType;
+  using MConstPtr = std::shared_ptr<M const>;
+  using EventType = MessageEvent<M const>;
 
   /**
    * \brief Constructor
@@ -134,9 +134,7 @@ public:
     incoming_connection_ =
       f.registerCallback(
       typename SimpleFilter<M>::EventCallback(
-        std::bind(
-          &TimeSequencer::cb, this,
-          std::placeholders::_1)));
+        [this](const EventType & evt) {cb(evt);}));
   }
 
   ~TimeSequencer()
@@ -181,8 +179,8 @@ public:
              mt::TimeStamp<M>::value(*rhs.getMessage());
     }
   };
-  typedef std::multiset<EventType, MessageSort> S_Message;
-  typedef std::vector<EventType> V_Message;
+  using S_Message = std::multiset<EventType, MessageSort>;
+  using V_Message = std::vector<EventType>;
 
   void cb(const EventType & evt)
   {

--- a/include/message_filters/time_synchronizer.hpp
+++ b/include/message_filters/time_synchronizer.hpp
@@ -77,8 +77,8 @@ template<class ... Ms>
 class TimeSynchronizer : public Synchronizer<sync_policies::ExactTime<Ms...>>
 {
 public:
-  typedef sync_policies::ExactTime<Ms...> Policy;
-  typedef Synchronizer<Policy> Base;
+  using Policy = sync_policies::ExactTime<Ms...>;
+  using Base = Synchronizer<Policy>;
 
   using Base::add;
   using Base::connectInput;


### PR DESCRIPTION
## Description

 - MessageEvent's operator< and operator== const (fixing a bug where const instances couldn't be compared) 
 - Deleted the now-redundant operator!= since C++20 synthesizes it from ==,
 - rclcpp::Time comparisons throw on mismatched clock sources.

### Did you use Generative AI?

Claude opus 4.7
