### PR TITLE
(#318) Fix humble merge: Remove __future__ import and Concatenate typ…

### DIFF
--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -27,9 +27,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 """Input aligner for synchronizing messages from multiple sources based on their timestamps."""
-
-from __future__ import annotations
-
 import heapq
 import threading
 import typing as tp
@@ -38,7 +35,6 @@ from builtin_interfaces.msg import Time as TimeMsg
 from rclpy.duration import Duration
 from rclpy.node import Node
 from rclpy.time import Time
-from rclpy.node import MsgType
 
 from .simple_filter import SimpleFilter
 
@@ -179,7 +175,7 @@ class InputAligner:
     def registerCallback(
         self,
         index: int,
-        callback: tp.Callable[tp.Concatenate[MsgType, P], None],
+        callback: tp.Callable,
         *args: tp.Any,
     ) -> int:
         return self.signals[index].registerCallback(callback, *args)

--- a/src/message_filters/simple_filter.py
+++ b/src/message_filters/simple_filter.py
@@ -25,11 +25,7 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from __future__ import annotations
-
 import typing as tp
-
-from rclpy.node import MsgType
 
 
 P = tp.ParamSpec('P')
@@ -42,7 +38,7 @@ class SimpleFilter:
 
     def registerCallback(
         self,
-        callback: tp.Callable[tp.Concatenate[MsgType, P], None],
+        callback: tp.Callable,
         *args
     ):
         """


### PR DESCRIPTION
## Description
Fix build. Remove `__future__` import and `Concatenate`, that is dependent on it.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes the issue with [these failing tests
](https://ci.ros2.org/job/ci_linux-rhel/9384/testReport/)
At least in terms of importing `__future__`

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
Used Google's AI to figure out versions of Python for different RHEL distriutives.
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
