### PR TITLE
Reduce compile time in time sequencer

### DIFF
--- a/include/message_filters/time_sequencer.hpp
+++ b/include/message_filters/time_sequencer.hpp
@@ -33,11 +33,12 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <set>
 #include <vector>
 
+#include <rclcpp/clock.hpp>
 #include <rclcpp/create_timer.hpp>
-#include <rclcpp/node.hpp>
 
 #include "message_filters/connection.hpp"
 #include "message_filters/message_traits.hpp"
@@ -87,19 +88,19 @@ public:
    * \param delay The minimum time to hold a message before passing it through.
    * \param update_rate The rate at which to check for messages which have passed "delay"
    * \param queue_size The number of messages to store
-   * \param node The Node to use to create the rclcpp::SteadyTimer that runs at update_rate
+   * \param node The node (e.g. rclcpp::Node::SharedPtr) used to create the timer that runs at
+   *   update_rate
    */
-  template<class F>
+  template<class F, class NodeT>
   TimeSequencer(
     F & f, rclcpp::Duration delay, rclcpp::Duration update_rate, uint32_t queue_size,
-    rclcpp::Node::SharedPtr node)
+    NodeT node)
   : delay_(delay)
     , update_rate_(update_rate)
     , queue_size_(queue_size)
-    , node_(node)
     , last_time_ (0, 0, RCL_ROS_TIME)
   {
-    init();
+    init(node);
     connectInput(f);
   }
 
@@ -111,18 +112,19 @@ public:
    * \param delay The minimum time to hold a message before passing it through.
    * \param update_rate The rate at which to check for messages which have passed "delay"
    * \param queue_size The number of messages to store
-   * \param node The Node to use to create the rclcpp::SteadyTimer that runs at update_rate
+   * \param node The node (e.g. rclcpp::Node::SharedPtr) used to create the timer that runs at
+   *   update_rate
    */
+  template<class NodeT>
   TimeSequencer(
     rclcpp::Duration delay, rclcpp::Duration update_rate, uint32_t queue_size,
-    rclcpp::Node::SharedPtr node)
+    NodeT node)
   : delay_(delay)
     , update_rate_(update_rate)
     , queue_size_(queue_size)
-    , node_(node)
     , last_time_ (0, 0, RCL_ROS_TIME)
   {
-    init();
+    init(node);
   }
 
   /**
@@ -197,7 +199,7 @@ public:
     {
       std::lock_guard<std::mutex> lock(messages_mutex_);
 
-      const rclcpp::Time now = node_->get_clock()->now();
+      const rclcpp::Time now = clock_->now();
       auto it = messages_.begin();
       while (it != messages_.end()) {
         const rclcpp::Time stamp = mt::TimeStamp<M>::value(*it->getMessage());
@@ -216,11 +218,13 @@ public:
     }
   }
 
-  void init()
+  template<class NodeT>
+  void init(NodeT node)
   {
+    clock_ = node->get_clock();
     update_timer_ = rclcpp::create_timer(
-      node_,
-      node_->get_clock(),
+      node,
+      clock_,
       std::chrono::nanoseconds(update_rate_.nanoseconds()), [this]() {
         dispatch();
       });
@@ -229,7 +233,7 @@ public:
   rclcpp::Duration delay_;
   rclcpp::Duration update_rate_;
   uint32_t queue_size_;
-  rclcpp::Node::SharedPtr node_;
+  rclcpp::Clock::SharedPtr clock_;
   rclcpp::TimerBase::SharedPtr update_timer_;
   Connection incoming_connection_;
 


### PR DESCRIPTION
## Description

 - Added missing `<mutex>` header
 - The class stores rclcpp::Clock::SharedPtr clock_ instead of the node
 - Both constructors are now templated on NodeT instead of taking rclcpp::Node::SharedPtr, so the header no longer needs rclcpp/node.hpp (1.34 s by itself)

### Did you use Generative AI?

Claude Opus 4.7

FYI @EsipovPA 