### PR TITLE
(#318) Fix humble build: Fix typing issues. Remove features not available in Python 3.6

### DIFF
--- a/src/message_filters/input_aligner.py
+++ b/src/message_filters/input_aligner.py
@@ -39,9 +39,6 @@ from rclpy.time import Time
 from .simple_filter import SimpleFilter
 
 
-P = tp.ParamSpec('P')
-
-
 class QueueStatus:
     def __init__(
         self,
@@ -103,7 +100,7 @@ class InputAligner:
                 return self.next_ts
             return _ros_max_time()
 
-        def pop_first(self) -> tuple[Time, tp.Any]:
+        def pop_first(self) -> tp.Tuple[Time, tp.Any]:
             stamp, _, msg = heapq.heappop(self.events)
             self.msgs_processed += 1
             return stamp, msg
@@ -128,7 +125,7 @@ class InputAligner:
     def __init__(
         self,
         timeout: Duration,
-        filters: tp.Sequence[SimpleFilter] | None = None,
+        filters: tp.Optional[tp.Sequence[SimpleFilter]] = None,
     ) -> None:
         self.timeout: Duration = timeout
         zero_time = _ros_zero_time()

--- a/src/message_filters/simple_filter.py
+++ b/src/message_filters/simple_filter.py
@@ -28,9 +28,6 @@
 import typing as tp
 
 
-P = tp.ParamSpec('P')
-
-
 class SimpleFilter:
 
     def __init__(self):


### PR DESCRIPTION
(#318) Fix humble build: Fix typing issues. Remove features not available in Python 3.6

## Description

I've decided to go with the simplest approach and just get rid of all the features not available in Python 3.6.
There was another way to go: To add `typing_extensions`, but since it is not utilized by any package that is currently in `humble`, I've decided to avoid adding new dependencies and just go without the detailed typing description. Guess it'll be better for everyone using `humble`.

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

I guess so. It fixes the `unstable` build result for `RHEL8` for the `Humble`.

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No.

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
